### PR TITLE
fix(ci): add explicit permissions to test job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Adds `permissions: contents: read` to the `test` job in the CI workflow, restricting the GITHUB_TOKEN scope to least privilege.
- The `build` job already had explicit permissions; `test` was inheriting the repo/org default.

Fixes https://github.com/rhel-lightspeed/okp-mcp/security/code-scanning/2