### PR TITLE
fix(RSPEED-2113): accept canonical nmcli bond slave syntax in assertion

### DIFF
--- a/tests/functional_cases.py
+++ b/tests/functional_cases.py
@@ -324,7 +324,7 @@ FUNCTIONAL_TEST_CASES = [
             ],
             required_facts=[
                 ("802.3ad", "mode=4"),
-                ("bond-slave", "bond-port"),
+                ("bond-slave", "bond-port", "master prod"),
                 "lacp_rate",
             ],
             forbidden_claims=["mode=active-lacp"],


### PR DESCRIPTION
## Summary

- Accept `master prod` (anchored to bond name) as a valid alternative to `bond-slave`/`bond-port` in the RSPEED-2113 functional test assertion

## Why

The `nmcli-examples(7)` man page (Example 8) uses `type ethernet ... master <bond>` as the **canonical form** for adding bond slaves — not `type bond-slave`. The model's response follows this upstream-preferred syntax and should not be penalized.

All three forms are functionally equivalent:
- `type bond-slave ifname ens6 master prod` (RHEL 7 convention)
- `type bond-port ifname ens6 master prod` (NM 1.26+ inclusive language)
- `type ethernet ifname ens6 master prod` (upstream canonical, per nmcli-examples(7))

The match is anchored to `"master prod"` (the bond name) rather than bare `"master"` to avoid false positives on incidental uses.

## Ticket

RSPEED-2113