### PR TITLE
RSPEED-2480: Reduce search_portal token output with intent-aware deprecation boosts

### DIFF
--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import html as html_mod
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 
 import httpx
@@ -271,6 +272,101 @@ def _apply_intent_boosts(params: dict, query_lower: str, cleaned_query: str) -> 
 
     if _detect_release_date_intent(query_lower):
         params["bq"] = 'title:"Enterprise Linux Release Dates"^200 allTitle:"release dates"^30'
+
+
+@dataclass(frozen=True, slots=True)
+class _DeprecationIntentBoost:
+    """Maps an intent detector to Solr boost terms for the deprecation query.
+
+    Each entry pairs a detection function with the allTitle and main_content
+    terms that should be boosted when that intent is active.  This ensures
+    the deprecation query finds deprecation notices about the user's actual
+    topic rather than unrelated deprecation content.
+
+    Attributes:
+        detect: Function that takes a lowercased query and returns True if
+            this intent is active.
+        title_terms: Solr OR-joined terms for the allTitle boost.
+        content_terms: Solr OR-joined terms for the main_content boost.
+    """
+
+    detect: Callable[[str], bool]
+    title_terms: str
+    content_terms: str
+
+
+# Registry of intent-specific boosts for the deprecation query.
+#
+# ORDER MATTERS: entries are evaluated first-match-wins.  SPICE must come
+# before VM because SPICE queries contain VM terms ("VMs") but need
+# display-protocol boosts (VNC), not VM management boosts (cockpit/virsh).
+#
+# To add a new intent: append a _DeprecationIntentBoost entry at the
+# correct priority position and add a functional test to verify.
+_DEPRECATION_INTENT_BOOSTS: list[_DeprecationIntentBoost] = [
+    # SPICE is a display protocol; deprecation results should mention
+    # SPICE, VNC (its replacement), or display protocols.
+    _DeprecationIntentBoost(
+        detect=_detect_spice_intent,
+        title_terms='SPICE OR VNC OR "display protocol"',
+        content_terms='SPICE OR VNC OR "display protocol"',
+    ),
+    # VM queries need deprecation results about virt-manager, cockpit,
+    # and virtualization tools, not Eclipse Vert.x or network teaming.
+    _DeprecationIntentBoost(
+        detect=_detect_vm_intent,
+        title_terms='"virt-manager" OR virtualization OR cockpit OR "virtual machine"',
+        content_terms='"virt-manager" OR cockpit OR virsh OR "virtual machine"',
+    ),
+]
+
+# Boost weights for deprecation intent terms.
+#
+# IMPORTANT: Keep these at ^5/^3 or lower.  Higher values (e.g. ^30/^15)
+# inflate deprecation query scores well above main query scores (~120),
+# causing _filter_by_score to drop ALL main results because they fall
+# below 45% of the inflated top score.  The score filter uses raw Solr
+# scores which are NOT comparable across queries with different bq boosts.
+#
+# At ^5/^3, the intent boosts are strong enough to re-rank within the
+# deprecation results (e.g. VM deprecation > Vert.x deprecation) without
+# overwhelming the cross-query score comparison.
+_DEP_TITLE_BOOST = 5
+_DEP_CONTENT_BOOST = 3
+
+
+def _apply_deprecation_intent_boosts(params: dict, query_lower: str) -> None:
+    """Add topic-specific boosts to the deprecation query based on detected intent.
+
+    Without intent-aware boosts, the deprecation query matches ANY content
+    containing "deprecated" and "removed", pulling in noise results like
+    Eclipse Vert.x release notes or network teaming deprecation notices for
+    a VM management question.  Adding intent-specific bq ensures the
+    deprecation query surfaces deprecation notices about the user's actual
+    topic, not unrelated deprecation content.
+
+    This function APPENDS to the existing bq (the base deprecation term
+    boosts defined in _build_deprecation_query) rather than replacing it,
+    so the original deprecation/removal title boosts remain active.
+
+    First matching intent wins (evaluated in _DEPRECATION_INTENT_BOOSTS
+    order).  Queries that match no intent are left unchanged.
+
+    Token budget impact: without these boosts, the deprecation query
+    contributes 2-3 completely off-topic results (e.g., Eclipse Vert.x
+    migration guides) that waste ~2,000 chars of response budget.
+
+    See functional tests RSPEED_2480 (VM management) and RSPEED_2481 (SPICE).
+    """
+    for boost in _DEPRECATION_INTENT_BOOSTS:
+        if boost.detect(query_lower):
+            existing_bq = params.get("bq", "")
+            params["bq"] = (
+                f"{existing_bq} "
+                f"allTitle:({boost.title_terms})^{_DEP_TITLE_BOOST} "
+                f"main_content:({boost.content_terms})^{_DEP_CONTENT_BOOST}"
+            )
+            return
 
 
 # ---------------------------------------------------------------------------
