### PR TITLE
fix(RSPEED-2480,RSPEED-2481): add intent-aware search boosts and reduce token output

### DIFF
--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import re
+from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 
 import httpx
@@ -68,6 +69,13 @@ _EOL_PRODUCTS: frozenset[str] = frozenset(
 # Highlight term expansions injected into hl.q for intent-specific queries.
 _VM_HIGHLIGHT_TERMS = "virsh cockpit deprecated virt-manager"
 _EUS_HIGHLIGHT_TERMS = '"Enhanced EUS" "48 months" "Enhanced Extended Update Support"'
+# SPICE highlight terms: VNC is the supported replacement for the deprecated
+# SPICE display protocol.  Including "VNC" in hl.q causes Solr to select
+# highlight snippets that mention VNC, which is critical for the LLM to
+# recommend the correct replacement.  Without this, the VM intent's
+# cockpit/virsh terms dominate snippets and the LLM omits VNC entirely.
+# See functional test RSPEED_2481.
+_SPICE_HIGHLIGHT_TERMS = "VNC deprecated removed replacement"
 
 
 # ---------------------------------------------------------------------------
@@ -78,6 +86,11 @@ _EUS_HIGHLIGHT_TERMS = '"Enhanced EUS" "48 months" "Enhanced Extended Update Sup
 _VM_INTENT_RE = re.compile(r"\b(?:vm|vms|virtual machine|virtualization|hypervisor)\b")
 _RELEASE_DATE_INTENT_RE = re.compile(r"\b(?:release dates?|released|when was|general availability)\b")
 _EUS_INTENT_RE = re.compile(r"\b(?:eus|extended update support)\b")
+# SPICE is a display/graphics protocol for VMs, NOT a VM management tool.
+# Queries mentioning SPICE need display-protocol-specific boosts (VNC),
+# not VM management boosts (cockpit/virsh).  This regex detects SPICE
+# intent so _apply_intent_boosts can override the generic VM intent.
+_SPICE_INTENT_RE = re.compile(r"\bspice\b")
 
 
 def _detect_vm_intent(query_lower: str) -> bool:
@@ -93,6 +106,17 @@ def _detect_release_date_intent(query_lower: str) -> bool:
 def _detect_eus_intent(query_lower: str) -> bool:
     """Return True if the lowercased query asks about EUS or Extended Update Support."""
     return bool(_EUS_INTENT_RE.search(query_lower))
+
+
+def _detect_spice_intent(query_lower: str) -> bool:
+    """Return True if the lowercased query mentions the SPICE display protocol.
+
+    SPICE questions are about display protocol availability and replacements
+    (VNC), not about VM management tools (cockpit/virsh).  Detecting SPICE
+    intent separately from VM intent prevents the generic VM boosts from
+    flooding results with irrelevant cockpit/virsh content.
+    """
+    return bool(_SPICE_INTENT_RE.search(query_lower))
 
 
 # ---------------------------------------------------------------------------
@@ -183,8 +207,12 @@ def _build_deprecation_query(cleaned_query: str) -> dict:
 def _apply_intent_boosts(params: dict, query_lower: str, cleaned_query: str) -> None:
     """Mutate *params* in-place to add intent-specific bq/hl.q boosts.
 
-    Called after ``_build_main_query`` to layer on VM, EUS, or release-date
-    boosts without complicating the base query builder.
+    Called after ``_build_main_query`` to layer on VM, EUS, release-date,
+    or SPICE boosts without complicating the base query builder.
+
+    Order matters: later intents overwrite earlier ones.  SPICE runs after
+    VM so that "SPICE for VMs" gets display-protocol boosts (VNC), not
+    VM-management boosts (cockpit/virsh).
     """
     if _detect_vm_intent(query_lower):
         params["bq"] = (
@@ -193,12 +221,122 @@ def _apply_intent_boosts(params: dict, query_lower: str, cleaned_query: str) -> 
         )
         params["hl.q"] = f"{cleaned_query} {_VM_HIGHLIGHT_TERMS}"
 
+    # SPICE intent MUST run after VM intent so it overwrites the VM boosts.
+    # SPICE questions are about the display protocol (SPICE vs VNC), not
+    # about VM management tools (cockpit/virsh).  Without this override,
+    # queries like "Is SPICE available for VMs?" trigger VM intent, which
+    # injects cockpit/virsh highlight terms that flood results with
+    # irrelevant VM management content and push out the critical VNC
+    # replacement information the LLM needs to answer correctly.
+    # See functional test RSPEED_2481.
+    if _detect_spice_intent(query_lower):
+        params["bq"] = (
+            'allTitle:(spice OR deprecated OR "no longer")^15 '
+            'main_content:(VNC OR deprecated OR removed OR replacement OR "no longer")^10'
+        )
+        params["hl.q"] = f"{cleaned_query} {_SPICE_HIGHLIGHT_TERMS}"
+
     if _detect_eus_intent(query_lower):
         params["bq"] = 'title:"Enhanced EUS"^100 title:"EUS FAQ"^80'
         params["hl.q"] = f"{cleaned_query} {_EUS_HIGHLIGHT_TERMS}"
 
     if _detect_release_date_intent(query_lower):
         params["bq"] = 'title:"Enterprise Linux Release Dates"^200 allTitle:"release dates"^30'
+
+
+@dataclass(frozen=True, slots=True)
+class _DeprecationIntentBoost:
+    """Maps an intent detector to Solr boost terms for the deprecation query.
+
+    Each entry pairs a detection function with the allTitle and main_content
+    terms that should be boosted when that intent is active.  This ensures
+    the deprecation query finds deprecation notices about the user's actual
+    topic rather than unrelated deprecation content.
+
+    Attributes:
+        detect: Function that takes a lowercased query and returns True if
+            this intent is active.
+        title_terms: Solr OR-joined terms for the allTitle boost.
+        content_terms: Solr OR-joined terms for the main_content boost.
+    """
+
+    detect: Callable[[str], bool]
+    title_terms: str
+    content_terms: str
+
+
+# Registry of intent-specific boosts for the deprecation query.
+#
+# ORDER MATTERS: entries are evaluated first-match-wins.  SPICE must come
+# before VM because SPICE queries contain VM terms ("VMs") but need
+# display-protocol boosts (VNC), not VM management boosts (cockpit/virsh).
+#
+# To add a new intent: append a _DeprecationIntentBoost entry at the
+# correct priority position and add a functional test to verify.
+_DEPRECATION_INTENT_BOOSTS: list[_DeprecationIntentBoost] = [
+    # SPICE is a display protocol; deprecation results should mention
+    # SPICE, VNC (its replacement), or display protocols.
+    _DeprecationIntentBoost(
+        detect=_detect_spice_intent,
+        title_terms='SPICE OR VNC OR "display protocol"',
+        content_terms='SPICE OR VNC OR "display protocol"',
+    ),
+    # VM queries need deprecation results about virt-manager, cockpit,
+    # and virtualization tools, not Eclipse Vert.x or network teaming.
+    _DeprecationIntentBoost(
+        detect=_detect_vm_intent,
+        title_terms='"virt-manager" OR virtualization OR cockpit OR "virtual machine"',
+        content_terms='"virt-manager" OR cockpit OR virsh OR "virtual machine"',
+    ),
+]
+
+# Boost weights for deprecation intent terms.
+#
+# IMPORTANT: Keep these at ^5/^3 or lower.  Higher values (e.g. ^30/^15)
+# inflate deprecation query scores well above main query scores (~120),
+# causing _filter_by_score to drop ALL main results because they fall
+# below 45% of the inflated top score.  The score filter uses raw Solr
+# scores which are NOT comparable across queries with different bq boosts.
+#
+# At ^5/^3, the intent boosts are strong enough to re-rank within the
+# deprecation results (e.g. VM deprecation > Vert.x deprecation) without
+# overwhelming the cross-query score comparison.
+_DEP_TITLE_BOOST = 5
+_DEP_CONTENT_BOOST = 3
+
+
+def _apply_deprecation_intent_boosts(params: dict, query_lower: str) -> None:
+    """Add topic-specific boosts to the deprecation query based on detected intent.
+
+    Without intent-aware boosts, the deprecation query matches ANY content
+    containing "deprecated" and "removed", pulling in noise results like
+    Eclipse Vert.x release notes or network teaming deprecation notices for
+    a VM management question.  Adding intent-specific bq ensures the
+    deprecation query surfaces deprecation notices about the user's actual
+    topic, not unrelated deprecation content.
+
+    This function APPENDS to the existing bq (the base deprecation term
+    boosts defined in _build_deprecation_query) rather than replacing it,
+    so the original deprecation/removal title boosts remain active.
+
+    First matching intent wins (evaluated in _DEPRECATION_INTENT_BOOSTS
+    order).  Queries that match no intent are left unchanged.
+
+    Token budget impact: without these boosts, the deprecation query
+    contributes 2-3 completely off-topic results (e.g., Eclipse Vert.x
+    migration guides) that waste ~2,000 chars of response budget.
+
+    See functional tests RSPEED_2480 (VM management) and RSPEED_2481 (SPICE).
+    """
+    for boost in _DEPRECATION_INTENT_BOOSTS:
+        if boost.detect(query_lower):
+            existing_bq = params.get("bq", "")
+            params["bq"] = (
+                f"{existing_bq} "
+                f"allTitle:({boost.title_terms})^{_DEP_TITLE_BOOST} "
+                f"main_content:({boost.content_terms})^{_DEP_CONTENT_BOOST}"
+            )
+            return
 
 
 # ---------------------------------------------------------------------------
@@ -480,7 +618,11 @@ async def _run_portal_search(
     *,
     client: httpx.AsyncClient,
     solr_endpoint: str,
-    max_results: int = 10,
+    # Reduced from 10 to 7 to match search_portal default.  7 is the
+    # sweet spot: enough coverage for cross-referencing deprecation vs
+    # current status, but avoids returning low-relevance tail results
+    # that inflate the tool response without improving answer quality.
+    max_results: int = 7,
 ) -> tuple[list[PortalChunk], bool]:
     """Execute the unified portal search pipeline.
 
@@ -505,6 +647,12 @@ async def _run_portal_search(
     _apply_intent_boosts(main_params, query_lower, cleaned)
 
     dep_params = _build_deprecation_query(cleaned)
+    # Apply intent-aware boosts to the deprecation query so it finds
+    # deprecation notices about the user's ACTUAL topic, not random
+    # deprecation content.  Without this, a VM management query gets
+    # Eclipse Vert.x and network teaming deprecation results that waste
+    # ~2,000 chars of response budget (see RSPEED_2480).
+    _apply_deprecation_intent_boosts(dep_params, query_lower)
 
     main_data, dep_data = await asyncio.gather(
         _solr_query(main_params, client=client, solr_endpoint=solr_endpoint),

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -15,7 +15,13 @@ logger = logging.getLogger("okp_mcp.tools.search_portal")
 async def search_portal(
     ctx: Context,
     query: str,
-    max_results: int = 10,
+    # Reduced from 10 to 7 to lower token overhead per search call.
+    # 7 results consistently provide enough coverage for the LLM to
+    # answer correctly across all functional test scenarios (RSPEED_2480,
+    # 2481, 2482).  The LLM can still request up to 20 via the parameter.
+    # DO NOT reduce below 5 without testing - some queries need multiple
+    # results to cross-reference deprecation vs current status.
+    max_results: int = 7,
 ) -> str:
     """Search Red Hat knowledge base: documentation, solutions, articles, CVEs, errata, and support policies.
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -11,6 +11,7 @@ from okp_mcp.portal import (
     _FALLBACK_MAX_CHARS,
     _KIND_LABELS,
     _MAIN_QF,
+    _SPICE_HIGHLIGHT_TERMS,
     _VM_HIGHLIGHT_TERMS,
     PortalChunk,
     _apply_intent_boosts,
@@ -20,6 +21,7 @@ from okp_mcp.portal import (
     _deduplicate_by_parent,
     _detect_eus_intent,
     _detect_release_date_intent,
+    _detect_spice_intent,
     _detect_vm_intent,
     _docs_to_chunks,
     _fallback_cve,
@@ -162,6 +164,43 @@ class TestDetectEusIntent:
     def test_negative(self, query: str):
         """Queries without EUS keywords do not trigger EUS intent."""
         assert _detect_eus_intent(query) is False
+
+
+class TestDetectSpiceIntent:
+    """Verify SPICE display protocol intent detection.
+
+    SPICE queries are about the display protocol, not VM management.
+    Detecting SPICE separately prevents the generic VM intent from injecting
+    cockpit/virsh boosts that drown out VNC replacement information.
+    """
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "is spice available for rhel vms",
+            "spice protocol deprecated",
+            "how to use spice with virtualization",
+            "spice remote display",
+        ],
+        ids=["spice-vms", "spice-deprecated", "spice-virtualization", "spice-display"],
+    )
+    def test_positive(self, query: str):
+        """Queries mentioning SPICE trigger SPICE intent."""
+        assert _detect_spice_intent(query) is True
+
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "configure firewall",
+            "create a vm on rhel 9",
+            "vnc remote display",
+            "",
+        ],
+        ids=["firewall", "vm-no-spice", "vnc-only", "empty"],
+    )
+    def test_negative(self, query: str):
+        """Queries without SPICE keyword do not trigger SPICE intent."""
+        assert _detect_spice_intent(query) is False
 
 
 # ---------------------------------------------------------------------------
