### PR TITLE
fix: handle incorrect CLA answer for RSPEED-2698

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -87,15 +87,18 @@ FUNCTIONAL_TEST_CASES = [
             question="How long is RHEL 10 supported?",
             expected_doc_refs=[
                 "updates/errata",
-                "7126291",
-                "life cycle",
+                "Life Cycle",
             ],
             required_facts=[
                 ("ten year", "ten-year", "10 year", "10-year"),
-                "Full Support",
-                "Maintenance Support",
+                "full support",
+                "maintenance support",
+                ("extended life", "extended life phase"),
             ],
-            forbidden_claims=[],
+            forbidden_claims=[
+                "unable to retrieve",
+                "has not been released",
+            ],
         ),
         id="RSPEED_2698",
     ),


### PR DESCRIPTION
## Summary

- Adds functional test for RSPEED-2698: "How long is RHEL 10 supported?" CLA previously said search was unavailable and gave a vague "typically 10 years" without RHEL 10 specifics.
- Supplements Solr highlights with BM25-extracted content for large documents (>10KB) where table-of-contents sections consume highlight slots, burying the actual lifecycle details.
- Preserves numeric tokens (e.g. "10", "9") during query cleaning so version-specific queries aren't stripped as stopwords.
- Adds lifecycle terminology (`life cycle`, `full support`, `maintenance support`, `extended life`) to BM25 extraction boost keywords.

## Test results

All 6 functional tests pass. Full CI suite (lint, typecheck, radon, unit tests) clean.

## RSPEED-2698

https://redhat.atlassian.net/browse/RSPEED-2698