### PR TITLE
feat(tests): add xdist-compatible token usage tracking

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,7 @@ Functional tests are **deselected by default** via `pytest_collection_modifyitem
 - `temperature=0` for reproducibility
 - Assertions check: tool call count, expected document references in tool returns/response, required facts (with tuple alternatives for "or" logic), and forbidden claims
 - Tests skip gracefully when `.env` is missing, credentials are invalid, or Solr is unavailable
+- Token usage is tracked via pytest's `record_property` fixture and aggregated in `pytest_terminal_summary` (xdist-safe; also embeds in JUnit XML when `--junitxml` is used)
 
 **Workflow**: See `INCORRECT_ANSWER_LOOP.md` for the full process of turning RSPEED "incorrect answer" tickets into functional test cases and fixing the MCP server until all tests pass.
 
@@ -83,7 +84,7 @@ src/okp_mcp/
   content.py     # Boilerplate stripping, content truncation, text cleaning
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
 tests/
-  conftest.py          # shared fixtures (solr mocks, sample responses) + functional marker deselection
+  conftest.py          # shared fixtures, functional marker deselection, token usage summary hook
   functional_cases.py  # FunctionalCase dataclass + parametrized RSPEED test data
   test_functional.py   # Vertex AI functional tests (gated behind -m functional)
   test_*.py            # unit test modules mirror src structure
@@ -107,6 +108,7 @@ INCORRECT_ANSWER_LOOP.md  # step-by-step workflow for turning RSPEED "incorrect 
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg via `MCP_` prefix |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
+| Token usage reporting | `tests/conftest.py` | `pytest_terminal_summary` hook; reads `record_property` data from test reports |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,6 @@
-"""Shared fixtures for okp-mcp tests."""
+"""Shared fixtures and hooks for okp-mcp tests."""
+
+from __future__ import annotations
 
 import httpx
 import pytest
@@ -52,3 +54,59 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
         functional = [item for item in items if "functional" in item.keywords]
         config.hook.pytest_deselected(items=functional)
         items[:] = [item for item in items if "functional" not in item.keywords]
+
+
+def _collect_token_usage(terminalreporter: pytest.TerminalReporter) -> list[dict[str, int | str]]:
+    """Extract token usage properties from test reports across all outcomes."""
+    results: list[dict[str, int | str]] = []
+    for outcome in ("passed", "failed", "error"):
+        for report in terminalreporter.stats.get(outcome, []):
+            if report.when != "call":
+                continue
+            props = dict(report.user_properties)
+            if "input_tokens" not in props:
+                continue
+            results.append(
+                {
+                    "test_id": report.nodeid,
+                    "input_tokens": props["input_tokens"],
+                    "output_tokens": props["output_tokens"],
+                    "requests": props["requests"],
+                    "tool_calls": props["tool_calls"],
+                }
+            )
+    return results
+
+
+def pytest_terminal_summary(terminalreporter: pytest.TerminalReporter, exitstatus: int, config: pytest.Config) -> None:
+    """Print aggregated token usage from functional tests.
+
+    Token data is attached to test reports via ``record_property`` and flows
+    through pytest-xdist's report serialization automatically.  Adding
+    ``--junitxml=report.xml`` also embeds the data in the XML artifact.
+    """
+    results = _collect_token_usage(terminalreporter)
+    if not results:
+        return
+
+    total_input = sum(int(r["input_tokens"]) for r in results)
+    total_output = sum(int(r["output_tokens"]) for r in results)
+    total_requests = sum(int(r["requests"]) for r in results)
+    total_tool_calls = sum(int(r["tool_calls"]) for r in results)
+
+    terminalreporter.section("Token Usage")
+    for r in results:
+        total = int(r["input_tokens"]) + int(r["output_tokens"])
+        tid = str(r["test_id"])
+        if "[" in tid:
+            tid = tid.split("[")[-1].rstrip("]")
+        terminalreporter.write_line(
+            f"  {tid}: {total:,} tokens ({r['input_tokens']:,} in / {r['output_tokens']:,} out), "
+            f"{r['requests']} requests, {r['tool_calls']} tool calls"
+        )
+    terminalreporter.write_line("")
+    terminalreporter.write_line(
+        f"  Total: {total_input + total_output:,} tokens "
+        f"({total_input:,} in / {total_output:,} out), "
+        f"{total_requests} requests, {total_tool_calls} tool calls"
+    )

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,6 +1,9 @@
 """Functional tests for the OKP MCP server using Pydantic AI and Vertex AI Gemini."""
 
+from __future__ import annotations
+
 import os
+from collections.abc import Callable
 from pathlib import Path
 
 import httpx
@@ -126,7 +129,7 @@ def _assert_no_forbidden_claims(case: FunctionalCase, response: str) -> None:
 
 
 @pytest.mark.parametrize("case", FUNCTIONAL_TEST_CASES)
-async def test_cla_scenario(case: FunctionalCase) -> None:
+async def test_cla_scenario(case: FunctionalCase, record_property: Callable[[str, object], None]) -> None:
     """Verify Gemini correctly answers a known CLA incorrect-answer scenario.
 
     Starts a fresh MCP server subprocess per test to avoid anyio cancel-scope
@@ -150,6 +153,12 @@ async def test_cla_scenario(case: FunctionalCase) -> None:
             with capture_run_messages() as messages:
                 result = await agent.run(case.question, model_settings={"temperature": 0})
     response: str = result.output
+
+    usage = result.usage()
+    record_property("input_tokens", usage.input_tokens or 0)
+    record_property("output_tokens", usage.output_tokens or 0)
+    record_property("requests", usage.requests)
+    record_property("tool_calls", usage.tool_calls)
 
     tool_calls = _extract_tool_calls(messages)
     tool_returns = _extract_tool_returns(messages)


### PR DESCRIPTION
## Summary

- Track per-test Vertex AI token usage (input/output tokens, requests, tool calls) in functional tests using pytest's built-in `record_property` fixture
- Aggregate and print a "Token Usage" summary table via `pytest_terminal_summary` hook
- Works with `pytest-xdist` (`-n 4`) because `record_property` data flows through pytest's standard `TestReport` serialization from workers to controller
- Also embeds in JUnit XML automatically when `--junitxml` is used

## Example output

```text
================================= Token Usage ==================================
  RSPEED_2482: 11,006 tokens (10,769 in / 237 out)
  RSPEED_2479_0: 10,017 tokens (9,639 in / 378 out)
  RSPEED_2481: 11,452 tokens (10,872 in / 580 out)
  RSPEED_2479_1: 51,696 tokens (50,359 in / 1,337 out)
  RSPEED_2480: 10,712 tokens (10,308 in / 404 out)

  Total: 94,883 tokens (91,947 in / 2,936 out), 12 requests, 7 tool calls
```