### PR TITLE
test: add functional test for RSPEED-2478 EUS release availability

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -68,4 +68,18 @@ FUNCTIONAL_TEST_CASES = [
         ),
         id="RSPEED_2479",
     ),
+    pytest.param(
+        FunctionalCase(
+            question="Which RHEL 9 releases have EUS available?",
+            expected_doc_refs=["rhel9-eus-faq", "rhel-eus", "updates/errata"],
+            required_facts=[
+                "9.0",
+                "9.2",
+                "9.4",
+                "9.6",
+            ],
+            forbidden_claims=["9.0 did not have EUS"],
+        ),
+        id="RSPEED_2478",
+    ),
 ]


### PR DESCRIPTION
## Summary

- Add functional test case for RSPEED-2478 covering EUS release availability queries
- Verifies the MCP server returns correct EUS lifecycle data (24-month support, 48-month EUS for minor releases like 9.4/9.6) and does not claim non-EUS releases have extended support