### PR TITLE
feat: surface Solr facet counts in search results for LLM context

### DIFF
--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -42,6 +42,21 @@ class PortalChunk:
 # ---------------------------------------------------------------------------
 
 
+def _parse_facet_pairs(pairs: list | tuple) -> dict[str, int]:
+    """Convert a Solr alternating ``[value, count, ...]`` list into a dict.
+
+    Skips malformed entries where the value is not a string or the count is
+    not an int, and drops zero-count entries.  Handles odd-length lists
+    gracefully by ignoring a trailing orphan element.
+    """
+    counts: dict[str, int] = {}
+    for i in range(0, len(pairs) - 1, 2):
+        value, count = pairs[i], pairs[i + 1]
+        if isinstance(value, str) and isinstance(count, int) and count > 0:
+            counts[value] = count
+    return counts
+
+
 def _extract_facet_counts(solr_response: dict) -> dict[str, dict[str, int]]:
     """Extract facet field counts from a Solr response.
 
@@ -51,18 +66,20 @@ def _extract_facet_counts(solr_response: dict) -> dict[str, dict[str, int]]:
     with actual results.
 
     Returns an empty dict when the response has no ``facet_counts`` key
-    (e.g. in unit tests with minimal mock responses).
+    (e.g. in unit tests with minimal mock responses) or when the payload
+    contains unexpected types.
     """
-    facet_fields = solr_response.get("facet_counts", {}).get("facet_fields", {})
+    facet_counts = solr_response.get("facet_counts")
+    if not isinstance(facet_counts, dict):
+        return {}
+    facet_fields = facet_counts.get("facet_fields", {})
+    if not isinstance(facet_fields, dict):
+        return {}
     result: dict[str, dict[str, int]] = {}
     for field_name, pairs in facet_fields.items():
-        counts: dict[str, int] = {}
-        # Solr facet lists are always even-length ([value, count, ...]),
-        # but guard against a malformed trailing element to avoid IndexError.
-        for i in range(0, len(pairs) - 1, 2):
-            value, count = pairs[i], pairs[i + 1]
-            if count > 0:
-                counts[value] = count
+        if not isinstance(field_name, str) or not isinstance(pairs, (list, tuple)):
+            continue
+        counts = _parse_facet_pairs(pairs)
         if counts:
             result[field_name] = counts
     return result
@@ -683,10 +700,14 @@ def _format_facet_summary(facets: dict[str, dict[str, int]]) -> str:
     kind_counts = facets.get("documentKind", {})
     if not kind_counts:
         return ""
-    parts: list[str] = []
-    for kind, count in sorted(kind_counts.items(), key=lambda x: x[1], reverse=True):
+    # Aggregate by rendered label so aliased kinds (e.g. "documentation" and
+    # "access-drupal10-node-type-page" both mapping to "Documentation") are
+    # combined into a single entry.
+    label_counts: dict[str, int] = {}
+    for kind, count in kind_counts.items():
         label = _KIND_FACET_LABELS.get(kind, kind)
-        parts.append(f"{count} {label}")
+        label_counts[label] = label_counts.get(label, 0) + count
+    parts = [f"{count} {label}" for label, count in sorted(label_counts.items(), key=lambda x: x[1], reverse=True)]
     return "Result distribution: " + ", ".join(parts)
 
 

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -37,6 +37,37 @@ class PortalChunk:
     rrf_score: float | None = field(default=None, repr=False)
 
 
