### PR TITLE
RSPEED-2908: chore(tekton): update task bundles and remove coverity checks

### DIFF
--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -312,7 +312,7 @@ spec:
             value: build-image-index
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.2@sha256:c7b0f7e1f743040d99a3532abbdfddc9484f80fd559a75171c97499c3eb5d163
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b65a1e0961e0e768dda1f118bc5b5cab9c7ca7f4ed094e6a4352e66f82b9fa0b
 
           - name: kind
             value: task
@@ -364,7 +364,7 @@ spec:
             value: clair-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3@sha256:3fa03be0280f33d7070ea53f26d53e727199737a7a2b9a59a95071ae40a999ac
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:cd49cdea7e5403a87c4774bd8ea10bc4e6aeb83841ff490cbe42b782779513a7
 
           - name: kind
             value: task
@@ -455,7 +455,7 @@ spec:
             value: clamav-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3@sha256:9f18b216ce71a66909e7cb17d9b34526c02d73cf12884ba32d1f10614f7b9f5a
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3.1@sha256:171eca520b545a0c860c6d59249796ffe5db5be1dab87f3a328fc5ef1fd68af2
 
           - name: kind
             value: task
@@ -465,97 +465,6 @@ spec:
           operator: in
           values:
             - "false"
-
-    - name: coverity-availability-check
-      runAfter:
-        - build-image-index
-
-      taskRef:
-        resolver: bundles
-        params:
-          - name: name
-            value: coverity-availability-check
-
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-coverity-availability-check:0.2@sha256:c9b9301c442830eca3ad7d9d5287b082b94c38d406442f391447484147afd006
-
-          - name: kind
-            value: task
-
-      when:
-        - input: $(params.skip-checks)
-          operator: in
-          values:
-            - "false"
-
-    - name: sast-coverity-check
-      params:
-        - name: image-digest
-          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
-
-        - name: image-url
-          value: $(tasks.build-image-index.results.IMAGE_URL)
-
-        - name: IMAGE
-          value: $(params.output-image)
-
-        - name: DOCKERFILE
-          value: $(params.dockerfile)
-
-        - name: CONTEXT
-          value: $(params.path-context)
-
-        - name: HERMETIC
-          value: $(params.hermetic)
-
-        - name: PREFETCH_INPUT
-          value: $(params.prefetch-input)
-
-        - name: IMAGE_EXPIRES_AFTER
-          value: $(params.image-expires-after)
-
-        - name: COMMIT_SHA
-          value: $(tasks.clone-repository.results.commit)
-
-        - name: BUILD_ARGS
-          value:
-            - $(params.build-args[*])
-            - SOURCE_DATE_EPOCH=$(tasks.clone-repository.results.commit-timestamp)
-
-        - name: BUILD_ARGS_FILE
-          value: $(params.build-args-file)
-
-        - name: SOURCE_ARTIFACT
-          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
-
-        - name: CACHI2_ARTIFACT
-          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
-
-      runAfter:
-        - coverity-availability-check
-
-      taskRef:
-        resolver: bundles
-        params:
-          - name: name
-            value: sast-coverity-check-oci-ta
-
-          - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-coverity-check-oci-ta:0.3@sha256:e8c63570f1d01d70b2a21b22a2a4aad9ca7d5c0327d8b2a4058a6e616cce17ca
-
-          - name: kind
-            value: task
-
-      when:
-        - input: "true"
-          operator: in
-          values:
-            - "false"
-
-        - input: $(tasks.coverity-availability-check.results.STATUS)
-          operator: in
-          values:
-            - success
 
     - name: sast-shell-check
       params:


### PR DESCRIPTION
## Summary

Ref: [RSPEED-2908](https://redhat.atlassian.net/browse/RSPEED-2908)

- Update three Tekton task bundles to latest versions (verified via skopeo registry inspection):
  - `build-image-index`: 0.2 -> 0.3
  - `clair-scan`: 0.3 -> 0.3.2
  - `clamav-scan`: 0.3 -> 0.3.1
- Remove `coverity-availability-check` and `sast-coverity-check` tasks from the pipeline (no longer required)

Pipeline goes from 17 tasks to 15. All remaining 15 task bundles are at their latest versions.

[RSPEED-2908]: https://redhat.atlassian.net/browse/RSPEED-2908?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