### PR TITLE
feat(content): add budget-aware result selection helper

### DIFF
--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -66,6 +66,9 @@ def _select_within_budget(results: list[str], max_chars: int, query: str) -> str
         included.append(result)
         chars_used += result_len
 
+    if not included:
+        return truncate_content(results[0], max_chars)
+
     output = separator.join(included)
 
     if len(included) < len(results):

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -169,3 +169,12 @@ def test_select_within_budget_tiny_budget():
     result = "a" * 1000
     output = _select_within_budget([result], max_chars=10, query="test")
     assert "Content truncated" in output
+
+
+def test_select_within_budget_first_exceeds_budget_multi():
+    """First result in a multi-result list exceeding the budget is hard-truncated."""
+    big = "z" * 5000
+    output = _select_within_budget([big, "small"], max_chars=100, query="test")
+    assert "Content truncated" in output
+    assert len(output) <= 200
+    assert "Budget reached" not in output


### PR DESCRIPTION
## Summary

- Add `_select_within_budget()` pure function that accumulates pre-sorted results until a character budget is reached, then drops tail entries with a truncation notice
- 7 unit tests covering: all-fit, tail-drop, single-huge-truncation, empty, separator, exact-boundary, tiny-budget

## Why

The response budget PR (#55) needs a way to select results within a character limit without truncating mid-result. This helper does exactly that: it iterates priority-sorted results, includes as many as fit, and appends a "[Budget reached]" message when results are dropped. A single oversized result gets hard-truncated via `truncate_content`.

No callers yet - will be wired in by #55 when the remaining budget enforcement lands.

Extracted from #55 to keep that PR smaller. Stacked on #57 -> #56.

## Changes

| File | What |
|------|------|
| `content.py` | `_select_within_budget()` function (~50 lines) |
| `test_content.py` | 7 new tests (~60 lines) |

## Testing

`make ci` green (lint + typecheck + radon + 79 tests pass). `content.py` at 100% coverage.