### PR TITLE
docs: rewrite README to reflect overhauled repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,81 @@
-# okp-solr-rag-prototype
+# okp-mcp
 
-## Getting started
+MCP server for the Red Hat Offline Knowledge Portal (OKP). Bridges LLM tool calls to the OKP Solr index so agents can search RHEL documentation, CVEs, errata, solutions, and articles.
 
-1. Pull the Offline Knowledge Portal with public RAG prototype image:
+## Quickstart
 
-```
-podman pull images.paas.redhat.com/offline-kbase/okp-rag-proto:nov20
-```
-
-NOTE: this requires a VPN connection
-
-2. Run the OKP image:
+Install dependencies:
 
 ```
-podman run --rm -p 8080:8080 -d --name okp okp-rag-proto:nov20
+uv sync
 ```
 
-3. Verify OKP image is running locally by opening this in your browser: http://127.0.0.1:8080/
-
-## Example queries
-
-Execute a symantic query:
+Run locally (stdio transport, default):
 
 ```
-uv run okp_query.py -s "how do I enbable remote desktop in gnome in rhel?"
+uv run okp-mcp
 ```
 
-Execute a hybrid query:
+Run with HTTP transport:
 
 ```
-uv run okp_query.py -y "CVE-2023-46604"
+uv run okp-mcp --transport streamable-http --port 8000
 ```
 
-Include debug output with `-d`:
+## Configuration
+
+Settings come from CLI arguments and `MCP_*` environment variables. CLI args take precedence.
+
+| Setting | Env var | Default | Description |
+|---------|---------|---------|-------------|
+| `--transport` | `MCP_TRANSPORT` | `streamable-http` | `stdio`, `sse`, or `streamable-http` |
+| `--host` | `MCP_HOST` | `0.0.0.0` | Bind address for HTTP transports |
+| `--port` | `MCP_PORT` | `8000` | Bind port for HTTP transports |
+| `--log-level` | `MCP_LOG_LEVEL` | `INFO` | Python log level |
+| `--solr-url` | `MCP_SOLR_URL` | `http://localhost:8983` | Base URL of the Solr instance |
+
+Run `okp-mcp --help` for the full list.
+
+## Running with Compose
+
+Start the OKP Solr instance and MCP server together:
 
 ```
-uv run okp_query.py -d -s "how do I enbable remote desktop in gnome in rhel?"
+podman-compose up -d
 ```
+
+This pulls the official OKP image from `registry.redhat.io` (requires `podman login registry.redhat.io` first) and builds the MCP server container locally.
+
+Build the MCP server image:
+
+```
+podman build -t okp-mcp -f Containerfile .
+```
+
+## Development
+
+Install dev dependencies:
+
+```
+uv sync --group dev
+```
+
+Run the full CI suite locally:
+
+```
+make ci
+```
+
+Individual targets:
+
+```
+make lint        # ruff check
+make format      # ruff format
+make typecheck   # ty check
+make radon       # cyclomatic complexity gate (A/B only)
+make test        # pytest with coverage
+```
+
+## License
+
+See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- Replace outdated prototype instructions (okp-rag-proto image, okp_query.py CLI) with current project docs
- Add quickstart, config reference table, compose usage, and dev workflow sections