### PR TITLE
feat: add syn_product synonym field to edismax query fields

### DIFF
--- a/docs/SYN_PRODUCT_FIELD.md
+++ b/docs/SYN_PRODUCT_FIELD.md
@@ -1,0 +1,106 @@
+# syn_product Field Investigation
+
+Investigation of the `syn_product` Solr field for product name synonym expansion (issue #144, item 1).
+
+## Field Infrastructure
+
+The Solr 9.10.1 server has a complete synonym expansion pipeline already configured:
+
+| Component | Configuration |
+|-----------|---------------|
+| Field | `syn_product` - type `text_product_synonym`, indexed, **not stored** |
+| Copy field | `product` -> `syn_product` (automatic) |
+| Index analyzer | WhitespaceTokenizer -> LowerCase -> StopFilter -> SynonymGraphFilter -> RemoveDuplicates -> FlattenGraph |
+| Query analyzer | WhitespaceTokenizer -> LowerCase -> StopFilter -> SynonymGraphFilter -> RemoveDuplicates |
+| Synonym file | `common-product-name-synonyms.txt`, bidirectional (`expand=true`, `ignoreCase=true`) |
+
+Both the index and query analyzers apply synonym expansion, so synonyms work regardless of which form was indexed or queried.
+
+## Synonym File Contents
+
+The file contains ~90 synonym rules covering:
+
+- **RHEL**: `red hat enterprise linux,rhel` plus every point release from 2.1 through 9.4, with variant spellings (`rhel8`, `rhel-8`, `rhel_8`, `rhel 8`, `rhel8.0`, etc.)
+- **RHEV/RHV**: `rhev, rhv, red hat enterprise virtualization, red hat virtualization` plus versions 2.x through 4.x
+- **Satellite**: `rhsat,satellite`
+- **JBoss**: `jboss-as,jboss as,jboss_as,jbossas`
+- **RHEV subsystems**: `rhev-h`/`rhevh`, `rhev-m`/`rhevm`/`rhev-manager`
+
+Notable gaps: no synonyms for OpenShift (OCP), Ansible (AAP), Ceph, Quay, or other products that commonly use abbreviations.
+
+## Coverage Analysis
+
+The `product` field (source for `syn_product`) is only populated on **documentation** pages:
+
+| documentKind | Has `product`? | Count | % of corpus |
+|--------------|:-:|------:|------:|
+| documentation | yes | 16,946 | 2.8% |
+| CVE | no | 320,349 | 53.2% |
+| solution | no | 158,338 | 26.3% |
+| Errata | no | 94,932 | 15.8% |
+| article | no | 7,426 | 1.2% |
+| other | no | 3,917 | 0.7% |
+| **Total** | | **601,908** | |
+
+Solutions and CVEs have no `product` field at all. Their stored fields are limited to `id`, `title`, `main_content`, `documentKind`, `lastModifiedDate`, `url_slug`, and `resourceName`.
+
+This means `syn_product` is populated for 16,946 documents (2.8% of the corpus). The field contains 197 distinct terms across 143 unique product values.
+
+## Verified Synonym Expansion
+
+Direct queries confirm synonyms work correctly:
+
+| Query | Field | numFound | Matched product |
+|-------|-------|------:|-----------------|
+| `syn_product:rhel` | syn_product | 1,959 | Red Hat Enterprise Linux (+ SAP, AI, Real Time, Atomic Host variants) |
+| `syn_product:rhsat` | syn_product | 367 | Red Hat Satellite |
+| `syn_product:rhev` | syn_product | 156 | Red Hat Virtualization |
+| `syn_product:satellite` | syn_product | 367 | Red Hat Satellite |
+
+The `rhsat` -> `satellite` and `rhel` -> `red hat enterprise linux` mappings both expand correctly in both directions.
+
+## A/B Comparison Results
+
+Tested with the current `qf` vs. adding `syn_product^6`:
+
+### "satellite installation" (solution-heavy query)
+
+Top 5 results **identical** with and without `syn_product^6`. All top hits are solutions (no `product` field), so `syn_product` contributes nothing to their scores.
+
+### "RHEL 9 networking" (mixed query)
+
+Same document ordering. Absolute scores dropped slightly with `syn_product^6` due to IDF redistribution from adding a sparse field, but rank order was preserved.
+
+### "rhsat" (abbreviation-only query, via edismax)
+
+`syn_product^6` correctly boosted Red Hat Satellite documentation pages. Without it, `rhsat` only matches via `all_content^1` (if present in body text).
+
+## Impact Assessment
+
+Adding `syn_product^6` to `qf` provides:
+
+**Benefits:**
+- Documentation pages for abbreviated product names (rhel, rhsat, rhev/rhv) get a strong relevance boost
+- Zero risk: the field is already indexed and populated, this just starts querying it
+- Helps queries where the user uses an abbreviation but the document title/content uses the full product name (or vice versa)
+
+**Limitations:**
+- Only affects 2.8% of the corpus (documentation pages)
+- Solutions, CVEs, errata, and articles are unaffected (no `product` field)
+- For queries where solutions dominate the top results, adding `syn_product` won't change the ranking
+- The synonym file has gaps: no coverage for OCP, AAP, Ceph, Quay, and other commonly abbreviated products
+
+## Changes Made
+
+Two files changed, one constant added to each `qf` string:
+
+- `src/okp_mcp/solr.py`: added `syn_product^6` to the base edismax `qf` assignment in `_solr_query()`
+- `src/okp_mcp/portal.py`: added `syn_product^6` to `_MAIN_QF` (overrides the base `qf` on the main search path)
+
+The `^6` weight puts product synonym matches above `title^5`, reflecting that a product name match via synonyms is a strong relevance signal for documentation pages.
+
+## Future Considerations
+
+- **Expand synonym file**: Add mappings for OCP/OpenShift, AAP/Ansible, and other commonly abbreviated products
+- **Product field on non-documentation docs**: If the Solr schema were updated to populate `product` on solutions, CVEs, and errata, `syn_product` would become dramatically more useful
+- **Weight tuning**: The `^6` weight may need adjustment based on functional test results; it should boost product-relevant docs without drowning out high-quality solutions that match on content

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -93,7 +93,9 @@ _DEPRECATION_FL = (
 # weights defined in solr._solr_query().  cve_details is a Solr `string` field
 # (not tokenized) so it cannot participate in edismax scoring; CVEs match via
 # allTitle, main_content, and all_content instead.
-_MAIN_QF = "title^5 main_content heading_h1^3 heading_h2 portal_synopsis^3 allTitle^3 content^2 all_content^1"
+_MAIN_QF = (
+    "title^5 main_content heading_h1^3 heading_h2 portal_synopsis^3 allTitle^3 content^2 all_content^1 syn_product^6"
+)
 
 
 def _build_eol_filter() -> str:

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -97,9 +97,39 @@ async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, 
         "wt": "json",
         # Use Extended DisMax, which supports field boosting, phrase boosting, and minimum-match.
         "defType": "edismax",
-        # Query fields with boosts: title matches matter most (^5), headings and synopses help,
-        # and body content contributes at lower weight.
-        "qf": "title^5 main_content heading_h1^3 heading_h2 portal_synopsis allTitle^3 content^2 all_content^1",
+        # Query fields with boosts.  edismax scores each field independently and
+        # combines them, so a term matching in a high-boost field contributes more
+        # to the final score than the same term in a low-boost field.
+        #
+        #   syn_product ^6  Product-name synonym field (copy of `product` through
+        #                   the `text_product_synonym` analyzer, which expands
+        #                   abbreviations like RHEL -> Red Hat Enterprise Linux via
+        #                   SynonymGraphFilterFactory).  Highest boost because a
+        #                   product-name match is a very strong relevance signal.
+        #                   Only populated on documentation pages (~2.8% of corpus);
+        #                   solutions, CVEs, errata, and articles have no `product`
+        #                   field and therefore no `syn_product` index entries.
+        #   title       ^5  Document title (exact tokenization, no stemming).
+        #   heading_h1  ^3  Top-level headings within the document.
+        #   allTitle    ^3  Alternate/combined title field (covers CVE IDs, errata
+        #                   advisory names, and other title variants).
+        #   content     ^2  Secondary content field.
+        #   main_content    Primary body text (no explicit boost = ^1).
+        #   heading_h2      Second-level headings (no explicit boost = ^1).
+        #   portal_synopsis Synopsis/abstract (no explicit boost = ^1).
+        #   all_content ^1  Copy-field that aggregates all text fields.  Uses the
+        #                   `text_en_splitting_tight` type (EnglishMinimalStemmer),
+        #                   so "configuring" matches "configuration".  Low weight
+        #                   keeps it as a recall safety net without distorting
+        #                   precision from the unstemmed primary fields.
+        #
+        # NOTE: portal.py defines _MAIN_QF which overrides this qf for the main
+        # search path (adds portal_synopsis^3).  Changes here only affect callers
+        # that use _solr_query() directly without a qf override.
+        "qf": (
+            "title^5 main_content heading_h1^3 heading_h2 portal_synopsis"
+            " allTitle^3 content^2 all_content^1 syn_product^6"
+        ),
         # Phrase boost: reward documents where all query terms appear as an exact phrase.
         "pf": "main_content^5 title^8",
         # Phrase slop for pf: terms may be up to 3 positions apart and still earn the phrase boost.


### PR DESCRIPTION
## Summary

- Add `syn_product^6` to the edismax `qf` in both `solr.py` (base params) and `portal.py` (`_MAIN_QF` override), enabling Solr's existing product-name synonym expansion (RHEL <-> Red Hat Enterprise Linux, rhsat <-> satellite, rhev <-> rhv, etc.)
- Expand the `qf` comment block in `solr.py` to document every field, its boost weight, and its purpose
- Add `docs/SYN_PRODUCT_FIELD.md` with investigation findings: field infrastructure, synonym file contents, coverage analysis, A/B comparisons, and future considerations

## Context

The Solr schema already has a `product` -> `syn_product` copy field with `SynonymGraphFilterFactory` and hundreds of product abbreviation mappings. Our code never queried it. This is item 1 from #144.

## Coverage caveat

Only documentation pages (~2.8% of the 602K corpus) have the `product` field. Solutions, CVEs, errata, and articles are unaffected since they have no product metadata. The synonym file also has gaps (no OCP, AAP, Ceph, Quay mappings).

## Testing

All 282 unit tests pass. No functional test changes needed since this doesn't alter result structure, just ranking weights.

Ref: #144