### PR TITLE
test: add functional tests for RSPEED-2745, 2136, 2123, 2113, 1931

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -327,4 +327,21 @@ FUNCTIONAL_TEST_CASES = [
         ),
         id="RSPEED_2113",
     ),
+    pytest.param(
+        FunctionalCase(
+            question="how do i update the kernel arguments on a system using rpm-ostree?",
+            expected_doc_refs=[
+                "7069583",
+                "using_image_mode_for_rhel",
+                "kargs",
+            ],
+            required_facts=[
+                "rpm-ostree kargs",
+                ("--append", "append"),
+                ("--delete", "--replace"),
+            ],
+            forbidden_claims=["grubby --update-kernel"],
+        ),
+        id="RSPEED_1931",
+    ),
 ]


### PR DESCRIPTION
## Summary

- Add 5 functional test cases for CLA incorrect-answer tickets that the MCP server already handles correctly
- No code changes needed: all tests pass immediately, locking in correct behavior to prevent regressions

## Test cases

| Ticket | Question | Key assertion |
|--------|----------|---------------|
| RSPEED-2745 | When does maintenance support end for RHEL 7? | June 30, 2024 (not August 2020) |
| RSPEED-2136 | How to prepare a custom SELinux policy from AVC messages? | audit2allow + semodule workflow |
| RSPEED-2123 | How to enable bnxt_en NIC driver debugging? | ethtool msglvl (not ethtool -P) |
| RSPEED-2113 | Configure LACP bond with nmcli | mode=802.3ad + bond-slave commands |
| RSPEED-1931 | Update kernel arguments on rpm-ostree system? | rpm-ostree kargs (not grubby) |