### PR TITLE
feat(server): add version and website_url metadata to FastMCP instance

### DIFF
--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -2,6 +2,7 @@
 
 # pyright: reportAttributeAccessIssue=false
 
+import importlib.metadata
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
@@ -48,8 +49,15 @@ def get_app_context(ctx: Context) -> AppContext:
     return ctx.lifespan_context["app"]
 
 
+try:
+    __version__ = importlib.metadata.version("okp-mcp")
+except importlib.metadata.PackageNotFoundError:
+    __version__ = "dev"
+
 mcp = FastMCP(
     "RHEL OKP Knowledge Base",
     instructions="Search the Red Hat documentation, CVEs, errata, solutions, and articles to answer RHEL questions.",
     lifespan=_app_lifespan,
+    version=__version__,
+    website_url="https://github.com/rhel-lightspeed/okp-mcp",
 )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -21,10 +21,12 @@ from okp_mcp.server import AppContext, _app_lifespan, get_app_context, mcp
             "instructions",
             "Search the Red Hat documentation, CVEs, errata, solutions, and articles to answer RHEL questions.",
         ),
+        ("version", "0.1.0"),
+        ("website_url", "https://github.com/rhel-lightspeed/okp-mcp"),
     ],
 )
 def test_mcp_properties(attr, expected):
-    """FastMCP instance has the expected name and instructions."""
+    """FastMCP instance has the expected name, instructions, version, and website_url."""
     assert getattr(mcp, attr) == expected
 
 


### PR DESCRIPTION
## Summary

- Extract package version via `importlib.metadata` with `PackageNotFoundError` fallback to `"dev"`
- Set `version` and `website_url` on the FastMCP constructor so MCP clients can discover server identity

## Dependencies

None - this PR can merge independently.

**Stack**: PR 1 of 3 (`feat/server-metadata` → `feat/ctx-logging-progress` → `feat/fastmcp-modernization`)