### PR TITLE
RSPEED-2764: fix get_document to accept URLs from search_portal results

### DIFF
--- a/src/okp_mcp/tools.py
+++ b/src/okp_mcp/tools.py
@@ -1,5 +1,7 @@
 """MCP tool definitions for RHEL OKP knowledge base search."""
 
+from urllib.parse import urlsplit
+
 import httpx
 from fastmcp import Context
 
@@ -8,6 +10,39 @@ from .content import doc_uri, strip_boilerplate, truncate_content
 from .portal import _format_portal_results, _run_portal_search
 from .server import get_app_context, mcp
 from .solr import _clean_query, _extract_relevant_section, _get_highlights, _solr_query
+
+
+def _normalize_doc_id(doc_id: str) -> str:
+    """Strip the access.redhat.com URL prefix so full URLs work as Solr lookups.
+
+    search_portal formats results with full URLs (e.g.
+    ``https://access.redhat.com/documentation/...``) but Solr stores path-based
+    IDs.  LLMs naturally pass the visible URL to get_document, so this strips
+    the prefix to recover the path.
+
+    Uses proper URL parsing to reject lookalike domains (e.g.
+    ``access.redhat.com.evil.tld``) and strip query/fragment parts.
+    """
+    parsed = urlsplit(doc_id)
+    if parsed.scheme in {"http", "https"} and parsed.netloc == "access.redhat.com":
+        return parsed.path or "/"
+    return doc_id
+
+
+def _escape_solr_phrase(value: str) -> str:
+    """Escape characters that are unsafe inside a quoted Solr/Lucene phrase."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def _doc_id_filter(doc_id: str) -> str:
+    """Build a Solr filter that matches a document by ``id`` or ``view_uri``.
+
+    Solr ``id`` may carry an ``/index.html`` suffix that ``view_uri`` omits,
+    so checking both fields ensures a match regardless of which form the
+    caller provides.  The value is escaped to prevent Lucene query injection.
+    """
+    safe = _escape_solr_phrase(doc_id)
+    return f'id:"{safe}" OR view_uri:"{safe}"'
 
 
 @mcp.tool
@@ -73,7 +108,7 @@ async def _fetch_document_with_query(
     return await _solr_query(
         {
             "q": _clean_query(query),
-            "fq": f'id:"{doc_id}"',
+            "fq": _doc_id_filter(doc_id),
             "fl": _DOCUMENT_FL,
             "rows": 1,
             "hl.snippets": "10",
@@ -98,7 +133,7 @@ async def _fetch_document_raw(doc_id: str, client: httpx.AsyncClient | None = No
         response = await client.get(
             solr_endpoint,
             params={
-                "q": f'id:"{doc_id}"',
+                "q": _doc_id_filter(doc_id),
                 "wt": "json",
                 "fl": _DOCUMENT_FL,
                 "rows": 1,
@@ -150,9 +185,10 @@ async def _format_document(doc: dict, data: dict, doc_id: str, query: str, max_c
 async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
     """Fetch full content of a specific document by its ID.
 
