### PR TITLE
refactor: split MCP tools into package modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,12 @@ src/okp_mcp/
   config.py      # ServerConfig (pydantic BaseSettings, MCP_* env vars)
   server.py      # FastMCP instance (single `mcp` object), AppContext, lifespan
   portal.py      # Unified portal search: query builders, chunk conversion, RRF, orchestrator, formatting
-  tools.py       # @mcp.tool definitions (search_portal, get_document, run_code)
+  tools/
+    __init__.py  # package export surface, triggers tool module imports for registration
+    search.py    # search_portal MCP tool
+    document.py  # get_document MCP tool + document helper functions
+    run_code.py  # placeholder run_code MCP tool
+    shared.py    # shared tool constants
   solr.py        # Solr query builder, BM25 paragraph extraction, RHV filtering
   content.py     # Boilerplate stripping, content truncation, text cleaning
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
@@ -105,7 +110,7 @@ INCORRECT_ANSWER_LOOP.md  # step-by-step workflow for turning RSPEED "incorrect 
 
 | Task | Location | Notes |
 |------|----------|-------|
-| Add a new MCP tool | `src/okp_mcp/tools.py` | Add `@mcp.tool` async function; follows error handling pattern |
+| Add a new MCP tool | `src/okp_mcp/tools/` | Add `@mcp.tool` async function in the relevant module and re-export it from `tools/__init__.py` |
 | Change portal search logic | `src/okp_mcp/portal.py` | Query builders, chunk conversion, RRF fusion, orchestrator, formatting |
 | Change Solr query logic | `src/okp_mcp/solr.py` | `_solr_query()` builds edismax params; `_clean_query()` for tokenization |
 | Modify result formatting | `src/okp_mcp/formatting.py` | `_annotate_result()` for deprecation/EOL (used by portal.py) |
@@ -128,14 +133,17 @@ uv run okp-mcp [--transport ...] [--port ...]
             → server.py: _app_lifespan()
                 ├─ creates shared httpx.AsyncClient
                 └─ yields AppContext(...)
-            → tools.py: @mcp.tool funcs  # registered via side-effect import
+            → tools/__init__.py: imports tool modules for @mcp.tool registration
 ```
 
 ## Module Dependencies
 
 ```text
 __init__.py → config, server, tools (side-effect import)
-tools.py    → config, portal, server, solr, content
+tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
+tools/search.py → config, portal, server
+tools/document.py → content, server, solr, tools/shared.py
+tools/run_code.py → config, server
 portal.py   → config, content, formatting, solr
 formatting.py → content, solr
 solr.py     → config
