### PR TITLE
fix(renovate): drop schedule gate on non-major dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -34,7 +34,6 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "groupName": "all non-major dependencies",
       "groupSlug": "all-non-major",
-      "schedule": ["before 5am on monday"],
       "automerge": true,
       "automergeType": "pr"
     }


### PR DESCRIPTION
## Summary

- Remove the `"before 5am on monday"` schedule from the non-major dependency packageRule
- Non-major deps (minor, patch, pin, digest) were stuck "awaiting schedule" 163 out of 168 hours per week because the window was only 5 hours
- Automerge is still enabled, so these PRs merge automatically once CI passes without needing a schedule gate