### PR TITLE
feat(tools): add MCP protocol structured logging and progress reporting

### DIFF
--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -277,6 +277,7 @@ async def search_documentation(
         "search_documentation: query=%r product=%r version=%r max_results=%d", query, product, version, max_results
     )
     await ctx.info(f"Searching documentation for: {query}")
+    await ctx.report_progress(progress=0, total=1)
     try:
         app = get_app_context(ctx)
         product = _PRODUCT_ALIASES.get(product, product) or "Red Hat Enterprise Linux"
@@ -295,7 +296,9 @@ async def search_documentation(
         doc_results, sol_results, has_deprecation = await _deduplicate_and_sort_results(
             doc_data, sol_data, dep_data, query
         )
-        return _assemble_search_output(doc_results, sol_results, has_deprecation, query)
+        result = _assemble_search_output(doc_results, sol_results, has_deprecation, query)
+        await ctx.report_progress(progress=1, total=1)
+        return result
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query)
         await ctx.warning("Search timed out. Try a simpler query.")
@@ -319,6 +322,7 @@ async def search_solutions(
     max_results = max(1, min(max_results, 20))
     logger.info("search_solutions: query=%r product=%r max_results=%d", query, product, max_results)
     await ctx.info(f"Searching solutions for: {query}")
+    await ctx.report_progress(progress=0, total=1)
     try:
         app = get_app_context(ctx)
         filters = ["documentKind:solution"]
@@ -341,7 +345,9 @@ async def search_solutions(
             return f"No solutions found for: {query}"
 
         results = [_format_solution_article_doc(doc, data, query) for doc in docs]
-        return f"Found {len(docs)} solutions for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        result = f"Found {len(docs)} solutions for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        await ctx.report_progress(progress=1, total=1)
+        return result
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query)
         await ctx.warning("Search timed out. Try a simpler query.")
@@ -369,6 +375,7 @@ async def search_cves(
     max_results = max(1, min(max_results, 20))
     logger.info("search_cves: query=%r severity=%r max_results=%d", query, severity, max_results)
     await ctx.info(f"Searching CVE advisories for: {query}")
+    await ctx.report_progress(progress=0, total=1)
     try:
         app = get_app_context(ctx)
         filters = ["documentKind:Cve"]
@@ -401,7 +408,9 @@ async def search_cves(
             result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
             results.append(result)
 
-        return f"Found {len(docs)} CVEs for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        output = f"Found {len(docs)} CVEs for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        await ctx.report_progress(progress=1, total=1)
+        return output
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query)
         await ctx.warning("Search timed out. Try a simpler query.")
@@ -431,6 +440,7 @@ async def search_errata(
         "search_errata: query=%r severity=%r type=%r max_results=%d", query, severity, advisory_type, max_results
     )
     await ctx.info(f"Searching errata for: {query}")
+    await ctx.report_progress(progress=0, total=1)
     try:
         app = get_app_context(ctx)
         filters = ["documentKind:Errata"]
@@ -455,7 +465,9 @@ async def search_errata(
             return f"No errata found for: {query}"
 
         results = [_format_errata_doc(doc) for doc in docs]
-        return f"Found {len(docs)} errata for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        output = f"Found {len(docs)} errata for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        await ctx.report_progress(progress=1, total=1)
+        return output
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query)
         await ctx.warning("Search timed out. Try a simpler query.")
@@ -478,6 +490,7 @@ async def search_articles(
     max_results = max(1, min(max_results, 20))
     logger.info("search_articles: query=%r max_results=%d", query, max_results)
     await ctx.info(f"Searching articles for: {query}")
+    await ctx.report_progress(progress=0, total=1)
     try:
         app = get_app_context(ctx)
         data = await _solr_query(
@@ -496,7 +509,9 @@ async def search_articles(
             return f"No articles found for: {query}"
 
         results = [_format_solution_article_doc(doc, data, query) for doc in docs]
-        return f"Found {len(docs)} articles for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        output = f"Found {len(docs)} articles for '{query}':\n\n" + "\n\n---\n\n".join(results)
+        await ctx.report_progress(progress=1, total=1)
+        return output
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query)
         await ctx.warning("Search timed out. Try a simpler query.")
@@ -606,6 +621,7 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
     """
     logger.info("get_document: doc_id=%r query=%r", doc_id, query)
     await ctx.info(f"Fetching document: {doc_id}")
+    await ctx.report_progress(progress=0, total=1)
     try:
         app = get_app_context(ctx)
         if query:
@@ -619,7 +635,9 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
         if not docs:
             return f"Document not found: {doc_id}"
 
-        return await _format_document(docs[0], data, doc_id, query)
+        result = await _format_document(docs[0], data, doc_id, query)
+        await ctx.report_progress(progress=1, total=1)
+        return result
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query)
         await ctx.warning("Document fetch timed out.")

--- a/tests/test_tools_ctx_logging.py
+++ b/tests/test_tools_ctx_logging.py
@@ -151,3 +151,24 @@ async def test_run_code_logs_ctx_info(mock_ctx):
     assert "not available" in result.lower()
     mock_ctx.info.assert_awaited_once()
     assert "not supported" in mock_ctx.info.call_args[0][0].lower()
+
+
+async def test_search_documentation_reports_progress(mock_ctx):
+    """search_documentation calls report_progress twice (start and end)."""
+    with patch("okp_mcp.tools._solr_query", AsyncMock(return_value=_EMPTY_SOLR)):
+        await tools.search_documentation(mock_ctx, "test query")
+    assert mock_ctx.report_progress.await_count == 2
+
+
+async def test_get_document_reports_progress(mock_ctx):
+    """get_document calls report_progress twice."""
+    solr_resp = {
+        "responseHeader": {"status": 0, "QTime": 1},
+        "response": {
+            "numFound": 1,
+            "docs": [{"allTitle": "Test", "view_uri": "/docs/test", "documentKind": "documentation"}],
+        },
+    }
+    with patch("okp_mcp.tools._fetch_document_raw", AsyncMock(return_value=solr_resp)):
+        await tools.get_document(mock_ctx, "/docs/test")
+    assert mock_ctx.report_progress.await_count == 2


### PR DESCRIPTION
## Summary

- Add `await ctx.info/warning/error()` calls to all 7 MCP tools for client-visible structured logging (alongside existing server-side `logger.*()` calls)
- Add `await ctx.report_progress(0, 1)` / `(1, 1)` to 6 search/retrieval tools (not `run_code`) for progress tracking
- No `report_progress` inside `asyncio.gather` coroutines (race condition avoidance)

## Dependencies

Depends on #63 (`feat/server-metadata`). Merge #63 first, then this PR's base auto-updates to `main`.

**Stack**: PR 2 of 3 (`feat/server-metadata` → `feat/ctx-logging-progress` → `feat/fastmcp-modernization`)