### PR TITLE
fix: improve get_document passages for documentation

### DIFF
--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -219,17 +219,30 @@ def _filter_rhv_sentences(text: str, query: str) -> str:
     return " ".join(filtered)
 
 
-def _get_highlights(data: dict, *keys: str, query: str = "") -> str:
-    """Extract highlight snippets for a document, trying multiple ID keys."""
+def _get_highlight_snippets(data: dict, *keys: str, query: str = "") -> list[str]:
+    """Extract cleaned highlight snippets for a document."""
     hl = data.get("highlighting", {})
+    seen: set[str] = set()
+    cleaned_snippets: list[str] = []
+
     for key in keys:
         if key and key in hl:
             snippets = hl[key].get("main_content", [])
-            if snippets:
-                clean = [re.sub(r"<[^>]+>", "", s).strip() for s in snippets]
-                joined = " ... ".join(clean)
-                return _filter_rhv_sentences(joined, query) if query else joined
-    return ""
+            for snippet in snippets:
+                clean = re.sub(r"<[^>]+>", "", snippet)
+                clean = re.sub(r"\s+", " ", clean).strip()
+                clean = _filter_rhv_sentences(clean, query) if query else clean
+                if not clean or clean in seen:
+                    continue
+                seen.add(clean)
+                cleaned_snippets.append(clean)
+
+    return cleaned_snippets
+
+
+def _get_highlights(data: dict, *keys: str, query: str = "") -> str:
+    """Extract highlight snippets for a document, trying multiple ID keys."""
+    return " ... ".join(_get_highlight_snippets(data, *keys, query=query))
 
 
 _EXTRACTION_BOOST_KEYWORDS = frozenset(

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -1,15 +1,17 @@
 """Document retrieval MCP tool and supporting helpers."""
 
+import logging
 from urllib.parse import urlsplit
 
 import httpx
 from fastmcp import Context
 
-from ..config import logger
-from ..content import doc_uri, strip_boilerplate, truncate_content
+from ..content import _select_within_budget, doc_uri, strip_boilerplate, truncate_content
 from ..server import get_app_context, mcp
-from ..solr import _clean_query, _extract_relevant_section, _get_highlights, _solr_query
+from ..solr import _clean_query, _extract_relevant_section, _get_highlight_snippets, _solr_query
 from .shared import DOCUMENT_FL
+
+logger = logging.getLogger("okp_mcp.tools.get_document")
 
 
 def _normalize_doc_id(doc_id: str) -> str:
@@ -43,6 +45,63 @@ def _doc_id_filter(doc_id: str) -> str:
     """
     safe = _escape_solr_phrase(doc_id)
     return f'id:"{safe}" OR view_uri:"{safe}"'
+
+
+def _uses_document_passages(doc: dict) -> bool:
+    """Return whether a document should render Solr highlights as passages."""
+    if doc.get("documentKind") == "documentation":
+        return True
+    return doc_uri(doc).startswith("/documentation/")
+
+
+def _format_metadata(doc: dict) -> str:
+    """Build the metadata header for a fetched document."""
+    result = f"**{doc.get('allTitle', 'Untitled')}**"
+    result += f"\nType: {doc.get('documentKind', 'Unknown')}"
+    if doc.get("product"):
+        result += f"\nProduct: {doc['product']}"
+    if doc.get("documentation_version"):
+        result += f" {doc['documentation_version']}"
+    result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
+
+    if doc.get("portal_synopsis"):
+        result += f"\n\nSynopsis: {doc['portal_synopsis']}"
+    if doc.get("portal_summary"):
+        result += f"\n\nSummary: {doc['portal_summary']}"
+    if doc.get("cve_details"):
+        result += f"\n\nCVE Details: {doc['cve_details']}"
+    return result
+
+
+def _format_document_passages(highlight_snippets: list[str], query: str, max_chars: int, current_result: str) -> str:
+    """Format highlight snippets as numbered passages within the remaining budget."""
+    remaining_budget = max_chars - len(current_result) - len("\n\nRelevant passages:\n")
+    if remaining_budget <= 0:
+        return ""
+
+    formatted_passages = [f"Passage {index + 1}:\n{snippet}" for index, snippet in enumerate(highlight_snippets)]
+    passages = _select_within_budget(formatted_passages, remaining_budget, query)
+    return f"\n\nRelevant passages:\n{passages}"
+
+
+def _format_document_content(
+    doc: dict, data: dict, doc_id: str, query: str, max_chars: int, current_result: str
+) -> str:
+    """Build the content section for a fetched document."""
+    main_content = doc.get("main_content")
+    if not main_content:
+        return ""
+
+    content = strip_boilerplate(main_content)
+    if not query:
+        return f"\n\nContent:\n{_extract_relevant_section(content, '', max_sections=8)}"
+
+    highlight_snippets = _get_highlight_snippets(data, doc.get("view_uri", ""), doc.get("id", ""), doc_id, query=query)
+    if not highlight_snippets:
+        return f"\n\nContent:\n{_extract_relevant_section(content, query, max_sections=8)}"
+    if _uses_document_passages(doc):
+        return _format_document_passages(highlight_snippets, query, max_chars, current_result)
+    return f"\n\nContent:\n{' ... '.join(highlight_snippets)}"
 
 
 async def _fetch_document_with_query(
@@ -105,31 +164,8 @@ async def _format_document(doc: dict, data: dict, doc_id: str, query: str, max_c
     and content (highlights if available, otherwise extracted relevant section).
     Truncates final output to max_chars as a safety net.
     """
-    view_uri = doc.get("view_uri", "")
-    result = f"**{doc.get('allTitle', 'Untitled')}**"
-    result += f"\nType: {doc.get('documentKind', 'Unknown')}"
-    if doc.get("product"):
-        result += f"\nProduct: {doc['product']}"
-    if doc.get("documentation_version"):
-        result += f" {doc['documentation_version']}"
-    result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
-
-    if doc.get("portal_synopsis"):
-        result += f"\n\nSynopsis: {doc['portal_synopsis']}"
-    if doc.get("portal_summary"):
-        result += f"\n\nSummary: {doc['portal_summary']}"
-    if doc.get("cve_details"):
-        result += f"\n\nCVE Details: {doc['cve_details']}"
-    if doc.get("main_content"):
-        content = strip_boilerplate(doc["main_content"])
-        if query:
-            highlights = _get_highlights(data, view_uri, doc_id, query=query)
-            if highlights:
-                result += f"\n\nContent:\n{highlights}"
-            else:
-                result += f"\n\nContent:\n{_extract_relevant_section(content, query, max_sections=8)}"
-        else:
-            result += f"\n\nContent:\n{_extract_relevant_section(content, '', max_sections=8)}"
+    result = _format_metadata(doc)
+    result += _format_document_content(doc, data, doc_id, query, max_chars, result)
     return truncate_content(result, max_chars)
 
 

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -1,5 +1,7 @@
 """Tests for SOLR query client lifecycle and query cleaning behavior."""
 
+# pyright: reportMissingImports=false
+
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -7,7 +9,7 @@ import pytest
 import respx
 
 from okp_mcp.config import ServerConfig
-from okp_mcp.solr import _clean_query, _solr_query
+from okp_mcp.solr import _clean_query, _get_highlight_snippets, _solr_query
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
@@ -159,3 +161,35 @@ async def test_solr_query_respx_regression_guard(solr_mock, sample_solr_response
 def test_clean_query(input_query, expected):
     """_clean_query strips trailing Solr wildcard chars from output tokens."""
     assert _clean_query(input_query) == expected
+
+
+def test_get_highlight_snippets_preserves_individual_fragments():
+    """_get_highlight_snippets returns cleaned highlight fragments without flattening them."""
+    data = {
+        "highlighting": {
+            "doc-1": {
+                "main_content": [
+                    "First <em>kernel</em> snippet.",
+                    "Second snippet about <em>panic</em>.",
+                ]
+            }
+        }
+    }
+
+    snippets = _get_highlight_snippets(data, "doc-1", query="kernel panic")
+
+    assert snippets == ["First kernel snippet.", "Second snippet about panic."]
+
+
+def test_get_highlight_snippets_deduplicates_across_alias_keys():
+    """_get_highlight_snippets deduplicates repeated fragments returned under multiple keys."""
+    data = {
+        "highlighting": {
+            "doc-1": {"main_content": ["Repeated <em>snippet</em>."]},
+            "/docs/doc-1": {"main_content": ["Repeated <em>snippet</em>.", "Unique snippet."]},
+        }
+    }
+
+    snippets = _get_highlight_snippets(data, "doc-1", "/docs/doc-1", query="snippet")
+
+    assert snippets == ["Repeated snippet.", "Unique snippet."]

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -125,6 +125,145 @@ async def test_format_document_budget_truncates_large_content():
     assert "Content truncated" in result
 
 
+async def test_format_document_uses_chunked_highlight_passages_for_documentation():
+    """_format_document keeps highlight snippets as separate passages for large docs."""
+    doc = {
+        "id": "/documentation/en-us/rhel/9/html/configuring_networking/index.html",
+        "allTitle": "Configuring networking",
+        "documentKind": "documentation",
+        "view_uri": "/documentation/en-us/rhel/9/html/configuring_networking/index",
+        "main_content": "Long body text that should not be used when highlights are available.",
+    }
+    data = {
+        "highlighting": {
+            doc["id"]: {
+                "main_content": [
+                    "First <em>network</em> configuration snippet.",
+                    "Second snippet about <em>routing</em>.",
+                ]
+            }
+        }
+    }
+
+    result = await _format_document(doc, data, doc["view_uri"], "network routing", max_chars=5000)
+
+    assert "Relevant passages:" in result
+    assert "Passage 1:" in result
+    assert "Passage 2:" in result
+    assert "First network configuration snippet." in result
+    assert "Second snippet about routing." in result
+
+
+async def test_format_document_falls_back_to_relevant_section_when_no_highlights():
+    """_format_document falls back to extracted sections when highlighting is unavailable."""
+    doc = {
+        "id": "/documentation/en-us/rhel/9/html/using_systemd/index.html",
+        "allTitle": "Using systemd",
+        "documentKind": "documentation",
+        "view_uri": "/documentation/en-us/rhel/9/html/using_systemd/index",
+        "main_content": (
+            "intro\n\n"
+            "systemd units manage services and targets across the operating system.\n\n"
+            "debugging boot delays with systemd-analyze can identify slow units."
+        ),
+    }
+
+    result = await _format_document(doc, {"highlighting": {}}, doc["view_uri"], "systemd analyze units", max_chars=5000)
+
+    assert "Relevant passages:" not in result
+    assert "Content:" in result
+    assert "systemd units manage services" in result
+
+
+async def test_format_document_non_documentation_keeps_flat_highlights():
+    """_format_document keeps non-documentation highlights in the legacy flat format."""
+    doc = {
+        "id": "/solutions/123/index.html",
+        "allTitle": "Kernel panic solution",
+        "documentKind": "solution",
+        "view_uri": "/solutions/123",
+        "main_content": "Long solution body.",
+    }
+    data = {
+        "highlighting": {
+            doc["id"]: {
+                "main_content": [
+                    "First <em>kernel</em> snippet.",
+                    "Second snippet about <em>panic</em>.",
+                ]
+            }
+        }
+    }
+
+    result = await _format_document(doc, data, doc["view_uri"], "kernel panic", max_chars=5000)
+
+    assert "Relevant passages:" not in result
+    assert "Content:" in result
+    assert "First kernel snippet. ... Second snippet about panic." in result
+
+
+async def test_format_document_documentation_budget_uses_remaining_space():
+    """_format_document limits passage output to the true remaining response budget."""
+    doc = {
+        "id": "/documentation/en-us/rhel/9/html/networking/index.html",
+        "allTitle": "X" * 180,
+        "documentKind": "documentation",
+        "view_uri": "/documentation/en-us/rhel/9/html/networking/index",
+        "main_content": "Long body text.",
+    }
+    data = {
+        "highlighting": {
+            doc["id"]: {
+                "main_content": [
+                    "First <em>network</em> snippet with enough detail to consume budget.",
+                    "Second snippet that should be excluded when the remaining budget is small.",
+                ]
+            }
+        }
+    }
+
+    result = await _format_document(doc, data, doc["view_uri"], "network", max_chars=320)
+
+    assert "Relevant passages:" in result
+    assert "Passage 1:" in result
+    assert "Passage 2:" not in result
+
+
+async def test_format_document_falls_back_when_highlights_clean_to_empty():
+    """_format_document falls back when highlight cleanup leaves no usable snippets."""
+    doc = {
+        "id": "/documentation/en-us/rhel/9/html/virtualization/index.html",
+        "allTitle": "Virtualization guide",
+        "documentKind": "documentation",
+        "view_uri": "/documentation/en-us/rhel/9/html/virtualization/index",
+        "main_content": (
+            "intro\n\nConfiguring KVM virtualization on RHEL systems.\n\nUse virsh to inspect virtual machines."
+        ),
+    }
+    data = {
+        "highlighting": {
+            doc["id"]: {
+                "main_content": [
+                    "RHV is <em>commonly used</em> and fully supported.",
+                ]
+            }
+        }
+    }
+
+    result = await _format_document(doc, data, doc["view_uri"], "kvm virtualization", max_chars=5000)
+
+    assert "Relevant passages:" not in result
+    assert "Content:" in result
+    assert "commonly used and fully supported" not in result
+    assert any(
+        paragraph in result
+        for paragraph in [
+            "Configuring KVM virtualization on RHEL systems.",
+            "Use virsh to inspect virtual machines.",
+        ]
+    )
+
+
 # --- _normalize_doc_id tests ---
 
 


### PR DESCRIPTION
Stacked PRs:
 * #131
 * #130
 * #127
 * #123
 * #122
 * __->__#121


--- --- ---

### fix: improve get_document passages for documentation


Keep Solr highlight snippets as chunk-like passages for formal documentation so large docs return relevant sections without flattening everything into one block. Preserve legacy highlight formatting for non-documentation docs and cover the new passage, budget, and fallback behavior with tests.

Signed-off-by: Major Hayden <major@redhat.com>
