### PR TITLE
fix: strip trailing Solr wildcard chars from portal query tokens

### DIFF
--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -49,7 +49,7 @@ _TERM_TRIM_CHARS = "?.,!"
 
 def _normalize_query_token(token: str) -> str:
     """Strip trailing punctuation and lowercase a query token for BM25 matching."""
-    return token.lower().strip(_TERM_TRIM_CHARS)
+    return token.lower().rstrip(_TERM_TRIM_CHARS)
 
 
 def _is_numeric(token: str) -> bool:
@@ -60,17 +60,29 @@ def _is_numeric(token: str) -> bool:
 def _clean_query(query: str) -> str:
     """Strip English stopwords and quote hyphenated compounds for SOLR relevance.
 
-    Preserves quoted phrases intact, and always keeps numeric tokens (e.g. '10',
+    Strips trailing punctuation (including Solr wildcard characters like ``?``),
+    preserves quoted phrases intact, and always keeps numeric tokens (e.g. '10',
     '9') since they are critical for version-specific queries in Red Hat content.
     Hyphenated tokens like ``rpm-ostree`` are wrapped in double quotes so SOLR
     matches them as phrases instead of splitting on the hyphen. Falls back to the
     original query if stripping would remove all terms.
     """
     tokens = _split_quoted_and_plain(query)
-    parts = [t for t in tokens if t.startswith('"') or _is_numeric(t) or t.lower().strip("?.,!") not in STOP_WORDS]
-    # Solr's tokenizer splits hyphens (rpm-ostree → rpm + ostree), so quote them
-    # to force phrase matching. Without this, "rpm" alone floods results with
-    # generic RPM package docs, burying actual rpm-ostree content.
+    parts: list[str] = []
+    for t in tokens:
+        if t.startswith('"'):
+            parts.append(t)
+            continue
+        # Strip trailing punctuation that doubles as Solr syntax (? is a
+        # single-char wildcard, . triggers fuzzy proximity, etc.)
+        stripped = t.rstrip(_TERM_TRIM_CHARS)
+        if not stripped:
+            continue
+        if _is_numeric(stripped) or stripped.lower() not in STOP_WORDS:
+            parts.append(stripped)
+    # Solr's tokenizer splits hyphens (rpm-ostree -> rpm + ostree), so quote
+    # them to force phrase matching. Without this, "rpm" alone floods results
+    # with generic RPM package docs, burying actual rpm-ostree content.
     parts = _quote_hyphenated_compounds(parts)
     return " ".join(parts) if parts else query
 

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -1,4 +1,4 @@
-"""Tests for SOLR query client lifecycle behavior."""
+"""Tests for SOLR query client lifecycle and query cleaning behavior."""
 
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -7,7 +7,7 @@ import pytest
 import respx
 
 from okp_mcp.config import ServerConfig
-from okp_mcp.solr import _solr_query
+from okp_mcp.solr import _clean_query, _solr_query
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
@@ -127,3 +127,35 @@ async def test_solr_query_respx_regression_guard(solr_mock, sample_solr_response
 
     assert solr_mock.called
     assert data["response"]["numFound"] == sample_solr_response["response"]["numFound"]
+
+
+@pytest.mark.parametrize(
+    "input_query, expected",
+    [
+        ("the red hat enterprise linux", "red hat enterprise linux"),
+        ("rpm-ostree update", '"rpm-ostree" update'),
+        ("RHEL 9.4 kernel", "RHEL 9.4 kernel"),
+        ("the and or", "the and or"),
+        ("the and ?", "the and ?"),
+        ("", ""),
+        ('"exact phrase" kernel', '"exact phrase" kernel'),
+        ("Can I run a RHEL 6 container on RHEL 9?", "RHEL 6 container RHEL 9"),
+        ("What version! of RHEL?", "version RHEL"),
+        ('"RHEL 9?" support', '"RHEL 9?" support'),
+    ],
+    ids=[
+        "stopwords",
+        "hyphenated",
+        "numeric",
+        "all-stopwords",
+        "punctuation-only",
+        "empty",
+        "quoted-phrase",
+        "trailing-question-mark",
+        "trailing-exclamation-and-question",
+        "quoted-punctuation",
+    ],
+)
+def test_clean_query(input_query, expected):
+    """_clean_query strips trailing Solr wildcard chars from output tokens."""
+    assert _clean_query(input_query) == expected


### PR DESCRIPTION
## Summary

- `_clean_query()` in `solr.py` had the same bug fixed in `rag/common.py` (PR #103): trailing punctuation (like `?`) was stripped for the stopword membership check but the raw token was preserved in output. Solr interprets `?` as a single-character wildcard, so `9?` matched `90`, `91`, etc., destroying search relevance for any query ending in a question mark.
- Refactored the list comprehension to a loop that applies `.rstrip(_TERM_TRIM_CHARS)` to non-quoted output tokens before appending them to the result list.
- Changed `_normalize_query_token()` from `.strip()` to `.rstrip()` for consistency with the RAG path.
- Added parametrized test cases for `_clean_query()` covering trailing `?`, `!`, quoted punctuation preservation, stopwords, hyphenated compounds, and edge cases.

## Impact

Every portal search tool (`search_documentation`, `search_solutions`, `search_cves`, `search_errata`, `search_articles`) flows through `_clean_query()`. Any natural-language question ending in `?` had wildcard pollution, e.g., "RHEL 9?" matching RHEL 90/91/92 instead of RHEL 9.

## Jira

Continuation of RSPEED-2754 (same root cause, different code path).