### PR TITLE
feat(tests): add RSPEED-2479 functional test for EUS support duration

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -55,4 +55,17 @@ FUNCTIONAL_TEST_CASES = [
         ),
         id="RSPEED_2480",
     ),
+    pytest.param(
+        FunctionalCase(
+            question="How long is an EUS release supported for?",
+            expected_doc_refs=["rhel9-eus-faq", "rhel-eus", "updates/errata"],
+            required_facts=[
+                "24 months",
+                ("enhanced eus", "enhanced extended update support"),
+                ("48 months", "4 years"),
+            ],
+            forbidden_claims=["30 months"],
+        ),
+        id="RSPEED_2479",
+    ),
 ]


### PR DESCRIPTION
## Summary

- Adds functional test case for RSPEED-2479 covering EUS (Extended Update Support) release duration
- Validates the LLM correctly reports 24-month EUS support period, enhanced EUS at 48 months, and doesn't hallucinate incorrect durations (e.g., 30 months)
- Checks expected doc references: `rhel9-eus-faq`, `rhel-eus`, `updates/errata`