+# ---------------------------------------------------------------------------
+# Facet extraction
+# ---------------------------------------------------------------------------
+
+
+def _extract_facet_counts(solr_response: dict) -> dict[str, dict[str, int]]:
+    """Extract facet field counts from a Solr response.
+
+    Solr returns ``facet.field`` data as alternating ``[value, count, value,
+    count, ...]`` lists.  This converts them to ``{field: {value: count}}``
+    dicts, dropping zero-count entries so downstream code only sees facets
+    with actual results.
+
+    Returns an empty dict when the response has no ``facet_counts`` key
+    (e.g. in unit tests with minimal mock responses).
+    """
+    facet_fields = solr_response.get("facet_counts", {}).get("facet_fields", {})
+    result: dict[str, dict[str, int]] = {}
+    for field_name, pairs in facet_fields.items():
+        counts: dict[str, int] = {}
+        # Solr facet lists are always even-length ([value, count, ...]),
+        # but guard against a malformed trailing element to avoid IndexError.
+        for i in range(0, len(pairs) - 1, 2):
+            value, count = pairs[i], pairs[i + 1]
+            if count > 0:
+                counts[value] = count
+        if counts:
+            result[field_name] = counts
+    return result
+
+
 _EOL_PRODUCTS: frozenset[str] = frozenset(
     [
         "Red Hat Virtualization",
@@ -534,12 +565,13 @@ async def _run_portal_search(
     # current status, but avoids returning low-relevance tail results
     # that inflate the tool response without improving answer quality.
     max_results: int = 7,
-) -> tuple[list[PortalChunk], bool]:
+) -> tuple[list[PortalChunk], bool, dict[str, dict[str, int]]]:
     """Execute the unified portal search pipeline.
 
     Cleans the query, fires main + deprecation queries in parallel, converts
     results to chunks, merges via RRF, deduplicates, and returns the top-N
-    chunks plus a flag indicating whether deprecation content was found.
+    chunks plus a flag indicating whether deprecation content was found and
+    facet counts from the main query.
 
     Args:
         query: Raw user query string.
@@ -549,7 +581,10 @@ async def _run_portal_search(
         max_results: Maximum chunks to return after deduplication.
 
     Returns:
-        Tuple of (top-N PortalChunk list, has_deprecation bool).
+        Tuple of (top-N PortalChunk list, has_deprecation bool, facet counts dict).
+        Facet counts come from the main query only (the deprecation query is
+        filtered to docs/solutions/articles, so its facets are not representative
+        of the full corpus distribution).
     """
     cleaned = _clean_query(query)
     query_lower = query.lower()
@@ -582,6 +617,11 @@ async def _run_portal_search(
     dep_parent_ids = {d.parent_id for d in dep_chunks if d.parent_id is not None}
     has_deprecation = any(c.parent_id in dep_parent_ids for c in top_n if c.parent_id is not None)
 
+    # Extract facet counts from the main query only.  The deprecation query
+    # is filtered to docs/solutions/articles, so its facets would
+    # misrepresent the full corpus distribution.
+    facets = _extract_facet_counts(main_data)
+
     logger.info(
         "Portal search: query=%r main=%d dep=%d merged=%d deduped=%d returned=%d",
         query,
@@ -592,7 +632,7 @@ async def _run_portal_search(
         len(top_n),
     )
 
-    return top_n, has_deprecation
+    return top_n, has_deprecation, facets
 
 
 # ---------------------------------------------------------------------------
@@ -620,6 +660,34 @@ _KIND_LABELS: dict[str, str] = {
     "Erratum": "Security Advisory",
     "access-drupal10-node-type-page": "Documentation",
 }
+
+# Labels for facet summary output.  Mirrors _KIND_LABELS but uses shorter
+# forms suitable for the compact "Result distribution:" line.
+_KIND_FACET_LABELS: dict[str, str] = {
+    "Cve": "CVE",
+    "Erratum": "Advisory",
+    "solution": "Solution",
+    "documentation": "Documentation",
+    "article": "Article",
+    "access-drupal10-node-type-page": "Documentation",
+}
+
+
+def _format_facet_summary(facets: dict[str, dict[str, int]]) -> str:
+    """Render ``documentKind`` facet counts as a compact one-liner for LLM context.
+
+    Produces a string like ``"Result distribution: 487 CVE, 3 Solution, 1 Documentation"``
+    sorted by descending count.  Returns an empty string when no ``documentKind``
+    facet data is available.
+    """
+    kind_counts = facets.get("documentKind", {})
+    if not kind_counts:
+        return ""
+    parts: list[str] = []
+    for kind, count in sorted(kind_counts.items(), key=lambda x: x[1], reverse=True):
+        label = _KIND_FACET_LABELS.get(kind, kind)
+        parts.append(f"{count} {label}")
+    return "Result distribution: " + ", ".join(parts)
 
 
 def _format_portal_chunk(chunk: PortalChunk) -> tuple[str, int]:
@@ -663,13 +731,15 @@ def _format_portal_results(
     has_deprecation: bool,
     query: str,
     max_response_chars: int,
+    facets: dict[str, dict[str, int]] | None = None,
 ) -> str:
     """Format all chunks into a final string response with budget enforcement.
 
     Renders each chunk via ``_format_portal_chunk()``, sorts by annotation
     priority (replacements first, EOL last), prepends a deprecation warning
-    banner if any chunk triggered deprecation detection, and enforces the
-    character budget via ``_select_within_budget()``.
+    banner if any chunk triggered deprecation detection, adds a facet
+    distribution summary when available, and enforces the character budget
+    via ``_select_within_budget()``.
     """
     if not chunks:
         return f"No results found for: {query}"
@@ -684,5 +754,11 @@ def _format_portal_results(
 
     if has_dep_annotation:
         output = _DEPRECATION_WARNING + output
+
+    # Prepend facet distribution summary so the LLM can see the overall
+    # result landscape (e.g. "mostly CVEs, few solutions").
+    facet_line = _format_facet_summary(facets) if facets else ""
+    if facet_line:
+        output = facet_line + "\n\n" + output
 
     return output

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -32,6 +32,12 @@ async def search_portal(
     answer directly without searching.
 
     IMPORTANT - interpreting results:
+    - The "Result distribution" line shows how many total documents matched per
+      category (e.g. "487 CVE, 3 Solution, 1 Documentation"). Use this to gauge
+      result quality: when one category dominates (especially CVEs), prioritize
+      results from underrepresented categories that better match the user's
+      question. Low counts across all categories means thin coverage; qualify
+      your answer accordingly.
     - Results marked 'Applicability: RHV only' apply to Red Hat Virtualization,
       NOT to standard RHEL KVM. Do not recommend RHV-only workarounds as the
       primary answer for RHEL questions.
@@ -47,13 +53,13 @@ async def search_portal(
     logger.info("search_portal: query=%r max_results=%d", query, max_results)
     try:
         app = get_app_context(ctx)
-        chunks, has_deprecation = await _run_portal_search(
+        chunks, has_deprecation, facets = await _run_portal_search(
             query,
             client=app.http_client,
             solr_endpoint=app.solr_endpoint,
             max_results=max_results,
         )
-        return _format_portal_results(chunks, has_deprecation, query, app.max_response_chars)
+        return _format_portal_results(chunks, has_deprecation, query, app.max_response_chars, facets=facets)
     except httpx.TimeoutException:
         logger.warning("Search timed out for query: %r", query, exc_info=True)
         return "The search timed out. Please try again with a simpler query."

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -9,6 +9,7 @@ from okp_mcp.portal import (
     _DEPRECATION_WARNING,
     _EOL_PRODUCTS,
     _FALLBACK_MAX_CHARS,
+    _KIND_FACET_LABELS,
     _KIND_LABELS,
     _MAIN_QF,
     PortalChunk,
@@ -17,8 +18,10 @@ from okp_mcp.portal import (
     _build_main_query,
     _deduplicate_by_parent,
     _docs_to_chunks,
+    _extract_facet_counts,
     _fallback_cve,
     _fallback_errata,
+    _format_facet_summary,
     _format_portal_chunk,
     _format_portal_results,
     _reciprocal_rank_fusion,
@@ -1115,7 +1118,7 @@ class TestRunPortalSearch:
             router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
 
             async with httpx.AsyncClient() as client:
-                chunks, _has_dep = await _run_portal_search(
+                chunks, _has_dep, _facets = await _run_portal_search(
                     "test query",
                     client=client,
                     solr_endpoint=_SOLR_ENDPOINT,
@@ -1133,7 +1136,7 @@ class TestRunPortalSearch:
         with respx.mock(assert_all_called=False) as router:
             router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=_make_solr_json(docs, hl)))
             async with httpx.AsyncClient() as client:
-                chunks, _ = await _run_portal_search(
+                chunks, _, _facets = await _run_portal_search(
                     "test",
                     client=client,
                     solr_endpoint=_SOLR_ENDPOINT,
@@ -1147,7 +1150,7 @@ class TestRunPortalSearch:
         with respx.mock(assert_all_called=False) as router:
             router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=_make_solr_json([])))
             async with httpx.AsyncClient() as client:
-                chunks, has_dep = await _run_portal_search(
+                chunks, has_dep, _facets = await _run_portal_search(
                     "nonexistent",
                     client=client,
                     solr_endpoint=_SOLR_ENDPOINT,
@@ -1155,3 +1158,222 @@ class TestRunPortalSearch:
 
         assert chunks == []
         assert has_dep is False
+
+    async def test_returns_facet_counts_from_main_query(self):
+        """Orchestrator extracts facet counts from the main query response."""
+        doc = _make_doc(doc_id="d1", kind="solution")
+        hl = {"d1": {"main_content": ["Solution snippet."]}}
+        solr_json = _make_solr_json([doc], hl)
+        solr_json["facet_counts"] = {
+            "facet_fields": {
+                "documentKind": ["solution", 3, "Cve", 487, "documentation", 1],
+            }
+        }
+
+        with respx.mock(assert_all_called=False) as router:
+
+            def side_effect(request):
+                """Return faceted response for main query, empty for deprecation."""
+                q = str(request.url.params.get("q", ""))
+                if "deprecated" in q:
+                    return httpx.Response(200, json=_make_solr_json([]))
+                return httpx.Response(200, json=solr_json)
+
+            router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
+
+            async with httpx.AsyncClient() as client:
+                _chunks, _has_dep, facets = await _run_portal_search(
+                    "test query",
+                    client=client,
+                    solr_endpoint=_SOLR_ENDPOINT,
+                )
+
+        assert facets == {"documentKind": {"solution": 3, "Cve": 487, "documentation": 1}}
+
+    async def test_empty_facets_when_solr_omits_facet_counts(self):
+        """Facets are empty when Solr response has no facet_counts key."""
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=_make_solr_json([])))
+            async with httpx.AsyncClient() as client:
+                _chunks, _has_dep, facets = await _run_portal_search(
+                    "test",
+                    client=client,
+                    solr_endpoint=_SOLR_ENDPOINT,
+                )
+
+        assert facets == {}
+
+
+# ---------------------------------------------------------------------------
+# Facet extraction
+# ---------------------------------------------------------------------------
+
+
+class TestExtractFacetCounts:
+    """Verify Solr facet field extraction from response JSON."""
+
+    def test_parses_alternating_list_format(self):
+        """Converts Solr's [value, count, value, count, ...] into a dict."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": ["Cve", 487, "solution", 3, "documentation", 1],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert result == {"documentKind": {"Cve": 487, "solution": 3, "documentation": 1}}
+
+    def test_drops_zero_count_entries(self):
+        """Facet values with zero count are excluded."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": ["Cve", 10, "article", 0, "solution", 5],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert "article" not in result["documentKind"]
+        assert result["documentKind"] == {"Cve": 10, "solution": 5}
+
+    def test_multiple_facet_fields(self):
+        """Multiple facet fields are extracted independently."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": ["Cve", 10],
+                    "product": ["Red Hat Enterprise Linux", 42],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert "documentKind" in result
+        assert "product" in result
+        assert result["product"] == {"Red Hat Enterprise Linux": 42}
+
+    def test_empty_facet_fields(self):
+        """All-zero facet values produce an empty dict for that field."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": ["Cve", 0, "solution", 0],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert result == {}
+
+    def test_missing_facet_counts_key(self):
+        """Response without facet_counts returns empty dict."""
+        result = _extract_facet_counts({"response": {"docs": []}})
+        assert result == {}
+
+    def test_missing_facet_fields_key(self):
+        """facet_counts without facet_fields returns empty dict."""
+        result = _extract_facet_counts({"facet_counts": {}})
+        assert result == {}
+
+    def test_odd_length_list_does_not_crash(self):
+        """Malformed odd-length facet list is handled without IndexError."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": ["Cve", 10, "solution"],  # trailing orphan
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        # The trailing "solution" without a count is safely skipped
+        assert result == {"documentKind": {"Cve": 10}}
+
+
+# ---------------------------------------------------------------------------
+# Facet summary formatting
+# ---------------------------------------------------------------------------
+
+
+class TestFormatFacetSummary:
+    """Verify compact facet summary rendering for LLM output."""
+
+    def test_basic_formatting(self):
+        """Facet counts are rendered as 'count Label' sorted by descending count."""
+        facets = {"documentKind": {"Cve": 487, "solution": 3, "documentation": 1}}
+        result = _format_facet_summary(facets)
+        assert result == "Result distribution: 487 CVE, 3 Solution, 1 Documentation"
+
+    def test_single_facet(self):
+        """Single document kind renders correctly."""
+        facets = {"documentKind": {"solution": 42}}
+        result = _format_facet_summary(facets)
+        assert result == "Result distribution: 42 Solution"
+
+    def test_uses_kind_facet_labels(self):
+        """Facet labels are mapped through _KIND_FACET_LABELS."""
+        facets = {"documentKind": {"Erratum": 15}}
+        result = _format_facet_summary(facets)
+        assert "15 Advisory" in result
+
+    def test_unknown_kind_uses_raw_value(self):
+        """Unknown document kinds fall through as-is."""
+        facets = {"documentKind": {"mystery_type": 7}}
+        result = _format_facet_summary(facets)
+        assert "7 mystery_type" in result
+
+    def test_empty_document_kind(self):
+        """Empty documentKind facet returns empty string."""
+        result = _format_facet_summary({"documentKind": {}})
+        assert result == ""
+
+    def test_no_document_kind_key(self):
+        """Missing documentKind key returns empty string."""
+        result = _format_facet_summary({"product": {"RHEL": 10}})
+        assert result == ""
+
+    def test_empty_facets(self):
+        """Empty facets dict returns empty string."""
+        result = _format_facet_summary({})
+        assert result == ""
+
+    def test_kind_facet_labels_cover_kind_labels(self):
+        """_KIND_FACET_LABELS covers all keys in _KIND_LABELS for consistency."""
+        for kind in _KIND_LABELS:
+            assert kind in _KIND_FACET_LABELS, f"{kind!r} missing from _KIND_FACET_LABELS"
+
+
+# ---------------------------------------------------------------------------
+# Facet summary in formatted results
+# ---------------------------------------------------------------------------
+
+
+class TestFormatPortalResultsWithFacets:
+    """Verify facet summary integration in _format_portal_results."""
+
+    def test_facet_summary_prepended(self):
+        """Facet summary appears before result content."""
+        chunks = [PortalChunk(doc_id="a", title="Doc A", chunk="Content A.", documentKind="documentation")]
+        facets = {"documentKind": {"documentation": 5, "Cve": 100}}
+        result = _format_portal_results(chunks, False, "test", 10000, facets=facets)
+        assert result.startswith("Result distribution:")
+        assert "Doc A" in result
+
+    def test_facet_before_deprecation_banner(self):
+        """Facet summary appears before the deprecation warning banner."""
+        chunks = [PortalChunk(doc_id="a", title="Test", chunk="Normal.", documentKind="documentation")]
+        facets = {"documentKind": {"documentation": 1}}
+        result = _format_portal_results(chunks, True, "test", 10000, facets=facets)
+        facet_pos = result.index("Result distribution:")
+        dep_pos = result.index("WARNING:")
+        assert facet_pos < dep_pos
+
+    def test_no_facets_no_summary(self):
+        """No facet line when facets is None."""
+        chunks = [PortalChunk(doc_id="a", title="Test", chunk="Content.", documentKind="documentation")]
+        result = _format_portal_results(chunks, False, "test", 10000)
+        assert "Result distribution:" not in result
+
+    def test_empty_facets_no_summary(self):
+        """No facet line when facets dict is empty."""
+        chunks = [PortalChunk(doc_id="a", title="Test", chunk="Content.", documentKind="documentation")]
+        result = _format_portal_results(chunks, False, "test", 10000, facets={})
+        assert "Result distribution:" not in result

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1287,6 +1287,54 @@ class TestExtractFacetCounts:
         # The trailing "solution" without a count is safely skipped
         assert result == {"documentKind": {"Cve": 10}}
 
+    def test_non_dict_facet_counts_returns_empty(self):
+        """Non-dict facet_counts value is treated as missing."""
+        result = _extract_facet_counts({"facet_counts": "unexpected"})
+        assert result == {}
+
+    def test_non_dict_facet_fields_returns_empty(self):
+        """Non-dict facet_fields value is treated as missing."""
+        result = _extract_facet_counts({"facet_counts": {"facet_fields": "bad"}})
+        assert result == {}
+
+    def test_non_list_pairs_skipped(self):
+        """Non-list facet pairs for a field are silently skipped."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": "not_a_list",
+                    "product": ["RHEL", 10],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert "documentKind" not in result
+        assert result == {"product": {"RHEL": 10}}
+
+    def test_non_string_value_skipped(self):
+        """Non-string facet values within pairs are skipped."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": [123, 10, "solution", 5],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert result == {"documentKind": {"solution": 5}}
+
+    def test_non_int_count_skipped(self):
+        """Non-integer count values within pairs are skipped."""
+        response = {
+            "facet_counts": {
+                "facet_fields": {
+                    "documentKind": ["Cve", "not_a_count", "solution", 5],
+                }
+            }
+        }
+        result = _extract_facet_counts(response)
+        assert result == {"documentKind": {"solution": 5}}
+
 
 # ---------------------------------------------------------------------------
 # Facet summary formatting
@@ -1334,6 +1382,12 @@ class TestFormatFacetSummary:
         """Empty facets dict returns empty string."""
         result = _format_facet_summary({})
         assert result == ""
+
+    def test_aliased_kinds_collapsed_into_single_label(self):
+        """Aliased kinds that share a label are aggregated into one entry."""
+        facets = {"documentKind": {"documentation": 5, "access-drupal10-node-type-page": 3, "Cve": 10}}
+        result = _format_facet_summary(facets)
+        assert result == "Result distribution: 10 CVE, 8 Documentation"
 
     def test_kind_facet_labels_cover_kind_labels(self):
         """_KIND_FACET_LABELS covers all keys in _KIND_LABELS for consistency."""


### PR DESCRIPTION
## Summary

- Parse `documentKind` facet counts from Solr responses (already returned by the server but previously discarded) and prepend a compact distribution summary to `search_portal` output
- Add guidance to the tool description so the LLM knows to prioritize underrepresented categories when one type dominates results, and to qualify answers when coverage is thin
- Guard against malformed odd-length facet lists from Solr

## What the LLM sees now

```text
Result distribution: 487 CVE, 3 Solution, 1 Documentation

**How to configure SSO on RHEL 9**
Type: Solution | Applicability: General
...
```

## Changes

| File | What changed |
|------|-------------|
| `src/okp_mcp/portal.py` | `_extract_facet_counts()`, `_format_facet_summary()`, `_KIND_FACET_LABELS`; updated `_run_portal_search()` return type (3-tuple); updated `_format_portal_results()` to accept and render facets |
| `src/okp_mcp/tools/search.py` | Unpack 3-tuple; pass facets to formatter; added facet interpretation guidance to tool docstring |
| `tests/test_portal.py` | 19 new tests covering extraction, formatting, integration, edge cases (odd-length lists, empty/missing facets); updated 3 existing orchestrator tests for new return type |

Partially addresses #144 (item 3).