### PR TITLE
refactor: replace compose.yaml with podman-compose.yml

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Copy to .env and fill in your values:
+#   cp .env.example .env
+OKP_ACCESS_KEY=your-access-key-here

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -11,7 +11,6 @@ services:
       SOLR_JETTY_HOST: "0.0.0.0"
     volumes:
       - okp-solr-data:/opt/solr/server/solr/portal/data
-      - ./rhel-okp-tar-wrapper.sh:/usr/local/bin/tar:ro,z
     restart: unless-stopped
 
   # OKP MCP Server — Solr bridge for LLM tool calls


### PR DESCRIPTION
## Summary

- Rename `compose.yaml` to `podman-compose.yml` to align with podman tooling
- Drop the tar wrapper volume mount (`rhel-okp-tar-wrapper.sh`) from the OKP service
- Add `.env.example` so new contributors know which env vars to set