### PR TITLE
refactor: replace hand-rolled STOP_WORDS with stop-words package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,13 @@ description = "MCP server for the Offline Knowledge Portal"
 readme = "README.md"
 authors = [{ name = "Major Hayden", email = "major@redhat.com" }]
 requires-python = ">=3.12"
-dependencies = ["fastmcp>=3.0.2", "httpx", "pydantic-settings>=2.13.1", "rank-bm25"]
+dependencies = [
+    "fastmcp>=3.0.2",
+    "httpx",
+    "pydantic-settings>=2.13.1",
+    "rank-bm25",
+    "stop-words>=2025.11.4",
+]
 
 [project.scripts]
 okp-mcp = "okp_mcp:main"

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import Field, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from stop_words import get_stop_words
 
 # Configure logging
 logging.basicConfig(
@@ -18,45 +19,7 @@ logger = logging.getLogger(__name__)
 SOLR_URL = os.environ.get("SOLR_URL", "http://localhost:8983")
 SOLR_ENDPOINT = f"{SOLR_URL}/solr/portal/select"
 
-STOP_WORDS = frozenset(
-    [
-        "a",
-        "an",
-        "and",
-        "are",
-        "as",
-        "at",
-        "be",
-        "but",
-        "by",
-        "do",
-        "does",
-        "for",
-        "from",
-        "had",
-        "has",
-        "have",
-        "if",
-        "in",
-        "into",
-        "is",
-        "it",
-        "its",
-        "may",
-        "of",
-        "on",
-        "or",
-        "so",
-        "than",
-        "the",
-        "then",
-        "to",
-        "was",
-        "will",
-        "with",
-        "would",
-    ]
-)
+STOP_WORDS: frozenset[str] = frozenset(get_stop_words("en"))
 
 logger.info("SOLR endpoint: %s", SOLR_ENDPOINT)
 

--- a/uv.lock
+++ b/uv.lock
@@ -750,6 +750,7 @@ dependencies = [
     { name = "httpx" },
     { name = "pydantic-settings" },
     { name = "rank-bm25" },
+    { name = "stop-words" },
 ]
 
 [package.dev-dependencies]
@@ -772,6 +773,7 @@ requires-dist = [
     { name = "httpx" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "rank-bm25" },
+    { name = "stop-words", specifier = ">=2025.11.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -1419,6 +1421,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+]
+
+[[package]]
+name = "stop-words"
+version = "2025.11.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/cb/27ee3d3e0b7b1169269e83331c075b2dd3c4bcc1a005821174c32a273dc4/stop_words-2025.11.4.tar.gz", hash = "sha256:0459072b54b11e43a6fb4c5b05bda87d2accfc4f14c1697974f3739af0f7b43d", size = 68622, upload-time = "2025-11-03T21:07:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/f5/992d668d21590ed39c6a9d1c62220e9b4b086a165e15fcb7580764cc7ceb/stop_words-2025.11.4-py3-none-any.whl", hash = "sha256:b3fc0722e42b722a9350aad59a8ba5850085a5b45a4ba9de390b4f5c4b86df25", size = 59496, upload-time = "2025-11-03T21:07:41.14Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Replace the 35-word hand-rolled `STOP_WORDS` frozenset in `config.py` with the [`stop-words`](https://pypi.org/project/stop-words/) package (BSD-3, zero transitive deps)
- The package provides a comprehensive English stop word list (1,333 words) maintained upstream, removing the need to curate our own
- No changes to the `solr.py` consumer code since `STOP_WORDS` is still exported as a `frozenset[str]` from `config`