### PR TITLE
RSPEED-2294: add functional test for Python version on RHEL 10

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -114,4 +114,19 @@ FUNCTIONAL_TEST_CASES = [
         ),
         id="RSPEED_2697",
     ),
+    pytest.param(
+        FunctionalCase(
+            question="What is most current version of Python for RHEL 10?",
+            expected_doc_refs=[
+                "dynamic_programming_languages",
+                "Application Stream",
+                "python 3.12",
+            ],
+            required_facts=[
+                "3.12",
+            ],
+            forbidden_claims=["has not been officially released"],
+        ),
+        id="RSPEED_2294",
+    ),
 ]


### PR DESCRIPTION
## Summary

- Add functional test case for RSPEED-2294 (CLA incorrectly says RHEL 10 hasn't been released when asked about Python versions)
- MCP server already returns the correct answer (Python 3.12), so no code fix needed
- Test locks in correct behavior to prevent regressions

## Test case

- **Question:** "What is most current version of Python for RHEL 10?"
- **Required facts:** 3.12
- **Forbidden claims:** "has not been officially released"
- All 8 functional tests pass, full CI green

## Jira

https://redhat.atlassian.net/browse/RSPEED-2294