### PR TITLE
fix: add build directive and rename OKP service in compose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,6 +214,3 @@ __marimo__/
 
 # Streamlit
 .streamlit/secrets.toml
-
-opencode.json
-.sisyphus

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "okp-mcp": {
+      "type": "http",
+      "url": "http://localhost:8000/mcp"
+    }
+  }
+}

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "https://opencode.ai/config.json",
+    "mcp": {
+        "okp-mcp": {
+            "type": "remote",
+            "url": "http://localhost:8000/mcp",
+            "enabled": true
+        }
+    }
+}

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -1,9 +1,9 @@
 services:
-  # RHEL OKP — Offline Knowledge Portal (Solr-based documentation index)
+  # Red Hat OKP — Offline Knowledge Portal (Solr-based documentation index)
   # Requires registry.redhat.io authentication: podman login registry.redhat.io
-  rhel-okp:
+  redhat-okp:
     image: registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
-    container_name: rhel-okp
+    container_name: redhat-okp
     ports:
       - "8983:8983"
     environment:
@@ -14,15 +14,18 @@ services:
     restart: unless-stopped
 
   # OKP MCP Server — Solr bridge for LLM tool calls
-  mcp-server:
+  okp-mcp:
+    build:
+      context: .
+      dockerfile: Containerfile
     image: okp-mcp:latest
     container_name: mcp-server
     ports:
       - "8000:8000"
     environment:
-      MCP_SOLR_URL: http://rhel-okp:8983
+      MCP_SOLR_URL: http://redhat-okp:8983
     depends_on:
-      - rhel-okp
+      - redhat-okp
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
## Summary

- Rename `rhel-okp` service/container to `redhat-okp` to avoid name collisions with standalone OKP containers
- Add `build` context to the `okp-mcp` service so `podman-compose up` builds from the local Containerfile instead of requiring a pre-built `okp-mcp:latest` image
- Add `.mcp.json` for editor MCP integration (streamable-http on `localhost:8000/mcp`)