### PR TITLE
feat(server): enable production hardening flags

### DIFF
--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -61,4 +61,5 @@ mcp = FastMCP(
     version=__version__,
     website_url="https://github.com/rhel-lightspeed/okp-mcp",
     mask_error_details=True,  # Mask internal exception details from MCP clients for unhandled errors
+    strict_input_validation=True,  # Reject type coercion silently; e.g. reject str "5" for int max_results
 )

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -136,3 +136,8 @@ def test_server_config_assignment_propagates_to_lifespan():
 def test_mcp_masks_error_details():
     """FastMCP instance hides internal error details for unhandled exceptions."""
     assert mcp._mask_error_details is True  # type: ignore[attr-defined]
+
+
+def test_mcp_validates_input_strictly():
+    """FastMCP instance rejects type coercion for tool parameters."""
+    assert mcp.strict_input_validation is True

--- a/tests/test_tools_ctx_logging.py
+++ b/tests/test_tools_ctx_logging.py
@@ -153,6 +153,12 @@ async def test_run_code_logs_ctx_info(mock_ctx):
     assert "not supported" in mock_ctx.info.call_args[0][0].lower()
 
 
+async def test_run_code_returns_friendly_message(mock_ctx):
+    """run_code placeholder returns helpful message without validation error."""
+    result = await tools.run_code(mock_ctx, language="python", code="print('hello')")
+    assert "not available" in result.lower()
+
+
 async def test_search_documentation_reports_progress(mock_ctx):
     """search_documentation calls report_progress twice (start and end)."""
     with patch("okp_mcp.tools._solr_query", AsyncMock(return_value=_EMPTY_SOLR)):


### PR DESCRIPTION
## Summary

- Enable `mask_error_details=True` to mask internal exception details from MCP clients in unhandled errors (defense-in-depth, existing try/except still returns user-friendly strings)
- Enable `strict_input_validation=True` to reject silent type coercion (e.g. string `"5"` for int `max_results` raises instead of silently coercing)

## Dependencies

Depends on #64 (`feat/ctx-logging-progress`). Merge #63 first, then #64, then this PR.

**Stack**: PR 3 of 3 (`feat/server-metadata` → `feat/ctx-logging-progress` → `feat/fastmcp-modernization`)