### PR TITLE
RSPEED-2702: fix: strip /index.html suffix from Solr document URLs

### DIFF
--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -46,6 +46,21 @@ def strip_boilerplate(text: str) -> str:
     return text
 
 
+def strip_index_suffix(path: str) -> str:
+    """Remove trailing /index.html from URL paths.
+
+    Solr document IDs include /index.html (e.g. /solutions/123/index.html)
+    but access.redhat.com returns 404 for these paths.
+
+    Args:
+        path: URL path that may end with /index.html.
+
+    Returns:
+        Path with /index.html suffix removed.
+    """
+    return path.removesuffix("/index.html")
+
+
 def clean_content(text: str | None, max_chars: int) -> str:
     """Clean and truncate content for LLM consumption.
 

--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -2,7 +2,7 @@
 
 import re
 
-from .content import strip_boilerplate
+from .content import strip_boilerplate, strip_index_suffix
 from .solr import _extract_relevant_section, _get_highlights
 
 EOL_PRODUCT_MENTIONS = [
@@ -151,7 +151,7 @@ async def _format_result(doc: dict, data: dict, include_content: bool = False, q
     doc_id = doc.get("id", "")
     view_uri = doc.get("view_uri", "")
     title = doc.get("allTitle") or doc.get("heading_h1") or doc.get("title", "").split("|")[0].strip() or "Untitled"
-    url_path = view_uri or doc_id
+    url_path = strip_index_suffix(view_uri or doc_id)
     highlights = _get_highlights(data, doc_id, view_uri, query=query)
     content_text = await _resolve_content_text(highlights, include_content, doc, query)
 

--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -7,7 +7,7 @@ import httpx
 from fastmcp import Context
 
 from .config import logger
-from .content import strip_boilerplate
+from .content import strip_boilerplate, strip_index_suffix
 from .formatting import SORT_DEPRECATION, _format_result
 from .server import get_app_context, mcp
 from .solr import _clean_query, _extract_relevant_section, _get_highlights, _solr_query
@@ -143,7 +143,8 @@ def _build_search_queries(
 
 def _doc_uri(doc: dict) -> str | None:
     """Return the canonical URI for a Solr document."""
-    return doc.get("view_uri") or doc.get("id")
+    uri = doc.get("view_uri") or doc.get("id")
+    return strip_index_suffix(uri) if uri else None
 
 
 async def _format_docs(docs: list[dict], data: dict, query: str) -> list[tuple[str, int]]:
@@ -230,7 +231,7 @@ def _format_solution_article_doc(doc: dict, data: dict, query: str) -> str:
     doc_id = doc.get("id", "")
     view_uri = doc.get("view_uri", "")
     title = doc.get("allTitle") or doc.get("heading_h1") or doc.get("title", "").split("|")[0].strip() or "Untitled"
-    url_path = view_uri or doc_id
+    url_path = strip_index_suffix(view_uri or doc_id)
     highlights = _get_highlights(data, view_uri, doc_id, query=query)
     result = f"**{title}**"
     result += f"\nURL: https://access.redhat.com{url_path}"
@@ -248,7 +249,7 @@ def _format_errata_doc(doc: dict) -> str:
         result += f" | Severity: {doc['portal_severity']}"
     if doc.get("portal_synopsis"):
         result += f"\nSynopsis: {doc['portal_synopsis']}"
-    result += f"\nURL: https://access.redhat.com{doc.get('view_uri', '')}"
+    result += f"\nURL: https://access.redhat.com{strip_index_suffix(doc.get('view_uri', ''))}"
     return result
 
 
@@ -397,7 +398,7 @@ async def search_cves(
             if doc.get("cve_details"):
                 detail = doc["cve_details"][:300]
                 result += f"\nDetails: {detail}"
-            result += f"\nURL: https://access.redhat.com{doc.get('view_uri', '')}"
+            result += f"\nURL: https://access.redhat.com{strip_index_suffix(doc.get('view_uri', ''))}"
             results.append(result)
 
         return f"Found {len(docs)} CVEs for '{query}':\n\n" + "\n\n---\n\n".join(results)
@@ -561,13 +562,14 @@ async def _format_document(doc: dict, data: dict, doc_id: str, query: str) -> st
     and content (highlights if available, otherwise extracted relevant section).
     """
     view_uri = doc.get("view_uri", "")
+    url_path = strip_index_suffix(view_uri or doc_id)
     result = f"**{doc.get('allTitle', 'Untitled')}**"
     result += f"\nType: {doc.get('documentKind', 'Unknown')}"
     if doc.get("product"):
         result += f"\nProduct: {doc['product']}"
     if doc.get("documentation_version"):
         result += f" {doc['documentation_version']}"
-    result += f"\nURL: https://access.redhat.com{view_uri}"
+    result += f"\nURL: https://access.redhat.com{url_path}"
 
     if doc.get("portal_synopsis"):
         result += f"\n\nSynopsis: {doc['portal_synopsis']}"

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from okp_mcp.content import clean_content, strip_boilerplate, truncate_content
+from okp_mcp.content import clean_content, strip_boilerplate, strip_index_suffix, truncate_content
 
 
 @pytest.mark.parametrize(
@@ -66,6 +66,32 @@ def test_strip_boilerplate_preserves_clean_text():
 def test_clean_content_edge_cases(text, max_chars, expected):
     """Edge cases: None, empty string, and clean text pass through correctly."""
     assert clean_content(text, max_chars=max_chars) == expected
+
+
+@pytest.mark.parametrize(
+    "path,expected",
+    [
+        ("/solutions/3257611/index.html", "/solutions/3257611"),
+        ("/articles/2585/index.html", "/articles/2585"),
+        ("/documentation/en-us/rhel/9/html-single/guide/index.html", "/documentation/en-us/rhel/9/html-single/guide"),
+        ("/security/cve/CVE-2024-9823/", "/security/cve/CVE-2024-9823/"),
+        ("/errata/RHSA-2022:4915/", "/errata/RHSA-2022:4915/"),
+        ("", ""),
+        ("/solutions/123", "/solutions/123"),
+    ],
+    ids=[
+        "solution-id",
+        "article-id",
+        "documentation-id",
+        "cve-view-uri-unchanged",
+        "errata-view-uri-unchanged",
+        "empty-string",
+        "no-suffix",
+    ],
+)
+def test_strip_index_suffix(path, expected):
+    """Trailing /index.html is stripped from Solr document ID paths."""
+    assert strip_index_suffix(path) == expected
 
 
 def test_clean_content_strips_then_truncates():


### PR DESCRIPTION
## Summary

- Strip trailing `/index.html` from Solr document ID paths that cause 404 errors on access.redhat.com
- Solutions, articles, and documentation lack `view_uri` in Solr, so the code falls back to `id` which carries `/index.html` (e.g. `/solutions/7134031/index.html`)
- Add `strip_index_suffix()` helper in `content.py`, applied at all six URL construction points in `tools.py` and `formatting.py`
- 7 parametrized test cases covering solutions, articles, docs, CVEs, errata, empty string, and no-suffix paths

Closes: RSPEED-2702