### PR TITLE
fix(RSPEED-2481): add SPICE intent detection for VNC replacement info

### DIFF
--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -69,6 +69,13 @@ _EOL_PRODUCTS: frozenset[str] = frozenset(
 # Highlight term expansions injected into hl.q for intent-specific queries.
 _VM_HIGHLIGHT_TERMS = "virsh cockpit deprecated virt-manager"
 _EUS_HIGHLIGHT_TERMS = '"Enhanced EUS" "48 months" "Enhanced Extended Update Support"'
+# SPICE highlight terms: VNC is the supported replacement for the deprecated
+# SPICE display protocol.  Including "VNC" in hl.q causes Solr to select
+# highlight snippets that mention VNC, which is critical for the LLM to
+# recommend the correct replacement.  Without this, the VM intent's
+# cockpit/virsh terms dominate snippets and the LLM omits VNC entirely.
+# See functional test RSPEED_2481.
+_SPICE_HIGHLIGHT_TERMS = "VNC deprecated removed replacement"
 
 
 # ---------------------------------------------------------------------------
@@ -79,6 +86,11 @@ _EUS_HIGHLIGHT_TERMS = '"Enhanced EUS" "48 months" "Enhanced Extended Update Sup
 _VM_INTENT_RE = re.compile(r"\b(?:vm|vms|virtual machine|virtualization|hypervisor)\b")
 _RELEASE_DATE_INTENT_RE = re.compile(r"\b(?:release dates?|released|when was|general availability)\b")
 _EUS_INTENT_RE = re.compile(r"\b(?:eus|extended update support)\b")
+# SPICE is a display/graphics protocol for VMs, NOT a VM management tool.
+# Queries mentioning SPICE need display-protocol-specific boosts (VNC),
+# not VM management boosts (cockpit/virsh).  This regex detects SPICE
+# intent so _apply_intent_boosts can override the generic VM intent.
+_SPICE_INTENT_RE = re.compile(r"\bspice\b")
 
 
 def _detect_vm_intent(query_lower: str) -> bool:
@@ -94,6 +106,17 @@ def _detect_release_date_intent(query_lower: str) -> bool:
 def _detect_eus_intent(query_lower: str) -> bool:
     """Return True if the lowercased query asks about EUS or Extended Update Support."""
     return bool(_EUS_INTENT_RE.search(query_lower))
+
+
+def _detect_spice_intent(query_lower: str) -> bool:
+    """Return True if the lowercased query mentions the SPICE display protocol.
+
+    SPICE questions are about display protocol availability and replacements
+    (VNC), not about VM management tools (cockpit/virsh).  Detecting SPICE
+    intent separately from VM intent prevents the generic VM boosts from
+    flooding results with irrelevant cockpit/virsh content.
+    """
+    return bool(_SPICE_INTENT_RE.search(query_lower))
 
 
 # ---------------------------------------------------------------------------
@@ -213,8 +236,12 @@ def _build_deprecation_query(cleaned_query: str) -> dict:
 def _apply_intent_boosts(params: dict, query_lower: str, cleaned_query: str) -> None:
     """Mutate *params* in-place to add intent-specific bq/hl.q boosts.
 
-    Called after ``_build_main_query`` to layer on VM, EUS, or release-date
-    boosts without complicating the base query builder.
+    Called after ``_build_main_query`` to layer on VM, EUS, release-date,
+    or SPICE boosts without complicating the base query builder.
+
+    Order matters: later intents overwrite earlier ones.  SPICE runs after
+    VM so that "SPICE for VMs" gets display-protocol boosts (VNC), not
+    VM-management boosts (cockpit/virsh).
     """
     if _detect_vm_intent(query_lower):
         params["bq"] = (
@@ -222,6 +249,21 @@ def _apply_intent_boosts(params: dict, query_lower: str, cleaned_query: str) -> 
             'main_content:(cockpit OR "cockpit-machines" OR virsh)^5'
         )
         params["hl.q"] = f"{cleaned_query} {_VM_HIGHLIGHT_TERMS}"
+
+    # SPICE intent MUST run after VM intent so it overwrites the VM boosts.
+    # SPICE questions are about the display protocol (SPICE vs VNC), not
+    # about VM management tools (cockpit/virsh).  Without this override,
+    # queries like "Is SPICE available for VMs?" trigger VM intent, which
+    # injects cockpit/virsh highlight terms that flood results with
+    # irrelevant VM management content and push out the critical VNC
+    # replacement information the LLM needs to answer correctly.
+    # See functional test RSPEED_2481.
+    if _detect_spice_intent(query_lower):
+        params["bq"] = (
+            'allTitle:(spice OR deprecated OR "no longer")^15 '
+            'main_content:(VNC OR deprecated OR removed OR replacement OR "no longer")^10'
+        )
+        params["hl.q"] = f"{cleaned_query} {_SPICE_HIGHLIGHT_TERMS}"
 
     if _detect_eus_intent(query_lower):
         params["bq"] = 'title:"Enhanced EUS"^100 title:"EUS FAQ"^80'

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -11,6 +11,7 @@ from okp_mcp.portal import (
     _FALLBACK_MAX_CHARS,
     _KIND_LABELS,
     _MAIN_QF,
+    _SPICE_HIGHLIGHT_TERMS,
     _VM_HIGHLIGHT_TERMS,
     PortalChunk,
     _apply_intent_boosts,
@@ -20,6 +21,7 @@ from okp_mcp.portal import (
     _deduplicate_by_parent,
     _detect_eus_intent,
     _detect_release_date_intent,
+    _detect_spice_intent,
     _detect_vm_intent,
     _docs_to_chunks,
     _fallback_cve,
@@ -162,6 +164,43 @@ class TestDetectEusIntent:
     def test_negative(self, query: str):
         """Queries without EUS keywords do not trigger EUS intent."""
         assert _detect_eus_intent(query) is False
+
+
+class TestDetectSpiceIntent:
+    """Verify SPICE display protocol intent detection.
+
+    SPICE queries are about the display protocol, not VM management.
+    Detecting SPICE separately prevents the generic VM intent from injecting
+    cockpit/virsh boosts that drown out VNC replacement information.
+    """
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "is spice available for rhel vms",
+            "spice protocol deprecated",
+            "how to use spice with virtualization",
+            "spice remote display",
+        ],
+        ids=["spice-vms", "spice-deprecated", "spice-virtualization", "spice-display"],
+    )
+    def test_positive(self, query: str):
+        """Queries mentioning SPICE trigger SPICE intent."""
+        assert _detect_spice_intent(query) is True
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "configure firewall",
+            "create a vm on rhel 9",
+            "vnc remote display",
+            "",
+        ],
+        ids=["firewall", "vm-no-spice", "vnc-only", "empty"],
+    )
+    def test_negative(self, query: str):
+        """Queries without SPICE keyword do not trigger SPICE intent."""
+        assert _detect_spice_intent(query) is False
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +388,31 @@ class TestApplyIntentBoosts:
     def test_release_date_intent_no_false_positive(self):
         """Substrings containing 'released' fragment must not trigger release-date intent."""
         assert not _detect_release_date_intent("unreleased feature flag")
