### PR TITLE
chore: add pre-merge checks and reduce walkthrough noise in CodeRabbit config

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,13 +10,26 @@ tone_instructions: >
 
 reviews:
   profile: chill
-  collapse_walkthrough: true
+  collapse_walkthrough: false
   poem: false
   request_changes_workflow: true
   high_level_summary: false
   high_level_summary_placeholder: "@coderabbitai summary"
   abort_on_close: true
   review_status: true
+  suggested_labels: false
+  suggested_reviewers: false
+  in_progress_fortune: false
+
+  pre_merge_checks:
+    title:
+      mode: error
+      requirements: "Use conventional commits format (e.g., 'feat: add search', 'fix: handle timeout')"
+    docstrings:
+      mode: warning
+      threshold: 80
+    description:
+      mode: warning
 
   auto_review:
     enabled: true


### PR DESCRIPTION
## Summary

- Add pre-merge checks: conventional commits title enforcement (`error`), docstring coverage at 80% (`warning`), and PR description check (`warning`)
- Disable suggested labels, suggested reviewers, and in-progress fortune cookies to reduce walkthrough noise