### PR TITLE
chore: document OKP_FUNCTIONAL_MODEL env var in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,4 +5,8 @@ OKP_ACCESS_KEY=your-access-key-here
 # Functional tests (uv run pytest -m functional)
 GOOGLE_APPLICATION_CREDENTIALS=./secrets/your-service-account.json
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+
+# Optional Vertex model for functional tests (default: gemini-2.5-flash).
+# If you see vertexai.allowedModels / "disallowed Gen AI model gemini-2.5-flash", set a model
+# your org allows (ask admin or see GCP console Organization Policy). Example:
 # OKP_FUNCTIONAL_MODEL=gemini-2.5-flash


### PR DESCRIPTION
## Summary

- Adds explanatory comments about `vertexai.allowedModels` org policy and how to set `OKP_FUNCTIONAL_MODEL` for functional tests

## Changes

- **`.env.example`**: 4-line comment block explaining when and why to override the default Gemini model

One-file, 4-line change.