### PR TITLE
RSPEED-2754: fix trailing Solr wildcard chars in RAG query tokens

### DIFF
--- a/src/okp_mcp/rag/common.py
+++ b/src/okp_mcp/rag/common.py
@@ -56,7 +56,7 @@ _TERM_TRIM_CHARS = "?.,!"
 
 def _normalize_query_token(token: str) -> str:
     """Strip trailing punctuation and lowercase a query token for BM25 matching."""
-    return token.lower().strip(_TERM_TRIM_CHARS)
+    return token.lower().rstrip(_TERM_TRIM_CHARS)
 
 
 def _is_numeric(token: str) -> bool:
@@ -67,9 +67,10 @@ def _is_numeric(token: str) -> bool:
 def clean_rag_query(query: str) -> str:
     """Clean a query string for RAG Solr search.
 
-    Strips English stopwords, quotes hyphenated compounds for phrase
-    matching, and preserves numeric tokens (e.g. version numbers).
-    Falls back to the original query if all tokens are stopwords.
+    Strips English stopwords, trailing punctuation (including Solr wildcard
+    characters like ``?``), quotes hyphenated compounds for phrase matching,
+    and preserves numeric tokens (e.g. version numbers).  Falls back to the
+    original query if all tokens are stopwords.
 
     Args:
         query: Raw user query string.
@@ -78,13 +79,18 @@ def clean_rag_query(query: str) -> str:
         Cleaned query string optimized for Solr eDisMax search.
     """
     tokens = _split_quoted_and_plain(query)
-    parts = [
-        t
-        for t in tokens
-        if t.startswith('"')
-        or _is_numeric(t)
-        or (_normalize_query_token(t) and _normalize_query_token(t) not in STOP_WORDS)
-    ]
+    parts: list[str] = []
+    for t in tokens:
+        if t.startswith('"'):
+            parts.append(t)
+            continue
+        # Strip trailing punctuation that doubles as Solr syntax (? is a
+        # single-char wildcard, . triggers fuzzy proximity, etc.)
+        stripped = t.rstrip(_TERM_TRIM_CHARS)
+        if not stripped:
+            continue
+        if _is_numeric(stripped) or stripped.lower() not in STOP_WORDS:
+            parts.append(stripped)
     parts = _quote_hyphenated_compounds(parts)
     return " ".join(parts) if parts else query
 

--- a/tests/rag/test_common.py
+++ b/tests/rag/test_common.py
@@ -92,8 +92,22 @@ async def test_rag_query_logs_at_info_level(rag_client, caplog):
         ("the and ?", "the and ?"),  # punctuation-only token stripped, fallback to original
         ("", ""),  # empty string
         ('"exact phrase" kernel', '"exact phrase" kernel'),  # quoted preservation
+        ("Can I run a RHEL 6 container on RHEL 9?", "RHEL 6 container RHEL 9"),  # trailing ? stripped
+        ("What version! of RHEL?", "version RHEL"),  # trailing ! and ? stripped
+        ('"RHEL 9?" support', '"RHEL 9?" support'),  # punctuation inside quotes preserved
     ],
-    ids=["stopwords", "hyphenated", "numeric", "all-stopwords", "punctuation-only", "empty", "quoted-phrase"],
+    ids=[
+        "stopwords",
+        "hyphenated",
+        "numeric",
+        "all-stopwords",
+        "punctuation-only",
+        "empty",
+        "quoted-phrase",
+        "trailing-question-mark",
+        "trailing-exclamation-and-question",
+        "quoted-punctuation",
+    ],
 )
 def test_clean_rag_query(input_query, expected):
     """clean_rag_query produces Solr-optimized tokens."""


### PR DESCRIPTION
## Summary

- `clean_rag_query()` stripped trailing `?.,!` for stopword checks but preserved them in the output. Solr interprets `?` as a single-character wildcard, so `9?` matched `90`, `91`, etc. instead of `9`, completely destroying search relevance for any query ending in a question mark.
- Refactored the list comprehension to a loop that applies `.strip(_TERM_TRIM_CHARS)` to non-quoted output tokens before adding them to the result.
- Added test cases covering trailing `?` and `!` stripping.

## Impact

Query "Can I run a RHEL 6 container on RHEL 9?" cleaned to `RHEL 6 container RHEL 9?`. The Container Compatibility Matrix doc (score 633 without `?`) vanished entirely from results, replaced by irrelevant OpenStack release notes (score 370). After the fix, the correct doc is result #1.

Validated against RSPEED-2482 (container compat matrix) and RSPEED-2481 (SPICE deprecation).

## Jira

https://redhat.atlassian.net/browse/RSPEED-2754