### PR TITLE
ci: build container on PRs without pushing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,9 @@ jobs:
       - name: Tests + coverage
         run: make test
 
-  build-and-push:
+  build:
     needs: test
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
     permissions:
       contents: read
       packages: write
@@ -59,6 +58,7 @@ jobs:
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
+        if: github.event_name == 'push'
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4
         with:
           registry: ghcr.io
@@ -71,6 +71,7 @@ jobs:
           echo "DEV_TAG=dev-$(date +%Y%m%d)-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
 
       - name: Extract metadata
+        if: github.event_name == 'push'
         uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
         id: meta
         with:
@@ -88,8 +89,10 @@ jobs:
         with:
           context: .
           file: Containerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name == 'push' }}
+          # On PRs the metadata step is skipped, so tags/labels are empty
+          # (build-only, nothing to tag)
+          tags: ${{ steps.meta.outputs.tags || '' }}
+          labels: ${{ steps.meta.outputs.labels || '' }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

- Run the container build job on PRs (build-only, no push) to catch Containerfile breakage before merge
- Conditionalize GHCR login and metadata extraction to push events only
- Add explicit empty-string fallbacks for tags/labels when the metadata step is skipped on PRs