### PR TITLE
feat(rag): wire fused search path into search_rag (hybrid + semantic + RRF)

### DIFF
--- a/src/okp_mcp/rag/AGENTS.md
+++ b/src/okp_mcp/rag/AGENTS.md
@@ -40,8 +40,8 @@ portal.py       -> config (logger), models
 rrf.py          -> models
 context.py      -> common (RAG_FL, rag_query), models
 formatting.py   -> models
-tools.py        -> server (mcp, get_app_context), common (RAG_FL, clean_rag_query),
-                   formatting, hybrid, models
+tools.py        -> server (AppContext, mcp, get_app_context), common (RAG_FL, clean_rag_query),
+                   asyncio, context, formatting, hybrid, semantic, rrf, models
 ```
 
 No circular imports. `models.py`, `rrf.py`, and `formatting.py` have no dependencies outside the subpackage. `embeddings.py` is the only module that imports ML libraries (sentence_transformers, torch).

--- a/src/okp_mcp/rag/README.md
+++ b/src/okp_mcp/rag/README.md
@@ -71,7 +71,7 @@ Four search strategies exist because no single approach covers everything.
 
 ### Hybrid Search (primary path)
 
-The `search_rag` MCP tool uses hybrid search exclusively. It hits the
+The `search_rag` MCP tool always runs hybrid retrieval. It hits the
 `/hybrid-search` Solr request handler, which has server-side eDisMax config
 with field boosts (title^30, chunk^20, headings_txt^15), phrase boosting,
 recency bias, and document-type weighting baked in. The client sends only the
@@ -96,7 +96,10 @@ text-to-vector path runs the embedding model asynchronously via a
 `ThreadPoolExecutor` with `max_workers=1` to serialize the non-thread-safe
 Rust tokenizer.
 
-Not wired into the MCP tool yet, but available for fusion pipelines.
+When an embedder is available in `AppContext`, `search_rag` runs semantic text
+search in parallel with hybrid search, then merges both result sets using
+reciprocal rank fusion. If semantic search fails, the tool logs a warning and
+gracefully falls back to hybrid-only results.
 
 ### Portal Search
 

--- a/src/okp_mcp/rag/tools.py
+++ b/src/okp_mcp/rag/tools.py
@@ -1,15 +1,20 @@
 """MCP tool definitions for RAG search against the portal-rag Solr core."""
 
+import asyncio
 import logging
+from typing import cast
 
 import httpx
 from fastmcp import Context
 
-from ..server import get_app_context, mcp
+from ..server import AppContext, get_app_context, mcp
 from .common import RAG_FL, clean_rag_query
+from .context import expand_chunks
 from .formatting import deduplicate_chunks, format_rag_result
 from .hybrid import hybrid_search
-from .models import RagDocument
+from .models import RagDocument, RagResponse
+from .rrf import reciprocal_rank_fusion
+from .semantic import semantic_text_search
 
 logger = logging.getLogger(__name__)
 
@@ -45,6 +50,59 @@ def _assemble_rag_output(docs: list[RagDocument], query: str, max_chars: int) ->
     return f"Found {n_shown} results for '{query}':\n\n" + "\n\n---\n\n".join(parts)
 
 
+async def _run_fused_search(
+    query: str,
+    cleaned: str,
+    *,
+    app: AppContext,
+    max_results: int,
+    product: str,
+) -> RagResponse:
+    """Run hybrid and semantic search in parallel, merge via reciprocal rank fusion.
+
+    Hybrid search uses the cleaned (stopword-stripped) query for BM25 precision.
+    Semantic search uses the raw query for natural-language embedding quality.
+    If semantic fails, logs a warning and falls back to hybrid results only.
+    If hybrid fails, re-raises immediately (hybrid is the primary path).
+
+    Args:
+        query: Original raw user query (for semantic search).
+        cleaned: Stopword-stripped query (for hybrid BM25 search).
+        app: Application context with HTTP client, Solr URL, and embedder.
+        max_results: Row count to request from each search backend.
+        product: Product filter/boost string.
+
+    Returns:
+        RagResponse with merged, RRF-scored results (or hybrid-only on semantic failure).
+    """
+    if app.embedder is None:
+        raise ValueError("Embedder is required for fused search")
+
+    hybrid_coro = hybrid_search(
+        cleaned,
+        client=app.http_client,
+        solr_url=app.rag_solr_url,
+        max_results=max_results,
+        fl=RAG_FL,
+        product=product,
+    )
+    semantic_coro = semantic_text_search(
+        query,
+        embedder=app.embedder,
+        client=app.http_client,
+        solr_url=app.rag_solr_url,
+        max_results=max_results,
+        fl=RAG_FL,
+    )
+    hybrid_result, semantic_result = await asyncio.gather(hybrid_coro, semantic_coro, return_exceptions=True)
+    if isinstance(hybrid_result, Exception):
+        raise hybrid_result
+    if isinstance(semantic_result, Exception):
+        logger.warning("Semantic search failed, using hybrid results only", exc_info=semantic_result)
+        return cast(RagResponse, hybrid_result)
+    return reciprocal_rank_fusion(cast(RagResponse, hybrid_result), cast(RagResponse, semantic_result))
+
+
 @mcp.tool(tags={"rag"})
 async def search_rag(
     ctx: Context,
@@ -52,13 +110,15 @@ async def search_rag(
     product: str = "",
     max_results: int = 10,
 ) -> str:
-    """Search Red Hat documentation, CVEs, and errata using semantic-boosted search.
+    """Search Red Hat documentation, CVEs, and errata using fused lexical and semantic retrieval.
 
     Uses the portal-rag knowledge base, which provides higher-fidelity chunks
     from Red Hat documentation, CVEs, and errata than the portal search tools.
 
     Coverage gaps: Does not include Red Hat solutions or articles. For
     troubleshooting guides, use search_documentation or search_solutions instead.
+    Graceful degradation and context expansion: semantic failures fall back to
+    hybrid-only retrieval, and all results are context-expanded before formatting.
 
     When to prefer this tool:
     - Looking up CVE details, errata advisories, or documentation excerpts
@@ -80,20 +140,24 @@ async def search_rag(
     try:
         app = get_app_context(ctx)
         cleaned = clean_rag_query(query)
-        response = await hybrid_search(
-            cleaned,
-            client=app.http_client,
-            solr_url=app.rag_solr_url,
-            max_results=max_results * 3,
-            fl=RAG_FL,
-            product=product,
-        )
+        if app.embedder is not None:
+            response = await _run_fused_search(query, cleaned, app=app, max_results=max_results * 3, product=product)
+        else:
+            response = await hybrid_search(
+                cleaned,
+                client=app.http_client,
+                solr_url=app.rag_solr_url,
+                max_results=max_results * 3,
+                fl=RAG_FL,
+                product=product,
+            )
 
         if not response.docs:
             return f"No results found for: {query}"
 
         deduped = deduplicate_chunks(response.docs)[:max_results]
-        return _assemble_rag_output(deduped, query, app.max_response_chars)
+        expanded = await expand_chunks(deduped, client=app.http_client, solr_url=app.rag_solr_url)
+        return _assemble_rag_output(expanded, query, app.max_response_chars)
 
     except httpx.TimeoutException:
         logger.warning("search_rag timed out for query: %r", query)

--- a/tests/rag/conftest.py
+++ b/tests/rag/conftest.py
@@ -31,3 +31,19 @@ async def rag_client():
     """Async httpx client with automatic cleanup for RAG tests."""
     async with httpx.AsyncClient() as client:
         yield client
+
+
+@pytest.fixture(autouse=True)
+async def _patch_expand_chunks(monkeypatch):
+    """Patch expand_chunks to return input unchanged in all tool tests.
+
+    The fused search path calls expand_chunks() after dedup on all paths.
+    Existing tests only mock the hybrid endpoint, so unmocked expansion
+    calls would hit real Solr (or raise in respx strict mode). This
+    fixture makes expansion a no-op unless a test explicitly overrides it.
+    """
+
+    async def _passthrough(chunks, **kwargs):
+        return chunks
+
+    monkeypatch.setattr("okp_mcp.rag.tools.expand_chunks", _passthrough)

--- a/tests/rag/test_tools.py
+++ b/tests/rag/test_tools.py
@@ -1,11 +1,14 @@
 """Unit tests for search_rag MCP tool."""
 
-from unittest.mock import MagicMock
+import logging
+from unittest.mock import MagicMock, patch
 
 import httpx
 import respx
 from fastmcp import Context
 
+from okp_mcp.rag.embeddings import Embedder
+from okp_mcp.rag.models import RagDocument, RagResponse
 from okp_mcp.rag.tools import search_rag
 from okp_mcp.server import AppContext
 
@@ -13,13 +16,14 @@ RAG_SOLR_URL = "http://test-solr:8984"
 HYBRID_ENDPOINT = f"{RAG_SOLR_URL}/solr/portal-rag/hybrid-search"
 
 
-def _make_app_context(client: httpx.AsyncClient, max_chars: int = 50_000) -> AppContext:
+def _make_app_context(client: httpx.AsyncClient, max_chars: int = 50_000, embedder=None) -> AppContext:
     """Create a minimal AppContext for testing."""
     return AppContext(
         http_client=client,
         solr_endpoint="http://test-solr:8983",
         max_response_chars=max_chars,
         rag_solr_url=RAG_SOLR_URL,
+        embedder=embedder,
     )
 
 
@@ -191,3 +195,130 @@ async def test_search_rag_registered_in_mcp_with_rag_tag():
     # ctx should NOT appear in the input schema (FastMCP injects it automatically)
     schema_props = tool.parameters.get("properties", {})
     assert "ctx" not in schema_props, f"ctx should not be in input schema, got: {list(schema_props)}"
+
+
+# --- Fused search path tests ---
+
+
+async def test_search_rag_fused_path_with_embedder(rag_client, rag_chunk_response):
+    """search_rag calls _run_fused_search when embedder is available."""
+    embedder = MagicMock(spec=Embedder)
+    fused_response = RagResponse(
+        num_found=1,
+        docs=[RagDocument(doc_id="/doc1", parent_id="/parent1", chunk="fused content", num_tokens=50)],
+    )
+    with patch("okp_mcp.rag.tools._run_fused_search", return_value=fused_response) as mock_fused:
+        app = _make_app_context(rag_client, embedder=embedder)
+        ctx = _make_ctx(app)
+        result = await search_rag(ctx, "test query")
+
+    mock_fused.assert_awaited_once()
+    assert "fused content" in result
+    assert "Found" in result
+
+
+async def test_search_rag_fused_uses_raw_query_for_semantic(rag_client):
+    """semantic_text_search receives raw query; hybrid_search receives cleaned query."""
+    embedder = MagicMock(spec=Embedder)
+    raw_query = "how to configure firewall on RHEL"
+    hybrid_resp = RagResponse(
+        num_found=1,
+        docs=[RagDocument(doc_id="/h1", parent_id="/p1", chunk="hybrid result", num_tokens=50)],
+    )
+    semantic_resp = RagResponse(
+        num_found=1,
+        docs=[RagDocument(doc_id="/s1", parent_id="/ps1", chunk="semantic result", num_tokens=50)],
+    )
+    rrf_resp = RagResponse(num_found=2, docs=hybrid_resp.docs + semantic_resp.docs)
+
+    with (
+        patch("okp_mcp.rag.tools.hybrid_search", return_value=hybrid_resp) as mock_hybrid,
+        patch("okp_mcp.rag.tools.semantic_text_search", return_value=semantic_resp) as mock_semantic,
+        patch("okp_mcp.rag.tools.reciprocal_rank_fusion", return_value=rrf_resp),
+    ):
+        app = _make_app_context(rag_client, embedder=embedder)
+        ctx = _make_ctx(app)
+        await search_rag(ctx, raw_query)
+
+    # Semantic gets raw query; hybrid gets cleaned (stopwords stripped)
+    semantic_call_text = mock_semantic.call_args[0][0]
+    hybrid_call_query = mock_hybrid.call_args[0][0]
+    assert semantic_call_text == raw_query
+    hybrid_words = hybrid_call_query.split()
+    assert "how" not in hybrid_words  # stopwords removed
+    assert "to" not in hybrid_words
+    assert "on" not in hybrid_words
+
+
+async def test_search_rag_falls_back_to_hybrid_on_semantic_failure(rag_client, caplog):
+    """search_rag falls back to hybrid results when semantic search raises."""
+    embedder = MagicMock(spec=Embedder)
+    hybrid_resp = RagResponse(
+        num_found=1,
+        docs=[RagDocument(doc_id="/h1", parent_id="/p1", chunk="hybrid only content", num_tokens=50)],
+    )
+
+    with (
+        patch("okp_mcp.rag.tools.hybrid_search", return_value=hybrid_resp),
+        patch("okp_mcp.rag.tools.semantic_text_search", side_effect=httpx.ConnectError("semantic down")),
+        caplog.at_level(logging.WARNING),
+    ):
+        app = _make_app_context(rag_client, embedder=embedder)
+        ctx = _make_ctx(app)
+        result = await search_rag(ctx, "firewall configuration")
+
+    # Should return hybrid results, not raise
+    assert "Found" in result
+    assert "hybrid only content" in result
+    # Warning should be logged
+    assert any("Semantic search failed" in r.message for r in caplog.records)
+
+
+async def test_search_rag_hybrid_only_when_no_embedder(rag_client, rag_chunk_response):
+    """search_rag uses hybrid-only path when AppContext.embedder is None."""
+    with (
+        respx.mock() as router,
+        patch("okp_mcp.rag.tools.semantic_text_search") as mock_semantic,
+    ):
+        router.get(HYBRID_ENDPOINT).mock(return_value=httpx.Response(200, json=rag_chunk_response))
+        app = _make_app_context(rag_client)  # embedder=None by default
+        ctx = _make_ctx(app)
+        await search_rag(ctx, "firewall")
+
+    mock_semantic.assert_not_called()
+
+
+async def test_search_rag_calls_expand_chunks_after_dedup(rag_client, rag_chunk_response):
+    """expand_chunks is called with deduped docs on all paths (hybrid-only)."""
+    expand_calls = []
+
+    async def _tracking_expand(chunks, **kwargs):
+        expand_calls.append(chunks)
+        return chunks
+
+    with (
+        respx.mock() as router,
+        patch("okp_mcp.rag.tools.expand_chunks", side_effect=_tracking_expand),
+    ):
+        router.get(HYBRID_ENDPOINT).mock(return_value=httpx.Response(200, json=rag_chunk_response))
+        app = _make_app_context(rag_client)
+        ctx = _make_ctx(app)
+        await search_rag(ctx, "CVE test")
+
+    assert len(expand_calls) == 1
+    assert isinstance(expand_calls[0], list)
+
+
+async def test_search_rag_handles_hybrid_failure_in_fused_path(rag_client):
+    """search_rag returns user-friendly message when hybrid fails in fused path."""
+    embedder = MagicMock(spec=Embedder)
+
+    with (
+        patch("okp_mcp.rag.tools.hybrid_search", side_effect=httpx.ConnectError("solr down")),
+        patch("okp_mcp.rag.tools.semantic_text_search", side_effect=httpx.ConnectError("semantic down")),
+    ):
+        app = _make_app_context(rag_client, embedder=embedder)
+        ctx = _make_ctx(app)
+        result = await search_rag(ctx, "test query")
+
+    assert "unavailable" in result.lower()


### PR DESCRIPTION
## Summary

- Wire existing hybrid, semantic, and RRF building blocks together in `search_rag()` so it runs both searches in parallel, merges via reciprocal rank fusion, and expands chunk context before formatting
- Falls back to hybrid-only when no embedder is available (zero regression for existing deployments)
- Graceful degradation: semantic failures log a warning and return hybrid results only

## Changes

**`src/okp_mcp/rag/tools.py`**
- New `_run_fused_search()` private async helper that runs hybrid + semantic via `asyncio.gather(return_exceptions=True)`, merges with synchronous `reciprocal_rank_fusion()`
- Updated `search_rag()` to use fused path when `app.embedder is not None`, hybrid-only otherwise
- `expand_chunks()` now runs on all paths after dedup, before formatting
- Updated docstring to reflect fused retrieval behavior

**`tests/rag/conftest.py`**
- New autouse `_patch_expand_chunks` fixture that makes `expand_chunks` a no-op by default (prevents existing tests from hitting unmocked Solr `/select` endpoints)

**`tests/rag/test_tools.py`**
- Extended `_make_app_context` with backward-compatible `embedder=None` parameter
- Added 6 new tests covering: fused path routing, raw vs cleaned query routing, graceful degradation on semantic failure, hybrid-only when no embedder, expand_chunks tracking, and hybrid failure in fused path
- All 9 existing test bodies are unchanged

**`src/okp_mcp/rag/AGENTS.md`** and **`src/okp_mcp/rag/README.md`**
- Updated dependency graph and pipeline documentation to reflect the fused search wiring

## Verification

- `make ci` passes (310 tests, lint, typecheck, radon)
- All functions in `tools.py` rated A or B by radon (`_run_fused_search` A(4), `_assemble_rag_output` B(6), `search_rag` B(7))
- 15/15 tool tests pass (9 existing + 6 new)
- 199/199 RAG suite tests pass