### PR TITLE
refactor: consolidate URL construction into public doc_uri()

### DIFF
--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -46,19 +46,14 @@ def strip_boilerplate(text: str) -> str:
     return text
 
 
-def strip_index_suffix(path: str) -> str:
-    """Remove trailing /index.html from URL paths.
+def doc_uri(doc: dict) -> str:
+    """Return the canonical URL path for a Solr document.
 
-    Solr document IDs include /index.html (e.g. /solutions/123/index.html)
-    but access.redhat.com returns 404 for these paths.
-
-    Args:
-        path: URL path that may end with /index.html.
-
-    Returns:
-        Path with /index.html suffix removed.
+    Prefers view_uri, falls back to id. Strips trailing /index.html
+    because Solr document IDs carry it but access.redhat.com 404s on those paths.
     """
-    return path.removesuffix("/index.html")
+    uri = doc.get("view_uri") or doc.get("id", "")
+    return uri.removesuffix("/index.html")
 
 
 def clean_content(text: str | None, max_chars: int) -> str:

--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -2,7 +2,7 @@
 
 import re
 
-from .content import strip_boilerplate, strip_index_suffix
+from .content import doc_uri, strip_boilerplate
 from .solr import _extract_relevant_section, _get_highlights
 
 EOL_PRODUCT_MENTIONS = [
@@ -151,7 +151,7 @@ async def _format_result(doc: dict, data: dict, include_content: bool = False, q
     doc_id = doc.get("id", "")
     view_uri = doc.get("view_uri", "")
     title = doc.get("allTitle") or doc.get("heading_h1") or doc.get("title", "").split("|")[0].strip() or "Untitled"
-    url_path = strip_index_suffix(view_uri or doc_id)
+    url_path = doc_uri(doc)
     highlights = _get_highlights(data, doc_id, view_uri, query=query)
     content_text = await _resolve_content_text(highlights, include_content, doc, query)
 

--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -7,7 +7,7 @@ import httpx
 from fastmcp import Context
 
 from .config import logger
-from .content import strip_boilerplate, strip_index_suffix
+from .content import doc_uri, strip_boilerplate
 from .formatting import SORT_DEPRECATION, _format_result
 from .server import get_app_context, mcp
 from .solr import _clean_query, _extract_relevant_section, _get_highlights, _solr_query
@@ -141,12 +141,6 @@ def _build_search_queries(
     return doc_params, sol_params, dep_params
 
 
-def _doc_uri(doc: dict) -> str | None:
-    """Return the canonical URI for a Solr document."""
-    uri = doc.get("view_uri") or doc.get("id")
-    return strip_index_suffix(uri) if uri else None
-
-
 async def _format_docs(docs: list[dict], data: dict, query: str) -> list[tuple[str, int]]:
     """Format a list of Solr docs into (text, sort_key) pairs."""
     return list(await asyncio.gather(*[_format_result(d, data, include_content=True, query=query) for d in docs]))
@@ -160,7 +154,7 @@ async def _collect_dep_pairs(
     """Format dep docs not already seen in doc/sol results."""
     pairs: list[tuple[str, int]] = []
     for d in dep_data["response"]["docs"]:
-        uri = _doc_uri(d)
+        uri = doc_uri(d)
         if uri not in seen_uris:
             pairs.append(await _format_result(d, dep_data, include_content=True, query=query))
             seen_uris.add(uri)
@@ -180,8 +174,8 @@ async def _deduplicate_and_sort_results(
     doc_pairs = await _format_docs(doc_data["response"]["docs"], doc_data, query)
     sol_pairs = await _format_docs(sol_data["response"]["docs"], sol_data, query)
 
-    seen_uris = {_doc_uri(d) for d in doc_data["response"]["docs"]}
-    seen_uris |= {_doc_uri(d) for d in sol_data["response"]["docs"]}
+    seen_uris = {doc_uri(d) for d in doc_data["response"]["docs"]}
+    seen_uris |= {doc_uri(d) for d in sol_data["response"]["docs"]}
     dep_pairs = await _collect_dep_pairs(dep_data, seen_uris, query)
 
     sol_pairs.extend(dep_pairs)
@@ -231,10 +225,9 @@ def _format_solution_article_doc(doc: dict, data: dict, query: str) -> str:
     doc_id = doc.get("id", "")
     view_uri = doc.get("view_uri", "")
     title = doc.get("allTitle") or doc.get("heading_h1") or doc.get("title", "").split("|")[0].strip() or "Untitled"
-    url_path = strip_index_suffix(view_uri or doc_id)
     highlights = _get_highlights(data, view_uri, doc_id, query=query)
     result = f"**{title}**"
-    result += f"\nURL: https://access.redhat.com{url_path}"
+    result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
     if highlights:
         result += f"\n> {highlights}"
     return result
@@ -249,7 +242,7 @@ def _format_errata_doc(doc: dict) -> str:
         result += f" | Severity: {doc['portal_severity']}"
     if doc.get("portal_synopsis"):
         result += f"\nSynopsis: {doc['portal_synopsis']}"
-    result += f"\nURL: https://access.redhat.com{strip_index_suffix(doc.get('view_uri', ''))}"
+    result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
     return result
 
 
@@ -398,7 +391,7 @@ async def search_cves(
             if doc.get("cve_details"):
                 detail = doc["cve_details"][:300]
                 result += f"\nDetails: {detail}"
-            result += f"\nURL: https://access.redhat.com{strip_index_suffix(doc.get('view_uri', ''))}"
+            result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
             results.append(result)
 
         return f"Found {len(docs)} CVEs for '{query}':\n\n" + "\n\n---\n\n".join(results)
@@ -562,14 +555,13 @@ async def _format_document(doc: dict, data: dict, doc_id: str, query: str) -> st
     and content (highlights if available, otherwise extracted relevant section).
     """
     view_uri = doc.get("view_uri", "")
