### PR TITLE
ci: enable CI/CD pipelines on release branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,10 +2,10 @@ name: CI/CD
 
 on:
   push:
-    branches: [main]
+    branches: [main, 'release/**']
     tags: ['v*']
   pull_request:
-    branches: [main]
+    branches: [main, 'release/**']
 
 jobs:
   test:

--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -8,7 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{ target_branch }}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch == "main"
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && (target_branch == "main" || target_branch.startsWith("release/"))
 
   creationTimestamp: null
 

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -11,6 +11,7 @@ metadata:
       event == "push"
       && (
         target_branch == "main"
+        || target_branch.startsWith("release/")
         || target_branch.startsWith("refs/tags/")
       )
 


### PR DESCRIPTION
## Summary
- Add `release/**` to GitHub Actions branch triggers (push + PR)
- Add `release/` prefix to Tekton push and pull_request CEL expressions
- Enables Konflux image builds and CI on release branches for code freeze workflow

Cherry-picked from `release/2026-04-01` branch.