### PR TITLE
fix(tools): boost release notes in deprecation search for vm_intent

### DIFF
--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -160,6 +160,9 @@ def _build_search_queries(
 
     dep_bq = (
         'allTitle:(deprecated OR removed OR "no longer" OR "end of life")^20 '
+        # Boost release notes and adoption guides — they carry authoritative deprecation notices
+        # that rank poorly due to large document size.
+        'allTitle:("release notes" OR "considerations in adopting")^15 '
         'main_content:(deprecated OR removed OR "no longer available")^10'
     )
     if vm_intent and extra_bq:
@@ -171,6 +174,8 @@ def _build_search_queries(
         "rows": 3,
         "bq": dep_bq,
     }
+    if vm_intent:
+        dep_params["hl.q"] = f"{cleaned} {_VM_HIGHLIGHT_TERMS}"
 
     return doc_params, sol_params, dep_params
 


### PR DESCRIPTION
## Summary

- Boost release notes and "Considerations in adopting" docs in the deprecation search query
- Pass `hl.q` with vm_intent highlight terms to the deprecation search

## Problem

When asked "Can I use virt-manager to manage virtual machines in RHEL 9?", the model incorrectly said "Yes, available and supported" 60% of the time. The RHEL 9.0 Release Notes explicitly state "virt-manager has been deprecated" but this snippet wasn't being surfaced.

**Root cause**: The deprecation search returned Cockpit solutions (which say "use cockpit") instead of release notes (which say "deprecated"). Release notes are huge docs (~335K chars) so the deprecation notice at position 259K was diluted by the document size. Additionally, the deprecation query didn't set `hl.q` to force Solr to extract the right highlight snippets.

## Fix

1. `allTitle:("release notes" OR "considerations in adopting")^15` — boosts authoritative deprecation sources
2. `dep_params["hl.q"]` for vm_intent — ensures deprecation highlight extraction matches the vm_intent pattern already used in doc/sol searches

## Validation

| Metric | Before | After |
|---|---|---|
| "Yes, available and supported" | 3/5 runs | 0/5 runs |
| Mentions cockpit/web console | 2/5 runs | 5/5 runs |
| Mentions deprecation | 4/5 runs (but contradicted) | 3/5 runs (consistent) |

227 unit tests pass, lint clean.