-    url_path = strip_index_suffix(view_uri or doc_id)
     result = f"**{doc.get('allTitle', 'Untitled')}**"
     result += f"\nType: {doc.get('documentKind', 'Unknown')}"
     if doc.get("product"):
         result += f"\nProduct: {doc['product']}"
     if doc.get("documentation_version"):
         result += f" {doc['documentation_version']}"
-    result += f"\nURL: https://access.redhat.com{url_path}"
+    result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
 
     if doc.get("portal_synopsis"):
         result += f"\n\nSynopsis: {doc['portal_synopsis']}"

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from okp_mcp.content import clean_content, strip_boilerplate, strip_index_suffix, truncate_content
+from okp_mcp.content import clean_content, doc_uri, strip_boilerplate, truncate_content
 
 
 @pytest.mark.parametrize(
@@ -69,29 +69,34 @@ def test_clean_content_edge_cases(text, max_chars, expected):
 
 
 @pytest.mark.parametrize(
-    "path,expected",
+    "doc,expected",
     [
-        ("/solutions/3257611/index.html", "/solutions/3257611"),
-        ("/articles/2585/index.html", "/articles/2585"),
-        ("/documentation/en-us/rhel/9/html-single/guide/index.html", "/documentation/en-us/rhel/9/html-single/guide"),
-        ("/security/cve/CVE-2024-9823/", "/security/cve/CVE-2024-9823/"),
-        ("/errata/RHSA-2022:4915/", "/errata/RHSA-2022:4915/"),
-        ("", ""),
-        ("/solutions/123", "/solutions/123"),
+        ({"id": "/solutions/3257611/index.html"}, "/solutions/3257611"),
+        ({"id": "/articles/2585/index.html"}, "/articles/2585"),
+        (
+            {"id": "/documentation/en-us/rhel/9/html-single/guide/index.html"},
+            "/documentation/en-us/rhel/9/html-single/guide",
+        ),
+        ({"view_uri": "/security/cve/CVE-2024-9823/"}, "/security/cve/CVE-2024-9823/"),
+        ({"view_uri": "/errata/RHSA-2022:4915/"}, "/errata/RHSA-2022:4915/"),
+        ({}, ""),
+        ({"id": "/solutions/123"}, "/solutions/123"),
+        ({"view_uri": "/solutions/7134031", "id": "/solutions/7134031/index.html"}, "/solutions/7134031"),
     ],
     ids=[
-        "solution-id",
-        "article-id",
-        "documentation-id",
+        "solution-id-strips-suffix",
+        "article-id-strips-suffix",
+        "documentation-id-strips-suffix",
         "cve-view-uri-unchanged",
         "errata-view-uri-unchanged",
-        "empty-string",
-        "no-suffix",
+        "empty-doc-returns-empty",
+        "no-suffix-unchanged",
+        "view-uri-preferred-over-id",
     ],
 )
-def test_strip_index_suffix(path, expected):
-    """Trailing /index.html is stripped from Solr document ID paths."""
-    assert strip_index_suffix(path) == expected
+def test_doc_uri(doc, expected):
+    """doc_uri returns canonical URL path, preferring view_uri and stripping /index.html."""
+    assert doc_uri(doc) == expected
 
 
 def test_clean_content_strips_then_truncates():


### PR DESCRIPTION
## Summary

Follow-on from #47 addressing [Lifto's review feedback](https://github.com/rhel-lightspeed/okp-mcp/pull/47#pullrequestreview-2791621804): consolidate all URL path construction into a single public `doc_uri(doc)` function instead of sprinkling `strip_index_suffix()` calls at 6 sites.

- Replace `strip_index_suffix(path: str)` in `content.py` with `doc_uri(doc: dict) -> str`, which resolves the URL path (`view_uri` > `id`) and strips `/index.html` in one place
- Delete private `_doc_uri()` from `tools.py`, since `content.doc_uri()` now lives where both `tools.py` and `formatting.py` can import it without circular deps
- Replace 6 manual URL construction call sites across `tools.py` and `formatting.py` with `doc_uri(doc)`
- Rewrite `test_strip_index_suffix` to test `doc_uri` with Solr doc dicts, add `view-uri-preferred-over-id` case

Net: -8 lines. No behavior change.