### PR TITLE
fix(formatting): cap per-result content to prevent oversized highlights

### DIFF
--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -102,6 +102,13 @@ def _extract_version_lists(text: str) -> str:
 
 _LARGE_DOC_THRESHOLD = 10_000
 
+# Cap content per search result to prevent a single large document from
+# consuming the entire tool response. With hl.fragsizeIsMinimum=true,
+# Solr can produce highlight fragments of several thousand characters each,
+# so even a few snippets can exceed the caller's budget and push all
+# subsequent results out of the tool response.
+_MAX_RESULT_CONTENT = 4_500
+
 
 async def _resolve_content_text(highlights: str, include_content: bool, doc: dict, query: str) -> str:
     """Resolve the content text to display: highlights take priority, then main_content.
@@ -146,7 +153,9 @@ def _build_metadata_lines(doc: dict, kind_label: str | None, applicability: str,
     return lines
 
 
-async def _format_result(doc: dict, data: dict, include_content: bool = False, query: str = "") -> tuple[str, int]:
+async def _format_result(
+    doc: dict, data: dict, include_content: bool = False, query: str = "", max_content: int = _MAX_RESULT_CONTENT
+) -> tuple[str, int]:
     """Format a single Solr document with applicability labels and annotations."""
     doc_id = doc.get("id", "")
     view_uri = doc.get("view_uri", "")
@@ -170,5 +179,7 @@ async def _format_result(doc: dict, data: dict, include_content: bool = False, q
     if version_bullets:
         result += f"\nReleases mentioned:\n{version_bullets}"
     if content_text:
+        if len(content_text) > max_content:
+            content_text = content_text[:max_content] + " [...]"
         result += f"\nContent: {content_text}"
     return result, sort_key

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,34 @@
+"""Tests for okp_mcp.formatting module."""
+
+import pytest
+
+from okp_mcp.formatting import _format_result
+
+
+@pytest.mark.parametrize(
+    "main_content,max_content,expect_truncated",
+    [
+        ("x" * 10_000, 200, True),
+        ("Brief content about kernels.", 5000, False),
+    ],
+    ids=["large-content-truncated", "short-content-preserved"],
+)
+async def test_format_result_content_cap(main_content: str, max_content: int, expect_truncated: bool):
+    """_format_result caps content at max_content, appending [...] when truncated."""
+    doc = {
+        "id": "doc-1",
+        "allTitle": "Test Doc",
+        "documentKind": "solution",
+        "view_uri": "/test-doc",
+        "main_content": main_content,
+    }
+    data: dict = {"highlighting": {}}
+    result, _ = await _format_result(doc, data, include_content=True, query="test", max_content=max_content)
+
+    if expect_truncated:
+        assert "[...]" in result
+        content_start = result.index("Content: ") + len("Content: ")
+        assert len(result[content_start:]) < max_content + 100
+    else:
+        assert "[...]" not in result
+        assert main_content in result


### PR DESCRIPTION
## Summary

- Cap each search result's content at 4,500 chars (`_MAX_RESULT_CONTENT`) to prevent a single large Solr highlight from dominating the tool response
- Add `max_content` parameter to `_format_result()` with a sensible default, allowing callers to override per-query

## Why

Solr's `hl.fragsizeIsMinimum=true` produces highlight fragments of several thousand characters each. A single result can consume the entire response and push all subsequent results out, reducing answer quality.

Extracted from #55 to keep that PR smaller.

## Changes

| File | What |
|------|------|
| `formatting.py` | `_MAX_RESULT_CONTENT` constant + `max_content` param on `_format_result` + truncation |
| `test_formatting.py` | 2 tests: truncation fires on large content, short content passes through |

## Testing

`make ci` green (lint + typecheck + radon + 72 tests pass).