### PR TITLE
fix(server): include traceback in embedder close warning

### DIFF
--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -70,7 +70,7 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
             try:
                 embedder.close()
             except Exception:
-                logger.warning("Failed to close embedder cleanly")
+                logger.warning("Failed to close embedder cleanly", exc_info=True)
 
 
 def get_app_context(ctx: Context) -> AppContext:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -262,3 +262,28 @@ async def test_lifespan_logs_warning_on_embedder_init_failure(caplog):
         server_module._server_config = original
 
     assert "Embedding model unavailable" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_lifespan_logs_warning_with_traceback_on_embedder_close_failure(caplog):
+    """Lifespan logs a warning with exc_info when embedder.close() fails."""
+    from okp_mcp import server as server_module
+    from okp_mcp.config import ServerConfig
+
+    mock_embedder = MagicMock()
+    mock_embedder.close.side_effect = OSError("device busy")
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    original = server_module._server_config
+    try:
+        server_module._server_config = ServerConfig(rag_solr_url="http://rag-test:8984")
+        with (
+            patch("okp_mcp.server.Embedder", return_value=mock_embedder),
+            patch("okp_mcp.server.httpx.AsyncClient", return_value=mock_client),
+        ):
+            async with _app_lifespan(mcp):
+                pass
+    finally:
+        server_module._server_config = original
+
+    assert "Failed to close embedder cleanly" in caplog.text
+    assert "device busy" in caplog.text


### PR DESCRIPTION
## Summary

- Add `exc_info=True` to `logger.warning()` when `embedder.close()` fails so the full traceback is recorded for production debugging
- Add test covering the close-failure warning path, verifying both the message and exception details appear in logs

Addresses review feedback from #97.