### PR TITLE
Add info-level log lines for intent boost application

### DIFF
--- a/src/okp_mcp/intent.py
+++ b/src/okp_mcp/intent.py
@@ -148,7 +148,8 @@ def apply_main_boosts(params: dict, query_lower: str, cleaned_query: str) -> Non
             params["bq"] = rule.bq
             if rule.highlight_terms:
                 params["hl.q"] = f"{cleaned_query} {rule.highlight_terms}"
-            logger.debug("Intent boost applied: %s", rule.name)
+            boosted = "bq + hl.q" if rule.highlight_terms else "bq"
+            logger.info("Intent boost: applied '%s' to main query (%s)", rule.name, boosted)
             return
 
 
@@ -187,5 +188,7 @@ def apply_deprecation_boosts(params: dict, query_lower: str) -> None:
             f"allTitle:({rule.dep_title_terms})^{_DEP_TITLE_BOOST} "
             f"main_content:({rule.dep_content_terms})^{_DEP_CONTENT_BOOST}"
         )
-        logger.debug("Deprecation intent boost applied: %s", rule.name)
+        logger.info(
+            "Intent boost: applied '%s' to deprecation query (^%d/^%d)", rule.name, _DEP_TITLE_BOOST, _DEP_CONTENT_BOOST
+        )
         return

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -4,7 +4,7 @@ import httpx
 import pytest
 import respx
 
-from okp_mcp.intent import INTENT_RULES, IntentRule, apply_main_boosts
+from okp_mcp.intent import INTENT_RULES, IntentRule, apply_deprecation_boosts, apply_main_boosts
 from okp_mcp.portal import (
     _DEPRECATION_WARNING,
     _EOL_PRODUCTS,
@@ -429,6 +429,57 @@ class TestApplyMainBoosts:
         result = apply_main_boosts(params, "eus policy", "eus policy")
         assert result is None
         assert "bq" in params
+
+
+# ---------------------------------------------------------------------------
+# Intent boost logging
+# ---------------------------------------------------------------------------
+
+
+class TestIntentBoostLogging:
+    """Verify that intent boost functions emit info-level log lines."""
+
+    @pytest.mark.parametrize(
+        ("query", "expected_fragment"),
+        [
+            ("create a vm", "applied 'vm' to main query (bq + hl.q)"),
+            ("when was rhel 9 released", "applied 'release_date' to main query (bq)"),
+            ("spice rhel", "applied 'spice' to main query (bq + hl.q)"),
+        ],
+        ids=["vm-bq-hlq", "release-date-bq-only", "spice-bq-hlq"],
+    )
+    def test_main_boost_logs(self, caplog, query, expected_fragment):
+        """Main query boost logs intent name and which params were set."""
+        params = _build_main_query(query)
+        with caplog.at_level("INFO", logger="okp_mcp"):
+            apply_main_boosts(params, query, query)
+        assert any(expected_fragment in m for m in caplog.messages)
+
+    def test_main_boost_no_match_no_log(self, caplog):
+        """No log line emitted when no intent matches."""
+        params = _build_main_query("configure firewall rhel 9")
+        with caplog.at_level("INFO", logger="okp_mcp"):
+            apply_main_boosts(params, "configure firewall rhel 9", "configure firewall rhel 9")
+        assert not any("Intent boost" in m for m in caplog.messages)
+
+    def test_deprecation_boost_logs_with_weights(self, caplog):
+        """Deprecation query boost logs intent name and boost weights."""
+        params = _build_deprecation_query("spice rhel")
+        with caplog.at_level("INFO", logger="okp_mcp"):
+            apply_deprecation_boosts(params, "spice rhel")
+        assert any("applied 'spice' to deprecation query (^5/^3)" in m for m in caplog.messages)
+
+    @pytest.mark.parametrize(
+        "query",
+        ["configure firewall rhel 9", "when was rhel 9 released"],
+        ids=["no-match", "intent-without-dep-terms"],
+    )
+    def test_deprecation_boost_no_log(self, caplog, query):
+        """No log line when no deprecation intent matches or matched intent has no dep terms."""
+        params = _build_deprecation_query(query)
+        with caplog.at_level("INFO", logger="okp_mcp"):
+            apply_deprecation_boosts(params, query)
+        assert not any("Intent boost" in m for m in caplog.messages)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Upgrades intent boost log lines from `debug` to `info` so they're visible alongside the existing score filter log line. Each boost application now emits one log line with the intent name and what was applied:

```
Intent boost: applied 'vm' to main query (bq + hl.q)
Intent boost: applied 'spice' to deprecation query (^5/^3)
```

## Changes

- `apply_main_boosts`: logs intent name + whether bq-only or bq + hl.q was set
- `apply_deprecation_boosts`: logs intent name + boost weights (^5/^3)
- Consistent `"Intent boost:"` prefix for easy grep
- Parametrized tests covering positive and negative cases for both functions

## Dependencies

> **Stacked on #134** (`refactor/extract-intent-detection`), which must merge first.

## Test plan

- `make ci` passes (lint, typecheck, radon, 280 tests)
- `uv run pytest tests/test_portal.py::TestIntentBoostLogging -v` runs 7 parametrized cases