### PR TITLE
fix: make functional test token tracking work with pytest-xdist

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,9 @@ Functional tests are **deselected by default** via `pytest_collection_modifyitem
 - Each test spawns a fresh MCP server subprocess with `--transport stdio` (the project defaults to `streamable-http`, so this flag is critical)
 - Region is hardcoded to `us-central1`
 - `temperature=0` for reproducibility
-- Assertions check: tool call count, expected document references in tool returns/response, required facts (with tuple alternatives for "or" logic), and forbidden claims
+- Assertions check: tool call count, expected document references in tool returns/response, required facts (with tuple alternatives for "or" logic), forbidden claims, and per-test input token threshold
+- Token usage tracking uses `record_property("token_usage", ...)` so data flows through `report.user_properties` and works with pytest-xdist (each worker serializes properties to the controller). `pytest_runtest_logreport` in conftest.py aggregates entries; `pytest_terminal_summary` prints the table.
+- Per-test input token threshold is configurable via `functional_max_input_tokens` in `pyproject.toml` (default: 40000)
 - Tests skip gracefully when `.env` is missing, credentials are invalid, or Solr is unavailable
 - Tests are fully independent (each spawns its own MCP subprocess, HTTP client, and Gemini agent), so pass `-n 4` to run them in parallel via pytest-xdist
 
@@ -85,7 +87,7 @@ src/okp_mcp/
   content.py     # Boilerplate stripping, content truncation, text cleaning
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
 tests/
-  conftest.py          # shared fixtures (solr mocks, sample responses) + functional marker deselection
+  conftest.py          # shared fixtures (solr mocks, sample responses) + functional marker deselection + token usage aggregation hooks
   functional_cases.py  # FunctionalCase dataclass + parametrized RSPEED test data
   test_functional.py   # Vertex AI functional tests (gated behind -m functional)
   test_portal.py       # portal.py unit tests: query builders, chunk conversion, RRF, formatting, orchestrator

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ testpaths = ["tests"]
 markers = [
     "functional: end-to-end tests requiring live Solr and Vertex AI credentials",
 ]
+functional_max_input_tokens = "40000"
 filterwarnings = [
     # Upstream google-genai bug: types.py uses _UnionGenericAlias (deprecated in 3.14).
     # https://github.com/googleapis/python-genai/issues/1233

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,9 +46,62 @@ def solr_mock(sample_solr_response):
         yield route
 
 
+def pytest_addoption(parser: pytest.Parser) -> None:
+    """Register ini options for functional tests."""
+    parser.addini(
+        "functional_max_input_tokens",
+        default="40000",
+        help="Fail functional tests exceeding this many input tokens (default: 40000)",
+    )
+
+
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Deselect functional tests unless explicitly requested with -m functional."""
     if "functional" not in (config.getoption("-m") or ""):
         functional = [item for item in items if "functional" in item.keywords]
         config.hook.pytest_deselected(items=functional)
         items[:] = [item for item in items if "functional" not in item.keywords]
+
+
+# ---------------------------------------------------------------------------
+# Functional test token usage aggregation (xdist-safe)
+# ---------------------------------------------------------------------------
+# Each functional test records a "token_usage" property via record_property().
+# xdist serializes report.user_properties to the controller, so
+# pytest_runtest_logreport collects entries from all workers in one place.
+# pytest_terminal_summary prints the aggregated table on the controller.
+# ---------------------------------------------------------------------------
+
+_functional_token_usage: list[dict] = []
+
+
+def pytest_runtest_logreport(report: pytest.TestReport) -> None:
+    """Collect token_usage properties from functional test reports."""
+    if report.when == "call":
+        for name, value in report.user_properties:
+            if name == "token_usage":
+                _functional_token_usage.append(value)  # type: ignore[arg-type]
+
+
+def pytest_terminal_summary(terminalreporter: object) -> None:
+    """Print aggregated functional test token usage summary."""
+    if not _functional_token_usage:
+        return
+
+    total_in = sum(e["input_tokens"] for e in _functional_token_usage)
+    total_out = sum(e["output_tokens"] for e in _functional_token_usage)
+    total_req = sum(e["requests"] for e in _functional_token_usage)
+
+    w = terminalreporter.write_line  # type: ignore[union-attr]
+    w("")
+    w("=" * 78)
+    w("FUNCTIONAL TEST TOKEN USAGE SUMMARY")
+    w("=" * 78)
+    w(f"{'Case':<42} {'Input':>10} {'Output':>10} {'Requests':>10}")
+    w("-" * 78)
+    for e in sorted(_functional_token_usage, key=lambda x: x["label"]):
+        w(f"{e['label']:<42} {e['input_tokens']:>10,} {e['output_tokens']:>10,} {e['requests']:>10}")
+    w("-" * 78)
+    w(f"{'TOTAL':<42} {total_in:>10,} {total_out:>10,} {total_req:>10}")
+    w("=" * 78)
+    w("")

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,8 +1,6 @@
 """Functional tests for the OKP MCP server using Pydantic AI and Vertex AI Gemini."""
 
 import os
-from collections.abc import Generator
-from dataclasses import dataclass, field
 from pathlib import Path
 
 import httpx
@@ -30,77 +28,6 @@ pytestmark = pytest.mark.functional
 
 _FIXTURES_DIR = Path(__file__).parent / "fixtures"
 SYSTEM_PROMPT = (_FIXTURES_DIR / "functional_system_prompt.txt").read_text(encoding="utf-8")
-
-
-# ---------------------------------------------------------------------------
-# Token usage tracking
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class _UsageEntry:
-    """Token usage for a single functional test case."""
-
-    label: str
-    input_tokens: int
-    output_tokens: int
-    requests: int
-
-
-@dataclass
-class _UsageTracker:
-    """Accumulates per-test token usage and prints a summary at session end."""
-
-    entries: list[_UsageEntry] = field(default_factory=list)
-
-    def record(self, case: FunctionalCase, result: object) -> None:
-        """Record token usage from an agent run result."""
-        usage = result.usage()  # type: ignore[union-attr]
-        label = case.question[:40].replace("\n", " ")
-        self.entries.append(
-            _UsageEntry(
-                label=label,
-                input_tokens=usage.input_tokens or 0,
-                output_tokens=usage.output_tokens or 0,
-                requests=usage.requests or 0,
-            )
-        )
-
-    def print_summary(self, writer: object) -> None:
-        """Print a token usage summary table via the provided write_line callable."""
-        if not self.entries:
-            return
-        total_in = sum(e.input_tokens for e in self.entries)
-        total_out = sum(e.output_tokens for e in self.entries)
-        total_req = sum(e.requests for e in self.entries)
-
-        w = writer.write_line  # type: ignore[union-attr]
-        w("")
-        w("=" * 78)
-        w("FUNCTIONAL TEST TOKEN USAGE SUMMARY")
-        w("=" * 78)
-        w(f"{'Case':<42} {'Input':>10} {'Output':>10} {'Requests':>10}")
-        w("-" * 78)
-        for e in self.entries:
-            w(f"{e.label:<42} {e.input_tokens:>10,} {e.output_tokens:>10,} {e.requests:>10}")
-        w("-" * 78)
-        w(f"{'TOTAL':<42} {total_in:>10,} {total_out:>10,} {total_req:>10}")
-        w("=" * 78)
-        if total_in > 20_000:
-            w("WARNING: Total input tokens exceed 20K - investigate tool response sizes")
-        w("")
-
-
-_usage_tracker = _UsageTracker()
-
-
-@pytest.fixture(scope="module", autouse=True)
-def _print_usage_summary(request: pytest.FixtureRequest) -> Generator[None, None, None]:
-    """Print token usage summary after all functional tests complete."""
-    yield
-    tr = request.config.pluginmanager.get_plugin("terminalreporter")
-    if tr:
-        _usage_tracker.print_summary(tr)
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -199,7 +126,7 @@ def _assert_no_forbidden_claims(case: FunctionalCase, response: str) -> None:
 
 
 @pytest.mark.parametrize("case", FUNCTIONAL_TEST_CASES)
-async def test_cla_scenario(case: FunctionalCase) -> None:
+async def test_cla_scenario(case: FunctionalCase, request: pytest.FixtureRequest, record_property) -> None:
     """Verify Gemini correctly answers a known CLA incorrect-answer scenario.
 
     Starts a fresh MCP server subprocess per test to avoid anyio cancel-scope
@@ -211,6 +138,7 @@ async def test_cla_scenario(case: FunctionalCase) -> None:
     4. Asserts at least one expected document reference appears in tool results or response.
     5. Asserts all required factual phrases appear in the response (case-insensitive).
     6. Asserts no known-incorrect claims appear in the response (case-insensitive).
+    7. Asserts input tokens stay within the configured threshold.
     """
     server = MCPServerStdio("uv", args=["run", "okp-mcp", "--transport", "stdio"])
 
@@ -223,7 +151,19 @@ async def test_cla_scenario(case: FunctionalCase) -> None:
             with capture_run_messages() as messages:
                 result = await agent.run(case.question, model_settings={"temperature": 0})
     response: str = result.output
-    _usage_tracker.record(case, result)
+
+    # Record token usage for the summary table (xdist-safe via report serialization).
+    usage = result.usage()  # type: ignore[union-attr]
+    input_tokens = usage.input_tokens or 0
+    record_property(
+        "token_usage",
+        {
+            "label": case.question[:40].replace("\n", " "),
+            "input_tokens": input_tokens,
+            "output_tokens": usage.output_tokens or 0,
+            "requests": usage.requests or 0,
+        },
+    )
 
     tool_calls = _extract_tool_calls(messages)
     tool_returns = _extract_tool_returns(messages)
@@ -231,3 +171,9 @@ async def test_cla_scenario(case: FunctionalCase) -> None:
     _assert_doc_refs(case, tool_calls, tool_returns, response)
     _assert_required_facts(case, response)
     _assert_no_forbidden_claims(case, response)
+
+    # Fail if input tokens exceed the configured threshold.
+    max_tokens = int(request.config.getini("functional_max_input_tokens"))
+    assert input_tokens <= max_tokens, (
+        f"Input tokens ({input_tokens:,}) exceed threshold ({max_tokens:,}).\nQuestion: {case.question[:80]}"
+    )


### PR DESCRIPTION
## Summary

- Replace the module-level `_UsageTracker` singleton (broken under xdist since each worker got its own copy) with `record_property("token_usage", ...)` which xdist serializes from workers to the controller
- Add `pytest_runtest_logreport` and `pytest_terminal_summary` hooks in `conftest.py` to aggregate and display the token usage table
- Add configurable per-test input token threshold (`functional_max_input_tokens` in `pyproject.toml`, default 40000) that fails tests exceeding the limit
- Update `AGENTS.md` to document the new tracking architecture

## How it works

`record_property()` attaches data to `report.user_properties`, which xdist serializes to the controller. `pytest_runtest_logreport` on the controller collects entries from all workers. `pytest_terminal_summary` prints the aggregated table. Works identically for both `-n <N>` parallel and single-process runs.

## Verified

```
$ uv run pytest -m functional -n 2 -v -k "2482 or sap_004"
[gw0] PASSED tests/test_functional.py::test_cla_scenario[RSPEED_2482]
[gw1] PASSED tests/test_functional.py::test_cla_scenario[sap_004]

==============================================================================
FUNCTIONAL TEST TOKEN USAGE SUMMARY
==============================================================================
Case                                            Input     Output   Requests
------------------------------------------------------------------------------
Can I run a RHEL 6 container on RHEL 9?         6,066        200          2
What are the names of the three RHEL Sys        5,505        224          2
------------------------------------------------------------------------------
TOTAL                                          11,571        424          4
==============================================================================

2 passed in 5.76s
```