+
+    def test_spice_intent_adds_bq_and_hlq(self):
+        """SPICE intent injects VNC/deprecation bq and expands hl.q with SPICE terms."""
+        params = _build_main_query("spice rhel")
+        _apply_intent_boosts(params, "spice rhel", "spice rhel")
+        assert "VNC" in params["bq"]
+        assert "spice" in params["bq"]
+        assert _SPICE_HIGHLIGHT_TERMS in params["hl.q"]
+        assert params["hl.q"].startswith("spice rhel")
+
+    def test_spice_overrides_vm_when_both_match(self):
+        """SPICE intent overrides VM intent for queries like 'SPICE for VMs'.
+
+        SPICE questions are about the display protocol, not VM management.
+        Without this override, cockpit/virsh highlight terms flood results
+        and the LLM omits the VNC replacement.  See RSPEED_2481.
+        """
+        params = _build_main_query("spice rhel vms")
+        _apply_intent_boosts(params, "is spice available for rhel vms", "spice rhel vms")
+        # SPICE runs after VM, so it wins
+        assert "VNC" in params["bq"]
+        assert _SPICE_HIGHLIGHT_TERMS in params["hl.q"]
+        # VM boosts must NOT survive
+        assert "cockpit" not in params["bq"]
+        assert "virt-manager" not in params["bq"]
 
     def test_eus_overrides_vm_when_both_match(self):
         """When both VM and EUS match, EUS runs second and overwrites bq/hl.q."""


### PR DESCRIPTION
## Summary

- Add SPICE display protocol intent detection to `portal.py` so queries about SPICE get VNC/deprecation boosts instead of cockpit/virsh VM management boosts
- Fixes RSPEED_2481 functional test which was failing because the LLM omitted VNC as the SPICE replacement
- Reduces input tokens from 6,845 to 6,422 (-6.2%) by eliminating irrelevant VM management results

## Root cause

The query "Is SPICE available to help with RHEL VMs?" triggered VM intent detection (matching "VMs"), injecting cockpit/virsh highlight terms. This flooded search results with VM management content and pushed out the critical VNC replacement information.

## What changed

**`src/okp_mcp/portal.py`**: Added `_detect_spice_intent()` and `_SPICE_HIGHLIGHT_TERMS`. SPICE intent runs after VM intent in `_apply_intent_boosts()` so it overwrites the cockpit/virsh boosts with VNC/deprecation boosts.

**`tests/test_portal.py`**: Added `TestDetectSpiceIntent` class (positive/negative tests) and two `TestApplyIntentBoosts` tests verifying SPICE boost injection and VM override.

## Verification

- RSPEED_2481: PASS (was FAIL)
- RSPEED_2482: PASS (no regression)
- 274 unit tests: PASS (including 10 new SPICE tests)