### PR TITLE
RSPEED-2201: add functional test for RHEL on AWS with Secure Boot

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -129,4 +129,20 @@ FUNCTIONAL_TEST_CASES = [
         ),
         id="RSPEED_2294",
     ),
+    pytest.param(
+        FunctionalCase(
+            question="How to configure RHEL on AWS with Secure Boot?",
+            expected_doc_refs=[
+                "deploying_rhel_9_on_amazon_web_services",
+                "deploying_and_managing_rhel_on_amazon_web_services",
+                "Secure Boot",
+            ],
+            required_facts=[
+                "marketplace",
+                ("custom image", "custom AMI"),
+            ],
+            forbidden_claims=["do not expose"],
+        ),
+        id="RSPEED_2201",
+    ),
 ]


### PR DESCRIPTION
## Summary

- Add regression test for RSPEED-2201: CLA was reported as incorrectly claiming AWS doesn't support UEFI Secure Boot for RHEL instances
- MCP server already returns the correct answer (Marketplace AMI and custom image methods), so no code fix needed
- Test locks in correct behavior to prevent future regressions

Depends on #49 (merge that first).