@@ -245,4 +253,4 @@ If findings come back, address them before creating the PR (or flag them for the
 
 ## Workarounds
 
-- `run_code()` in tools.py is a KLUDGE: placeholder tool that prevents Gemini 2.5 Flash from crashing when it tries to use its built-in code execution tool. Returns a polite "not supported" message. Do not remove without verifying Gemini behavior first.
+- `run_code()` in `src/okp_mcp/tools/run_code.py` is a KLUDGE: placeholder tool that prevents Gemini 2.5 Flash from crashing when it tries to use its built-in code execution tool. Returns a polite "not supported" message. Do not remove without verifying Gemini behavior first.

--- a/INCORRECT_ANSWER_LOOP.md
+++ b/INCORRECT_ANSWER_LOOP.md
@@ -155,7 +155,9 @@ The MCP server code that affects search results and LLM behavior:
 
 | File | What it controls |
 |------|-----------------|
-| `src/okp_mcp/tools.py` | Search queries, Solr parameters, boost queries, filters, result assembly |
+| `src/okp_mcp/tools/search.py` | `search_portal()` entrypoint, tool-level error handling |
+| `src/okp_mcp/tools/document.py` | `get_document()` entrypoint, document fetch helpers, formatting |
+| `src/okp_mcp/portal.py` | Search queries, boost queries, filters, result assembly |
 | `src/okp_mcp/solr.py` | Query cleaning, highlighting, section extraction |
 | `src/okp_mcp/content.py` | Boilerplate stripping from document content |
 | `src/okp_mcp/formatting.py` | Result formatting, sort keys, deprecation detection |
@@ -165,11 +167,11 @@ The MCP server code that affects search results and LLM behavior:
 
 | Symptom | Likely cause | Fix area |
 |---------|-------------|----------|
-| Wrong documents returned | Boost queries (`bq`) not prioritizing correct docs | `_build_search_queries()` in `tools.py` |
+| Wrong documents returned | Boost queries (`bq`) not prioritizing correct docs | `_build_search_queries()` in `portal.py` |
 | Right docs returned but LLM ignores them | System prompt doesn't instruct the model to handle this case | `functional_system_prompt.txt` |
 | Key terms getting stripped from query | Query cleaning too aggressive | `_clean_query()` in `solr.py` |
 | Relevant content truncated | Section extraction or formatting cutting off key info | `solr.py` or `formatting.py` |
-| Deprecated feature recommended as available | Deprecation boost/detection insufficient | `bq` params or `_detect_*` functions in `tools.py` |
+| Deprecated feature recommended as available | Deprecation boost/detection insufficient | `portal.py` ranking logic or `_detect_*` functions in `formatting.py` |
 
 ### Iteration loop
 

--- a/src/okp_mcp/tools/__init__.py
+++ b/src/okp_mcp/tools/__init__.py
@@ -1,0 +1,25 @@
+"""MCP tool definitions for RHEL OKP knowledge base search."""
+
+from .document import (
+    _doc_id_filter,
+    _escape_solr_phrase,
+    _fetch_document_raw,
+    _fetch_document_with_query,
+    _format_document,
+    _normalize_doc_id,
+    get_document,
+)
+from .run_code import run_code
+from .search import search_portal
+
+__all__ = [
+    "_doc_id_filter",
+    "_escape_solr_phrase",
+    "_fetch_document_raw",
+    "_fetch_document_with_query",
+    "_format_document",
+    "_normalize_doc_id",
+    "get_document",
+    "run_code",
+    "search_portal",
+]

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -1,15 +1,15 @@
-"""MCP tool definitions for RHEL OKP knowledge base search."""
+"""Document retrieval MCP tool and supporting helpers."""
 
 from urllib.parse import urlsplit
 
 import httpx
 from fastmcp import Context
 
-from .config import logger
-from .content import doc_uri, strip_boilerplate, truncate_content
-from .portal import _format_portal_results, _run_portal_search
-from .server import get_app_context, mcp
-from .solr import _clean_query, _extract_relevant_section, _get_highlights, _solr_query
+from ..config import logger
+from ..content import doc_uri, strip_boilerplate, truncate_content
+from ..server import get_app_context, mcp
+from ..solr import _clean_query, _extract_relevant_section, _get_highlights, _solr_query
+from .shared import DOCUMENT_FL
 
 
 def _normalize_doc_id(doc_id: str) -> str:
@@ -17,7 +17,7 @@ def _normalize_doc_id(doc_id: str) -> str:
 
     search_portal formats results with full URLs (e.g.
     ``https://access.redhat.com/documentation/...``) but Solr stores path-based
-    IDs.  LLMs naturally pass the visible URL to get_document, so this strips
+    IDs. LLMs naturally pass the visible URL to get_document, so this strips
     the prefix to recover the path.
 
     Uses proper URL parsing to reject lookalike domains (e.g.
@@ -39,66 +39,18 @@ def _doc_id_filter(doc_id: str) -> str:
 
     Solr ``id`` may carry an ``/index.html`` suffix that ``view_uri`` omits,
     so checking both fields ensures a match regardless of which form the
-    caller provides.  The value is escaped to prevent Lucene query injection.
+    caller provides. The value is escaped to prevent Lucene query injection.
     """
     safe = _escape_solr_phrase(doc_id)
     return f'id:"{safe}" OR view_uri:"{safe}"'
 
 
-@mcp.tool
-async def search_portal(
-    ctx: Context,
-    query: str,
-    max_results: int = 10,
-) -> str:
-    """Search Red Hat knowledge base: documentation, solutions, articles, CVEs, errata, and support policies.
-
-    Use this tool when you need official Red Hat documentation, security advisories,
-    or errata to answer accurately, especially for version-specific details,
-    lifecycle dates, deprecation status, or changes after 2024. For well-known
-    Linux concepts (e.g. vi commands, systemd units, common CLI tools) you may
-    answer directly without searching.
-
-    IMPORTANT - interpreting results:
-    - Results marked 'Applicability: RHV only' apply to Red Hat Virtualization,
-      NOT to standard RHEL KVM. Do not recommend RHV-only workarounds as the
-      primary answer for RHEL questions.
-    - If results conflict and one states a feature was deprecated or removed in
-      RHEL, lead with the deprecation/removal. Mention other-product workarounds
-      only as a brief secondary note.
-    - When results list specific releases or dates (e.g. EUS availability per
-      minor release), enumerate every release explicitly in your answer.
-    """
-    if not query or not query.strip():
-        return "Please provide a search query."
-    max_results = max(1, min(max_results, 20))
-    logger.info("search_portal: query=%r max_results=%d", query, max_results)
-    try:
-        app = get_app_context(ctx)
-        chunks, has_deprecation = await _run_portal_search(
-            query,
-            client=app.http_client,
-            solr_endpoint=app.solr_endpoint,
-            max_results=max_results,
-        )
-        return _format_portal_results(chunks, has_deprecation, query, app.max_response_chars)
-    except httpx.TimeoutException:
-        logger.warning("Search timed out for query: %r", query, exc_info=True)
-        return "The search timed out. Please try again with a simpler query."
-    except (httpx.HTTPError, ValueError):
-        logger.exception("Search failed for query: %r", query)
-        return "No results found. The knowledge base may be temporarily unavailable."
-
-
-_DOCUMENT_FL = (
-    "id,allTitle,title,heading_h1,main_content,view_uri,documentKind,"
-    "product,documentation_version,lastModifiedDate,"
-    "cve_details,portal_synopsis,portal_summary"
-)
-
-
 async def _fetch_document_with_query(
-    doc_id: str, query: str, client: httpx.AsyncClient | None = None, *, solr_endpoint: str
+    doc_id: str,
+    query: str,
+    client: httpx.AsyncClient | None = None,
+    *,
+    solr_endpoint: str,
 ) -> dict:
     """Fetch a document by ID using edismax query mode with highlighting.
 
@@ -109,7 +61,7 @@ async def _fetch_document_with_query(
         {
             "q": _clean_query(query),
             "fq": _doc_id_filter(doc_id),
-            "fl": _DOCUMENT_FL,
+            "fl": DOCUMENT_FL,
             "rows": 1,
             "hl.snippets": "10",
             "hl.fragsize": "600",
@@ -135,7 +87,7 @@ async def _fetch_document_raw(doc_id: str, client: httpx.AsyncClient | None = No
             params={
                 "q": _doc_id_filter(doc_id),
                 "wt": "json",
-                "fl": _DOCUMENT_FL,
+                "fl": DOCUMENT_FL,
                 "rows": 1,
             },
         )
@@ -210,28 +162,3 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
     except (httpx.HTTPError, ValueError):
         logger.exception("get_document failed for doc_id=%r query=%r", doc_id, query)
         return f"Unable to fetch document {doc_id}. The knowledge base may be temporarily unavailable."
-
-
-# KLUDGE: Gemini 2.5 Flash has a built-in code execution capability that it
-# attempts to invoke even when not explicitly configured as an available tool.
-# When invoked via OpenAI-compatible endpoints through llama-stack, this causes
-# "RuntimeError: OpenAI response failed: Unsupported tool call: run_code" and
-# returns HTTP 500 to the client.
-#
-# This placeholder tool prevents the crash by registering run_code as a valid
-# (but non-functional) tool. When Gemini attempts code execution, it receives
-# feedback that code execution is unavailable rather than causing a server error.
-#
-# Related issue: https://discuss.ai.google.dev/t/gemini-live-api-unexpectedly-invokes-execute-code-and-other-built-in-tools-even-when-not-configured/87603
-@mcp.tool
-async def run_code(ctx: Context, language: str, code: str) -> str:
-    """Execute code in the specified language.
-
-    NOTE: This is a placeholder tool. Code execution is not available in this environment.
-    """
-    logger.warning("PLACEHOLDER run_code tool was invoked: language=%r code_length=%d", language, len(code))
-    return (
-        "Code execution is not available in this environment. "
-        "Please provide the answer or code example directly in your response as text, "
-        "rather than attempting to execute code."
-    )

--- a/src/okp_mcp/tools/run_code.py
+++ b/src/okp_mcp/tools/run_code.py
@@ -1,0 +1,32 @@
+"""Placeholder code execution MCP tool."""
+
+from fastmcp import Context
+
+from ..config import logger
+from ..server import mcp
+
+
+# KLUDGE: Gemini 2.5 Flash has a built-in code execution capability that it
+# attempts to invoke even when not explicitly configured as an available tool.
+# When invoked via OpenAI-compatible endpoints through llama-stack, this causes
+# "RuntimeError: OpenAI response failed: Unsupported tool call: run_code" and
+# returns HTTP 500 to the client.
+#
+# This placeholder tool prevents the crash by registering run_code as a valid
+# (but non-functional) tool. When Gemini attempts code execution, it receives
+# feedback that code execution is unavailable rather than causing a server error.
+#
+# Related issue: https://discuss.ai.google.dev/t/gemini-live-api-unexpectedly-invokes-execute-code-and-other-built-in-tools-even-when-not-configured/87603
+@mcp.tool
+async def run_code(ctx: Context, language: str, code: str) -> str:
+    """Execute code in the specified language.
+
+    NOTE: This is a placeholder tool. Code execution is not available in this environment.
+    """
+    del ctx
+    logger.warning("PLACEHOLDER run_code tool was invoked: language=%r code_length=%d", language, len(code))
+    return (
+        "Code execution is not available in this environment. "
+        "Please provide the answer or code example directly in your response as text, "
+        "rather than attempting to execute code."
+    )

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -1,0 +1,56 @@
+"""Portal search MCP tool."""
+
+import httpx
+from fastmcp import Context
+
+from ..config import logger
+from ..portal import _format_portal_results, _run_portal_search
+from ..server import get_app_context, mcp
+
+
+@mcp.tool
+async def search_portal(
+    ctx: Context,
+    query: str,
+    max_results: int = 10,
+) -> str:
+    """Search Red Hat knowledge base: documentation, solutions, articles, CVEs, errata, and support policies.
+
+    Use this tool when you need official Red Hat documentation, security advisories,
+    or errata to answer accurately, especially for version-specific details,
+    lifecycle dates, deprecation status, or changes after 2024. For well-known
+    Linux concepts (e.g. vi commands, systemd units, common CLI tools) you may
+    answer directly without searching.
+
+    IMPORTANT - interpreting results:
+    - Results marked 'Applicability: RHV only' apply to Red Hat Virtualization,
+      NOT to standard RHEL KVM. Do not recommend RHV-only workarounds as the
+      primary answer for RHEL questions.
+    - If results conflict and one states a feature was deprecated or removed in
+      RHEL, lead with the deprecation/removal. Mention other-product workarounds
+      only as a brief secondary note.
+    - When results list specific releases or dates (e.g. EUS availability per
+      minor release), enumerate every release explicitly in your answer.
+    """
+    if not query or not query.strip():
+        return "Please provide a search query."
+    max_results = max(1, min(max_results, 20))
+    logger.info("search_portal: query=%r max_results=%d", query, max_results)
+    try:
+        app = get_app_context(ctx)
+        chunks, has_deprecation = await _run_portal_search(
+            query,
+            client=app.http_client,
+            solr_endpoint=app.solr_endpoint,
+            max_results=max_results,
+        )
+        return _format_portal_results(chunks, has_deprecation, query, app.max_response_chars)
+    except httpx.TimeoutException:
+        logger.warning("Search timed out for query: %r", query, exc_info=True)
+        return "The search timed out. Please try again with a simpler query."
+    except httpx.HTTPError:
+        logger.exception("Search failed for query: %r", query)
+        return "The knowledge base search is temporarily unavailable. Please try again shortly."
+    except ValueError:
+        logger.exception("Search failed for query: %r", query)
+        return "The knowledge base search returned an unexpected response. Please try again."

--- a/src/okp_mcp/tools/shared.py
+++ b/src/okp_mcp/tools/shared.py
@@ -1,0 +1,7 @@
+"""Shared constants and helpers for MCP tool modules."""
+
+DOCUMENT_FL = (
+    "id,allTitle,title,heading_h1,main_content,view_uri,documentKind,"
+    "product,documentation_version,lastModifiedDate,"
+    "cve_details,portal_synopsis,portal_summary"
+)

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -13,6 +13,7 @@ from okp_mcp import tools
 from okp_mcp.config import ServerConfig
 from okp_mcp.server import mcp
 from okp_mcp.tools import _doc_id_filter, _escape_solr_phrase, _format_document, _normalize_doc_id
+from okp_mcp.tools import document as document_tools
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
@@ -40,7 +41,9 @@ async def test_fetch_document_raw_uses_provided_client_without_constructing_or_c
     mock_client.get = AsyncMock(return_value=response)
     mock_client.aclose = AsyncMock()
 
-    with patch("okp_mcp.tools.httpx.AsyncClient", side_effect=AssertionError("constructor should not be called")):
+    with patch(
+        "okp_mcp.tools.document.httpx.AsyncClient", side_effect=AssertionError("constructor should not be called")
+    ):
         data = await tools._fetch_document_raw("/solutions/123", client=mock_client, solr_endpoint=_SOLR_ENDPOINT)
 
     mock_client.get.assert_awaited_once()
@@ -58,7 +61,7 @@ async def test_fetch_document_raw_creates_and_closes_client_when_not_provided():
     created_client.get = AsyncMock(return_value=response)
     created_client.aclose = AsyncMock()
 
-    with patch("okp_mcp.tools.httpx.AsyncClient", return_value=created_client) as client_ctor:
+    with patch("okp_mcp.tools.document.httpx.AsyncClient", return_value=created_client) as client_ctor:
         data = await tools._fetch_document_raw("/solutions/123", solr_endpoint=_SOLR_ENDPOINT)
 
     client_ctor.assert_called_once_with(timeout=30.0)
@@ -72,7 +75,7 @@ async def test_fetch_document_with_query_passes_client_to_solr_query():
     mock_client = AsyncMock(spec=httpx.AsyncClient)
     expected = {"response": {"numFound": 1, "docs": [{"id": "123"}]}}
 
-    with patch("okp_mcp.tools._solr_query", AsyncMock(return_value=expected)) as solr_query_mock:
+    with patch("okp_mcp.tools.document._solr_query", AsyncMock(return_value=expected)) as solr_query_mock:
         data = await tools._fetch_document_with_query(
             "/solutions/123", "kernel panic", client=mock_client, solr_endpoint=_SOLR_ENDPOINT
         )
@@ -232,11 +235,11 @@ async def test_get_document_normalizes_full_url():
     mock_app.max_response_chars = 5000
 
     with (
-        patch("okp_mcp.tools.get_app_context", return_value=mock_app),
-        patch("okp_mcp.tools._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
+        patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),
+        patch("okp_mcp.tools.document._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
     ):
         mock_fetch.return_value = {"response": {"docs": [{"allTitle": "Test", "documentKind": "documentation"}]}}
-        await tools.get_document(mock_ctx, full_url)
+        await document_tools.get_document(mock_ctx, full_url)
 
         # The normalized path (not the full URL) should reach the fetch function.
         call_args = mock_fetch.call_args


### PR DESCRIPTION
Stacked PRs:
 * #127
 * #123
 * #122
 * #121
 * __->__#120


--- --- ---

### refactor: split MCP tools into package modules


Move search_portal, get_document, and run_code into dedicated modules under src/okp_mcp/tools while preserving the okp_mcp.tools import surface. Update tests and docs so FastMCP tool registration and helper patch targets continue to work after the package split.

Signed-off-by: Major Hayden <major@redhat.com>