@@ -619,7 +715,11 @@ async def _run_portal_search(
     *,
     client: httpx.AsyncClient,
     solr_endpoint: str,
-    max_results: int = 10,
+    # Reduced from 10 to 7 to match search_portal default.  7 is the
+    # sweet spot: enough coverage for cross-referencing deprecation vs
+    # current status, but avoids returning low-relevance tail results
+    # that inflate the tool response without improving answer quality.
+    max_results: int = 7,
 ) -> tuple[list[PortalChunk], bool]:
     """Execute the unified portal search pipeline.
 
@@ -644,6 +744,12 @@ async def _run_portal_search(
     _apply_intent_boosts(main_params, query_lower, cleaned)
 
     dep_params = _build_deprecation_query(cleaned)
+    # Apply intent-aware boosts to the deprecation query so it finds
+    # deprecation notices about the user's ACTUAL topic, not random
+    # deprecation content.  Without this, a VM management query gets
+    # Eclipse Vert.x and network teaming deprecation results that waste
+    # ~2,000 chars of response budget (see RSPEED_2480).
+    _apply_deprecation_intent_boosts(dep_params, query_lower)
 
     main_data, dep_data = await asyncio.gather(
         _solr_query(main_params, client=client, solr_endpoint=solr_endpoint),
@@ -685,12 +791,21 @@ async def _run_portal_search(
 # fragments of 2000+ characters.  Without this cap, a single large highlight
 # can push other results out of the token budget entirely.
 #
-# 1500 chars is enough to include structured data like the RHEL container
-# compatibility matrix table (~800 chars for the key rows) while still
-# leaving room for ~8 other results in a typical 30K char budget.
+# 1000 chars is enough to include structured data like the RHEL container
+# compatibility matrix table (~800 chars for the key rows) and the core
+# facts the LLM needs to answer correctly.  Reduced from 1500 to cut
+# per-result token overhead; the key facts (cockpit, virsh, deprecated,
+# unsupported, etc.) consistently appear in the first 600-800 chars of
+# highlight snippets.  When the truncated snippet lacks a detail, the
+# LLM can call get_document for the full content.
+#
+# DO NOT increase above 1200 without measuring the token impact across
+# functional tests (RSPEED_2480, 2481, 2482) - each extra 100 chars
+# multiplies across all results in the response.
+#
 # See also: formatting.py _MAX_RESULT_CONTENT (used by the legacy
 # _format_result path, not this portal chunk path).
-_MAX_CHUNK_CONTENT = 1500
+_MAX_CHUNK_CONTENT = 1000
 
 _KIND_LABELS: dict[str, str] = {
     "documentation": "Documentation",

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -15,7 +15,13 @@ logger = logging.getLogger("okp_mcp.tools.search_portal")
 async def search_portal(
     ctx: Context,
     query: str,
-    max_results: int = 10,
+    # Reduced from 10 to 7 to lower token overhead per search call.
+    # 7 results consistently provide enough coverage for the LLM to
+    # answer correctly across all functional test scenarios (RSPEED_2480,
+    # 2481, 2482).  The LLM can still request up to 20 via the parameter.
+    # DO NOT reduce below 5 without testing - some queries need multiple
+    # results to cross-reference deprecation vs current status.
+    max_results: int = 7,
 ) -> str:
     """Search Red Hat knowledge base: documentation, solutions, articles, CVEs, errata, and support policies.
 


### PR DESCRIPTION
## Summary

Optimizes token output from the `search_portal` MCP tool for VM management queries (RSPEED-2480), reducing input tokens by 14.4% (5,582 -> 4,777).

**Root cause of waste**: the deprecation query matched ANY content containing "deprecated"/"removed", pulling in 2-3 completely off-topic results (Eclipse Vert.x release notes, network teaming deprecation) that were sorted to the TOP of results due to deprecation annotation priority.

## Changes

- **Intent-aware deprecation query boosts** (`_DeprecationIntentBoost` registry + `_apply_deprecation_intent_boosts`): ensures the deprecation query surfaces deprecation notices about the user's actual topic, not unrelated deprecation content. Uses a registry-based dispatch pattern for extensibility (SPICE, VM intents currently registered).
- **Reduced `_MAX_CHUNK_CONTENT`** (1500 -> 1000): key facts consistently appear in the first 600-800 chars of highlight snippets. The LLM can call `get_document` for full content when needed.
- **Reduced default `max_results`** (10 -> 7): tail results were consistently noise (old RHEL 5/7 docs, TOC-only content).

All changes include detailed comments explaining rationale and what would break if reverted.

## Token impact

| Test | Before | After | Delta |
|------|--------|-------|-------|
| RSPEED_2480 | 5,582 | 4,777 | -805 (-14.4%) |
| RSPEED_2481 | - | 5,181 | pass (no regression) |
| RSPEED_2482 | - | 4,800 | pass (no regression) |

## Test plan

1. `make ci` passes (274 unit tests, lint, typecheck, radon)
2. `uv run pytest -m functional -k "RSPEED_2480 or RSPEED_2481 or RSPEED_2482" -v` passes all three