### PR TITLE
fix(openshift): update container image to production registry

### DIFF
--- a/openshift/okp-mcp.yml
+++ b/openshift/okp-mcp.yml
@@ -105,7 +105,7 @@ parameters:
   - name: IMAGE
     displayName: Container Image
     description: The container image to deploy.
-    value: quay.io/redhat-user-workloads/rhel-lightspeed-tenant/okp-mcp
+    value: quay.io/redhat-services-prod/rhel-lightspeed-tenant/okp-mcp
     required: true
   - name: IMAGE_TAG
     displayName: Image Tag


### PR DESCRIPTION
## Summary

- Update OpenShift deployment template to use the production Konflux registry (`redhat-services-prod`) instead of the old user workloads registry (`redhat-user-workloads`)