### PR TITLE
feat(config): add max_response_chars setting with AppContext wiring

### DIFF
--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -49,6 +49,11 @@ class ServerConfig(BaseSettings):
         default="http://localhost:8983",
         description="Base URL of the Solr instance",
     )
+    max_response_chars: int = Field(
+        default=30_000,
+        ge=1,
+        description="Maximum characters in a single tool response",
+    )
 
     @computed_field
     @property

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -23,6 +23,7 @@ class AppContext:
 
     http_client: httpx.AsyncClient
     solr_endpoint: str
+    max_response_chars: int
 
 
 @asynccontextmanager
@@ -31,10 +32,13 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
     del server
     cfg = _server_config if _server_config is not None else ServerConfig()
     solr_endpoint = cfg.solr_endpoint
+    max_response_chars = cfg.max_response_chars
     logger.info("SOLR endpoint: %s", solr_endpoint)
     client = httpx.AsyncClient(timeout=30.0)
     try:
-        yield {"app": AppContext(http_client=client, solr_endpoint=solr_endpoint)}
+        yield {
+            "app": AppContext(http_client=client, solr_endpoint=solr_endpoint, max_response_chars=max_response_chars)
+        }
     finally:
         await client.aclose()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -121,3 +121,23 @@ def test_solr_url_from_env():
 
     assert config.solr_url == "http://remote:1234"
     assert config.solr_endpoint == "http://remote:1234/solr/portal/select"
+
+
+def test_max_response_chars_default():
+    """max_response_chars defaults to 30000."""
+    config = ServerConfig()
+    assert config.max_response_chars == 30_000
+
+
+def test_max_response_chars_env_override():
+    """MCP_MAX_RESPONSE_CHARS environment variable overrides the default."""
+    with patch.dict("os.environ", {"MCP_MAX_RESPONSE_CHARS": "20000"}):
+        config = ServerConfig()
+    assert config.max_response_chars == 20_000
+
+
+@pytest.mark.parametrize("bad_value", [0, -1, -100])
+def test_max_response_chars_rejects_non_positive(bad_value):
+    """max_response_chars rejects zero and negative values at load time."""
+    with pytest.raises(ValidationError, match="max_response_chars"):
+        ServerConfig(max_response_chars=bad_value)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -97,6 +97,7 @@ def test_get_app_context_returns_lifespan_app_context():
     expected_context = AppContext(
         http_client=AsyncMock(spec=httpx.AsyncClient),
         solr_endpoint="http://localhost:8983/solr/portal/select",
+        max_response_chars=30_000,
     )
     ctx = cast(Context, SimpleNamespace(lifespan_context={"app": expected_context}))
 


### PR DESCRIPTION
## Summary

- Add `max_response_chars` config field (default 30K) to `ServerConfig` with `MCP_MAX_RESPONSE_CHARS` env var override
- Wire the value through `AppContext` and `_app_lifespan()` so tools can access it at runtime
- Plumbing only, no consumers yet - budget enforcement comes in #55

Part of the stacked PR series extracting pieces from #55 (along with #56, #57, #58).