@@ -349,6 +388,31 @@ class TestApplyIntentBoosts:
     def test_release_date_intent_no_false_positive(self):
         """Substrings containing 'released' fragment must not trigger release-date intent."""
         assert not _detect_release_date_intent("unreleased feature flag")
+
+    def test_spice_intent_adds_bq_and_hlq(self):
+        """SPICE intent injects VNC/deprecation bq and expands hl.q with SPICE terms."""
+        params = _build_main_query("spice rhel")
+        _apply_intent_boosts(params, "spice rhel", "spice rhel")
+        assert "VNC" in params["bq"]
+        assert "spice" in params["bq"]
+        assert _SPICE_HIGHLIGHT_TERMS in params["hl.q"]
+        assert params["hl.q"].startswith("spice rhel")
+
+    def test_spice_overrides_vm_when_both_match(self):
+        """SPICE intent overrides VM intent for queries like 'SPICE for VMs'.
+
+        SPICE questions are about the display protocol, not VM management.
+        Without this override, cockpit/virsh highlight terms flood results
+        and the LLM omits the VNC replacement.  See RSPEED_2481.
+        """
+        params = _build_main_query("spice rhel vms")
+        _apply_intent_boosts(params, "is spice available for rhel vms", "spice rhel vms")
+        # SPICE runs after VM, so it wins
+        assert "VNC" in params["bq"]
+        assert _SPICE_HIGHLIGHT_TERMS in params["hl.q"]
+        # VM boosts must NOT survive
+        assert "cockpit" not in params["bq"]
+        assert "virt-manager" not in params["bq"]
 
     def test_eus_overrides_vm_when_both_match(self):
         """When both VM and EUS match, EUS runs second and overwrites bq/hl.q."""


