### PR TITLE
fix(tools): make search optional for well-known Linux concepts

### DIFF
--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -312,7 +312,10 @@ async def search_documentation(
 ) -> str:
     """Search Red Hat knowledge base: documentation, solutions, articles, and support policies.
 
-    This is the primary search tool. Always use this first for any RHEL question.
+    Use this tool when you need official Red Hat documentation to answer accurately,
+    especially for version-specific details, lifecycle dates, deprecation status,
+    or changes after 2024. For well-known Linux concepts (e.g. vi commands,
+    systemd units, common CLI tools) you may answer directly without searching.
     Covers how-to guides, troubleshooting, deprecation notices, compatibility
     matrices, lifecycle policies, known issues, and best practices.
 


### PR DESCRIPTION
## Summary

Change the `search_documentation` tool description from "Always use this first for any RHEL question" to guidance that lets the model skip search when confident about well-known Linux concepts.

## Before → After

```diff
- This is the primary search tool. Always use this first for any RHEL question.
+ Use this tool when you need official Red Hat documentation to answer accurately,
+ especially for version-specific details, lifecycle dates, deprecation status,
+ or changes after 2024. For well-known Linux concepts (e.g. vi commands,
+ systemd units, common CLI tools) you may answer directly without searching.
```

## Why

Forced search was **introducing noise** that degraded answers the model already knows correctly. For example, asking about `virsh vcpupin` — the model knows the correct command from training, but search returns XML-based pinning docs that cause it to hallucinate `virsh cpupin` instead.

## A/B Test Results (cla-tests, 96 tests across tiers 1-3)

| Config | Tier 1 (27) | Tier 2 (44) | Tier 3 (25) | **Total (96)** |
|---|---|---|---|---|
| No RAG | 77.8% | 63.6% | 80.0% | 71.9% |
| Forced RAG | 74.1% | 79.5% | 72.0% | 76.0% |
| **Optional RAG** | **70.4%** | **81.8%** | **84.0%** | **79.2%** |

Optional RAG captures the best of both: the model searches when it needs documentation (tier 2 technical questions) and answers directly when search would add noise (tier 1/3 common knowledge).

## Risk

The model might skip search when it shouldn't. Mitigated by:
- The tool description still emphasizes using search for version-specific, lifecycle, deprecation, and post-2024 topics
- The system prompt still instructs the model to cite sources from documentation