-    Use view_uri values from search results as doc_id. Pass query (the original
+    Use the URL from search results as doc_id. Pass query (the original
     search question) to get BM25-scored relevant passages instead of raw truncated content.
     """
+    doc_id = _normalize_doc_id(doc_id)
     logger.info("get_document: doc_id=%r query=%r", doc_id, query)
     try:
         app = get_app_context(ctx)

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -6,12 +6,13 @@ import inspect
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
+import pytest
 
 import okp_mcp  # noqa: F401 -- triggers @mcp.tool registration
 from okp_mcp import tools
 from okp_mcp.config import ServerConfig
 from okp_mcp.server import mcp
-from okp_mcp.tools import _format_document
+from okp_mcp.tools import _doc_id_filter, _escape_solr_phrase, _format_document, _normalize_doc_id
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
@@ -119,3 +120,124 @@ async def test_format_document_budget_truncates_large_content():
     result = await _format_document(doc, data, "/test-doc", "kernel panic", max_chars=200)
     assert len(result) <= 400  # slack for truncation message
     assert "Content truncated" in result
+
+
+# --- _normalize_doc_id tests ---
+
+
+@pytest.mark.parametrize(
+    ("doc_id", "expected"),
+    [
+        pytest.param(
+            "https://access.redhat.com/documentation/en-us/rhel/9/html/configuring_networking/index",
+            "/documentation/en-us/rhel/9/html/configuring_networking/index",
+            id="full_url_stripped",
+        ),
+        pytest.param(
+            "http://access.redhat.com/solutions/12345",
+            "/solutions/12345",
+            id="http_url_stripped",
+        ),
+        pytest.param(
+            "https://access.redhat.com/docs/page?foo=bar#section",
+            "/docs/page",
+            id="query_and_fragment_stripped",
+        ),
+        pytest.param(
+            "/documentation/en-us/rhel/9/html/configuring_networking/index",
+            "/documentation/en-us/rhel/9/html/configuring_networking/index",
+            id="path_unchanged",
+        ),
+        pytest.param("RHSA-2022:4915", "RHSA-2022:4915", id="errata_id_unchanged"),
+        pytest.param(
+            "https://example.com/docs/page",
+            "https://example.com/docs/page",
+            id="other_domain_unchanged",
+        ),
+        pytest.param(
+            "https://access.redhat.com.evil.tld/phish",
+            "https://access.redhat.com.evil.tld/phish",
+            id="lookalike_domain_rejected",
+        ),
+    ],
+)
+def test_normalize_doc_id(doc_id: str, expected: str):
+    """_normalize_doc_id correctly strips access.redhat.com URLs and rejects imposters."""
+    assert _normalize_doc_id(doc_id) == expected
+
+
+# --- _escape_solr_phrase tests ---
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        pytest.param("simple", "simple", id="plain_text"),
+        pytest.param('has"quote', 'has\\"quote', id="double_quote_escaped"),
+        pytest.param("has\\backslash", "has\\\\backslash", id="backslash_escaped"),
+        pytest.param('both\\"chars', 'both\\\\\\"chars', id="both_escaped"),
+    ],
+)
+def test_escape_solr_phrase(value: str, expected: str):
+    """_escape_solr_phrase escapes backslashes and double quotes for Lucene."""
+    assert _escape_solr_phrase(value) == expected
+
+
+# --- _doc_id_filter tests ---
+
+
+@pytest.mark.parametrize(
+    ("doc_id", "expected_id", "expected_view_uri"),
+    [
+        pytest.param(
+            "/documentation/en-us/rhel/9",
+            'id:"/documentation/en-us/rhel/9"',
+            'view_uri:"/documentation/en-us/rhel/9"',
+            id="path_filter",
+        ),
+        pytest.param(
+            "RHSA-2022:4915",
+            'id:"RHSA-2022:4915"',
+            'view_uri:"RHSA-2022:4915"',
+            id="errata_filter",
+        ),
+        pytest.param(
+            'inject"attempt',
+            'id:"inject\\"attempt"',
+            'view_uri:"inject\\"attempt"',
+            id="quote_escaped",
+        ),
+    ],
+)
+def test_doc_id_filter(doc_id: str, expected_id: str, expected_view_uri: str):
+    """_doc_id_filter produces an OR filter with properly escaped values."""
+    result = _doc_id_filter(doc_id)
+    assert expected_id in result
+    assert expected_view_uri in result
+    assert " OR " in result
+
+
+# --- get_document tool-level integration test ---
+
+
+async def test_get_document_normalizes_full_url():
+    """get_document accepts a full access.redhat.com URL and normalizes it before querying Solr."""
+    full_url = "https://access.redhat.com/documentation/en-us/rhel/9/html/configuring_networking/index"
+    expected_path = "/documentation/en-us/rhel/9/html/configuring_networking/index"
+
+    mock_ctx = Mock()
+    mock_app = Mock()
+    mock_app.http_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_app.solr_endpoint = _SOLR_ENDPOINT
+    mock_app.max_response_chars = 5000
+
+    with (
+        patch("okp_mcp.tools.get_app_context", return_value=mock_app),
+        patch("okp_mcp.tools._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_fetch.return_value = {"response": {"docs": [{"allTitle": "Test", "documentKind": "documentation"}]}}
+        await tools.get_document(mock_ctx, full_url)
+
+        # The normalized path (not the full URL) should reach the fetch function.
+        call_args = mock_fetch.call_args
+        assert call_args[0][0] == expected_path


### PR DESCRIPTION
## Summary

- Strip `https://access.redhat.com` prefix from `doc_id` so full URLs from `search_portal` results work as Solr lookups
- Query both `id` and `view_uri` Solr fields via OR filter so path-based IDs match regardless of which field the doc uses
- Update `get_document` docstring to tell LLMs to pass the URL (not the non-existent `view_uri`)
- Add unit tests for `_normalize_doc_id` and `_doc_id_filter`

## Problem

`search_portal` formats results with full URLs (`https://access.redhat.com/documentation/...`), but `get_document` queries Solr with `fq=id:"<doc_id>"` where `id` is a path (`/documentation/...`). LLMs naturally pass the visible URL, so every `get_document` call returned "Document not found", wasting a round trip and inflating token usage via context accumulation.

## Result

RSPEED_1998 (SAP package list, worst case): **62,366 -> 30,256 input tokens** (51% reduction), 7 -> 5 Gemini requests.

## Jira

[RSPEED-2764](https://redhat.atlassian.net/browse/RSPEED-2764)

[RSPEED-2764]: https://redhat.atlassian.net/browse/RSPEED-2764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