### PR DESCRIPTION
## Summary

- Add SPICE display protocol intent detection so queries about SPICE get VNC/deprecation boosts instead of cockpit/virsh VM management boosts (RSPEED-2481)
- Add registry-based deprecation intent boost system (`_DeprecationIntentBoost`) ensuring the deprecation query surfaces topic-relevant deprecation notices instead of unrelated content like Eclipse Vert.x or network teaming (RSPEED-2480)
- Reduce default `max_results` from 10 to 7 to cut tail-result noise

Combines #131 and #132 onto `main`, using #132's registry-based dispatch pattern for intent detection extensibility.

## What changed

**`src/okp_mcp/portal.py`**:
- `_detect_spice_intent()` + `_SPICE_INTENT_RE` + `_SPICE_HIGHLIGHT_TERMS`: SPICE intent detection
- SPICE block in `_apply_intent_boosts()` that overrides VM boosts with VNC/deprecation boosts
- `_DeprecationIntentBoost` dataclass + `_DEPRECATION_INTENT_BOOSTS` registry: first-match-wins dispatch for deprecation query boosts
- `_apply_deprecation_intent_boosts()`: appends topic-specific bq to the deprecation query
- `_run_portal_search` default `max_results` reduced from 10 to 7

**`src/okp_mcp/tools/search.py`**: `search_portal` default `max_results` reduced from 10 to 7

**`tests/test_portal.py`**: `TestDetectSpiceIntent` class (8 parametrized tests) + 2 SPICE boost tests in `TestApplyIntentBoosts`

## Note

PR 132's `_MAX_CHUNK_CONTENT` reduction (1500 to 1000) is excluded because the constant itself was introduced by the stack below and doesn't exist on `main` yet.

Closes #131
Closes #132