### PR TITLE
fix: add SOLR_PORT for rag container

### DIFF
--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -23,7 +23,10 @@ services:
     environment:
       ACCESS_KEY: ${OKP_ACCESS_KEY}
       SOLR_JETTY_HOST: "0.0.0.0"
+      # This is the SOLR recommended method for setting the port
       SOLR_PORT_LISTEN: 8984
+      # But this is the only method that works for OKP 😆
+      SOLR_PORT: 8984
     volumes:
       - redhat-okp-rag-data:/opt/solr/server/solr/portal/data
     restart: unless-stopped


### PR DESCRIPTION
Although `SOLR_PORT_LISTEN` is the officially supported environment variable, `SOLR_PORT` is the only one that works on the OKP container with RAG.