### PR TITLE
test: guard against vacuous pass in test_expand_chunks_parallel

### DIFF
--- a/tests/rag/test_context_functional.py
+++ b/tests/rag/test_context_functional.py
@@ -125,6 +125,8 @@ class TestContextExpansionFunctional:
             if len(diverse_chunks) >= 3:
                 break
 
+        assert diverse_chunks, "Solr returned no chunks with distinct parents for this query"
+
         expanded = await expand_chunks(diverse_chunks, client=client, solr_url=RAG_SOLR_URL)
 
         assert len(expanded) == len(diverse_chunks)


### PR DESCRIPTION
## Summary

- Adds a guard assertion that `diverse_chunks` is non-empty before calling `expand_chunks`, preventing the test from passing trivially when Solr returns no chunks with distinct parents.

Follow-on from #92 (CodeRabbit [review comment](https://github.com/rhel-lightspeed/okp-mcp/pull/92#pullrequestreview-4021994050)).