### PR TITLE
feat(config): add MCP_RAG_SOLR_URL for separate RAG Solr instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Settings come from CLI arguments and `MCP_*` environment variables. CLI args tak
 | `--port` | `MCP_PORT` | `8000` | Bind port for HTTP transports |
 | `--log-level` | `MCP_LOG_LEVEL` | `INFO` | Python log level |
 | `--solr-url` | `MCP_SOLR_URL` | `http://localhost:8983` | Base URL of the Solr instance |
+| `--rag-solr-url` | `MCP_RAG_SOLR_URL` | *(falls back to MCP_SOLR_URL)* | Base URL of the RAG Solr instance |
 
 Run `okp-mcp --help` for the full list.
 

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -38,10 +38,8 @@ services:
     ports:
       - "8000:8000"
     environment:
-      # For standard testing, use the main OKP Solr instance:
       MCP_SOLR_URL: http://redhat-okp:8983
-      # For RAG testing, switch to the RAG Solr instance:
-      # MCP_SOLR_URL: http://redhat-okp-rag:8984
+      MCP_RAG_SOLR_URL: http://redhat-okp-rag:8984
     depends_on:
       - redhat-okp
     restart: unless-stopped

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -49,6 +49,10 @@ class ServerConfig(BaseSettings):
         default="http://localhost:8983",
         description="Base URL of the Solr instance",
     )
+    rag_solr_url: str | None = Field(
+        default=None,
+        description="Base URL of the RAG Solr instance (portal-rag core). Falls back to solr_url if not set.",
+    )
     max_response_chars: int = Field(
         default=30_000,
         ge=1,

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -24,6 +24,7 @@ class AppContext:
     http_client: httpx.AsyncClient
     solr_endpoint: str
     max_response_chars: int
+    rag_solr_url: str
 
 
 @asynccontextmanager
@@ -33,11 +34,20 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
     cfg = _server_config if _server_config is not None else ServerConfig()
     solr_endpoint = cfg.solr_endpoint
     max_response_chars = cfg.max_response_chars
+    rag_solr_url = cfg.rag_solr_url or cfg.solr_url
+    if cfg.rag_solr_url is None:
+        logger.warning("MCP_RAG_SOLR_URL not set; falling back to solr_url (%s) for RAG queries", cfg.solr_url)
     logger.info("SOLR endpoint: %s", solr_endpoint)
+    logger.info("RAG Solr URL: %s", rag_solr_url)
     client = httpx.AsyncClient(timeout=30.0)
     try:
         yield {
-            "app": AppContext(http_client=client, solr_endpoint=solr_endpoint, max_response_chars=max_response_chars)
+            "app": AppContext(
+                http_client=client,
+                solr_endpoint=solr_endpoint,
+                max_response_chars=max_response_chars,
+                rag_solr_url=rag_solr_url,
+            )
         }
     finally:
         await client.aclose()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_defaults():
     assert config.port == 8000
     assert config.log_level == "INFO"
     assert config.solr_url == "http://localhost:8983"
+    assert config.rag_solr_url is None
 
 
 @pytest.mark.parametrize(
@@ -141,3 +142,24 @@ def test_max_response_chars_rejects_non_positive(bad_value):
     """max_response_chars rejects zero and negative values at load time."""
     with pytest.raises(ValidationError, match="max_response_chars"):
         ServerConfig(max_response_chars=bad_value)
+
+
+@pytest.mark.parametrize(
+    "rag_solr_url, expected",
+    [
+        (None, None),
+        ("http://rag:8984", "http://rag:8984"),
+        ("http://custom-rag:9000", "http://custom-rag:9000"),
+    ],
+)
+def test_rag_solr_url_values(rag_solr_url, expected):
+    """rag_solr_url accepts None (default) or explicit URL string."""
+    config = ServerConfig(rag_solr_url=rag_solr_url)
+    assert config.rag_solr_url == expected
+
+
+def test_rag_solr_url_from_env():
+    """MCP_RAG_SOLR_URL env var populates rag_solr_url field."""
+    with patch.dict("os.environ", {"MCP_RAG_SOLR_URL": "http://rag:8984"}):
+        config = ServerConfig()
+    assert config.rag_solr_url == "http://rag:8984"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -98,6 +98,7 @@ def test_get_app_context_returns_lifespan_app_context():
         http_client=AsyncMock(spec=httpx.AsyncClient),
         solr_endpoint="http://localhost:8983/solr/portal/select",
         max_response_chars=30_000,
+        rag_solr_url="http://localhost:8983",
     )
     ctx = cast(Context, SimpleNamespace(lifespan_context={"app": expected_context}))
 
@@ -129,3 +130,27 @@ def test_server_config_assignment_propagates_to_lifespan():
         assert server_module._server_config is cfg
     finally:
         server_module._server_config = original
+
+
+@pytest.mark.asyncio
+async def test_lifespan_rag_solr_url_falls_back_to_solr_url():
+    """When MCP_RAG_SOLR_URL not set, lifespan falls back to solr_url."""
+    async with _app_lifespan(mcp) as lifespan_context:
+        app_context = lifespan_context["app"]
+        assert app_context.rag_solr_url == "http://localhost:8983"
+
+
+@pytest.mark.asyncio
+async def test_lifespan_uses_explicit_rag_solr_url():
+    """When MCP_RAG_SOLR_URL is set, lifespan uses it directly."""
+    with patch.dict("os.environ", {"MCP_RAG_SOLR_URL": "http://rag-instance:8984"}):
+        from okp_mcp import server as server_module
+
+        original = server_module._server_config
+        try:
+            server_module._server_config = None  # force fresh config load
+            async with _app_lifespan(mcp) as lifespan_context:
+                app_context = lifespan_context["app"]
+                assert app_context.rag_solr_url == "http://rag-instance:8984"
+        finally:
+            server_module._server_config = original


### PR DESCRIPTION
## Summary

- Adds `MCP_RAG_SOLR_URL` env var (CLI: `--rag_solr_url`) so the future `search_rag()` tool can hit the portal-rag Solr core on a different port/host than the legacy portal core
- Falls back to `MCP_SOLR_URL` when not set, with a warning log at startup
- Wires the resolved URL into `AppContext.rag_solr_url` for downstream tool use
- Removes the old commented-out `MCP_SOLR_URL` workaround from `podman-compose.yml` since `MCP_RAG_SOLR_URL` replaces it

## Changes

| File | What |
|------|------|
| `src/okp_mcp/config.py` | `rag_solr_url: str \| None` field (default `None`) |
| `src/okp_mcp/server.py` | `AppContext.rag_solr_url` field + lifespan fallback/logging |
| `README.md` | Config table row for the new setting |
| `podman-compose.yml` | Active `MCP_RAG_SOLR_URL` env var, removed stale comment |
| `tests/test_config.py` | Default, parametrized, and env var tests |
| `tests/test_server.py` | AppContext constructor, lifespan fallback, and explicit-URL tests |

No changes to `src/okp_mcp/rag/` or `src/okp_mcp/tools.py`. Next step on the [RAG Tool Planning](https://github.com/rhel-lightspeed/okp-mcp/wiki/RAG-Tool-Planning) wiki will wire this into an actual `search_rag()` tool.