### PR TITLE
feat: disable portal search tools when RAG is active

### DIFF
--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -37,7 +37,10 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
     solr_endpoint = cfg.solr_endpoint
     max_response_chars = cfg.max_response_chars
     rag_solr_url = cfg.rag_solr_url or cfg.solr_url
-    if not cfg.rag_solr_url:
+    if cfg.rag_solr_url:
+        mcp.disable(tags={"portal"})
+        logger.info("Portal search tools disabled: RAG tools active (MCP_RAG_SOLR_URL is set)")
+    else:
         logger.warning("MCP_RAG_SOLR_URL not set; falling back to solr_url (%s) for RAG queries", cfg.solr_url)
         mcp.disable(tags={"rag"})
         logger.info("RAG tools disabled: MCP_RAG_SOLR_URL not set")

--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -302,7 +302,7 @@ def _format_errata_doc(doc: dict) -> str:
     return result
 
 
-@mcp.tool
+@mcp.tool(tags={"portal"})
 async def search_documentation(
     ctx: Context,
     query: str,
@@ -368,7 +368,7 @@ async def search_documentation(
         return "No results found. The knowledge base may be temporarily unavailable."
 
 
-@mcp.tool
+@mcp.tool(tags={"portal"})
 async def search_solutions(
     ctx: Context,
     query: str,
@@ -411,7 +411,7 @@ async def search_solutions(
         return "No results found. The knowledge base may be temporarily unavailable."
 
 
-@mcp.tool
+@mcp.tool(tags={"portal"})
 async def search_cves(
     ctx: Context,
     query: str,
@@ -468,7 +468,7 @@ async def search_cves(
         return "No results found. The knowledge base may be temporarily unavailable."
 
 
-@mcp.tool
+@mcp.tool(tags={"portal"})
 async def search_errata(
     ctx: Context,
     query: str,
@@ -519,7 +519,7 @@ async def search_errata(
         return "No results found. The knowledge base may be temporarily unavailable."
 
 
-@mcp.tool
+@mcp.tool(tags={"portal"})
 async def search_articles(
     ctx: Context,
     query: str,


### PR DESCRIPTION
## Summary

- Tags the five legacy search tools (`search_documentation`, `search_solutions`, `search_cves`, `search_errata`, `search_articles`) with `{"portal"}`
- Disables them at startup when `MCP_RAG_SOLR_URL` is set, making RAG and portal tool sets mutually exclusive
- `get_document` and `run_code` remain untagged and always available regardless of configuration