### PR TITLE
docs: add podman quadlet files for systemd-managed local deployment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,12 @@ docs/
   SOLR_EXPLORATION.md     # Historical: original redhat-okp container schema map
 openshift/
   okp-mcp.yml   # OpenShift deployment template (Deployment, Service, ServiceAccount)
+quadlet/
+  okp.network          # shared podman network for container DNS resolution
+  okp-solr-data.volume # persistent Solr index volume
+  okp-solr.container   # OKP Solr search engine (rootless quadlet)
+  okp-mcp.container    # OKP MCP server (rootless quadlet, depends on Solr)
+  README.md            # quadlet install, usage, management, troubleshooting
 ```
 
 ## Where to Look
@@ -98,6 +104,7 @@ openshift/
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |
+| Run locally with systemd | `quadlet/` | Rootless quadlet files: `.container`, `.network`, `.volume`; see `quadlet/README.md` |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 
 ## Boot Sequence

--- a/README.md
+++ b/README.md
@@ -107,6 +107,10 @@ You should see a response with `serverInfo.name: "RHEL OKP Knowledge Base"`.
 podman pod rm -f okp
 ```
 
+### Alternative: systemd quadlets
+
+For a systemd-managed setup with automatic restart, boot persistence, and journald logging, see [`quadlet/README.md`](quadlet/README.md).
+
 ### Alternative: podman-compose
 
 A `podman-compose.yml` is included for development use. It builds from source and is useful for local iteration, but note that `podman-compose` is not supported on RHEL.

--- a/quadlet/README.md
+++ b/quadlet/README.md
@@ -1,0 +1,166 @@
+# Running OKP with systemd quadlets
+
+Podman quadlet files that run the OKP Solr index and MCP server as rootless systemd services. This gives you automatic restart on failure, journald logging, and start-at-login with no manual `podman run` commands.
+
+## Prerequisites
+
+- Podman 4.4+ (quadlet support)
+- Authenticated to `registry.redhat.io` (`podman login registry.redhat.io`)
+- An OKP access key from <https://access.redhat.com/offline/access>
+
+## Setup
+
+### 1. Create the environment file
+
+The Solr container reads its access key from a file rather than embedding it in the quadlet:
+
+```bash
+mkdir -p ~/.config/okp-mcp
+cat > ~/.config/okp-mcp/solr.env << 'EOF'
+ACCESS_KEY=<your-access-key>
+EOF
+chmod 600 ~/.config/okp-mcp/solr.env
+```
+
+### 2. Install the quadlet files
+
+Copy all quadlet files into a subdirectory under the rootless systemd path:
+
+```bash
+mkdir -p ~/.config/containers/systemd/okp-mcp
+cp quadlet/*.{container,network,volume} ~/.config/containers/systemd/okp-mcp/
+```
+
+### 3. Reload and start
+
+Tell systemd to pick up the new quadlet files, then start the MCP server (which pulls in Solr automatically via its dependency):
+
+```bash
+systemctl --user daemon-reload
+systemctl --user start okp-mcp
+```
+
+The first start pulls the Solr image (~10 GB) and indexes content. This takes several minutes. Watch progress with:
+
+```bash
+journalctl --user -xeu okp-solr -f
+```
+
+Wait until you see `Started Solr server on port 8983`.
+
+### 4. Verify
+
+Confirm Solr has data:
+
+```bash
+curl -s "http://localhost:8983/solr/portal/select?q=*:*&rows=0" | python3 -m json.tool
+```
+
+You should see `numFound` with a large number of documents (600k+).
+
+Confirm the MCP server responds:
+
+```bash
+curl -s -N -X POST http://localhost:8000/mcp \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc": "2.0", "method": "initialize", "params": {"protocolVersion": "2025-11-25", "capabilities": {}, "clientInfo": {"name": "test", "version": "1.0"}}, "id": 1}'
+```
+
+You should see a response with `serverInfo.name: "RHEL OKP Knowledge Base"`.
+
+## Management
+
+Start/stop both containers (dependency ordering is automatic):
+
+```bash
+systemctl --user start okp-mcp
+systemctl --user stop okp-mcp
+```
+
+The quadlet files include `[Install] WantedBy=default.target`, so both services start automatically when you log in. No `systemctl enable` is needed for quadlet-generated units.
+
+To keep services running after logout (and start them at boot without logging in), enable lingering:
+
+```bash
+loginctl enable-linger "$USER"
+```
+
+View logs:
+
+```bash
+journalctl --user -xeu okp-solr
+journalctl --user -xeu okp-mcp
+```
+
+Check status:
+
+```bash
+systemctl --user status okp-solr okp-mcp
+```
+
+## Automatic image updates
+
+The MCP server container is configured with `AutoUpdate=registry`. To enable periodic checks for new images, start the podman auto-update timer:
+
+```bash
+systemctl --user enable --now podman-auto-update.timer
+```
+
+Without this timer, the auto-update label is present but nothing triggers it.
+
+## Troubleshooting
+
+### Dry-run the quadlet generator
+
+If the services don't appear after `daemon-reload`, verify the generator can parse the quadlet files:
+
+```bash
+/usr/lib/systemd/system-generators/podman-system-generator --user --dryrun
+```
+
+This prints the generated unit files or errors explaining what went wrong.
+
+### Service won't start
+
+Check the full journal output for the failing service:
+
+```bash
+journalctl --user -xeu okp-solr --no-pager
+```
+
+Common issues:
+- Missing `~/.config/okp-mcp/solr.env` (create it per step 1)
+- Not logged into `registry.redhat.io` (`podman login registry.redhat.io`)
+- Port conflict on 8983 or 8000 (stop any existing Solr or MCP containers)
+
+## Cleanup
+
+Stop the services:
+
+```bash
+systemctl --user stop okp-solr okp-mcp
+```
+
+Remove the quadlet files and reload:
+
+```bash
+rm -r ~/.config/containers/systemd/okp-mcp
+systemctl --user daemon-reload
+```
+
+Optionally remove the Solr data volume and environment file:
+
+```bash
+podman volume rm okp-solr-data
+rm -r ~/.config/okp-mcp
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `okp.network` | Shared podman network for container DNS resolution |
+| `okp-solr-data.volume` | Persistent storage for the Solr search index |
+| `okp-solr.container` | OKP Solr search engine |
+| `okp-mcp.container` | OKP MCP server (depends on Solr) |

--- a/quadlet/okp-mcp.container
+++ b/quadlet/okp-mcp.container
@@ -1,0 +1,22 @@
+# OKP MCP server (connects to Solr over the shared network).
+
+[Unit]
+Description=OKP MCP server
+After=okp-solr.service
+Requires=okp-solr.service
+
+[Container]
+Image=quay.io/redhat-user-workloads/rhel-lightspeed-tenant/okp-mcp:latest
+ContainerName=okp-mcp
+Network=okp.network
+PublishPort=8000:8000
+
+Environment=MCP_TRANSPORT=streamable-http
+Environment=MCP_SOLR_URL=http://okp-solr:8983
+AutoUpdate=registry
+
+[Service]
+Restart=on-failure
+
+[Install]
+WantedBy=default.target

--- a/quadlet/okp-solr-data.volume
+++ b/quadlet/okp-solr-data.volume
@@ -1,0 +1,5 @@
+# Persistent storage for the Solr search index.
+# Survives container restarts and upgrades.
+
+[Volume]
+VolumeName=okp-solr-data

--- a/quadlet/okp-solr.container
+++ b/quadlet/okp-solr.container
@@ -1,0 +1,25 @@
+# Red Hat OKP Solr search engine.
+# First start pulls ~10 GB and takes several minutes to index.
+
+[Unit]
+Description=OKP Solr search engine
+
+[Container]
+Image=registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:latest
+ContainerName=okp-solr
+Network=okp.network
+PublishPort=8983:8983
+Volume=okp-solr-data.volume:/opt/solr/server/solr/portal/data
+
+Environment=SOLR_JETTY_HOST=0.0.0.0
+EnvironmentFile=%h/.config/okp-mcp/solr.env
+
+# Graceful shutdown window before forcible stop.
+PodmanArgs=--stop-timeout=30
+
+[Service]
+Restart=on-failure
+TimeoutStartSec=600
+
+[Install]
+WantedBy=default.target

--- a/quadlet/okp.network
+++ b/quadlet/okp.network
@@ -1,0 +1,5 @@
+# Shared network for OKP containers.
+# Containers on this network resolve each other by ContainerName via DNS.
+
+[Network]
+NetworkName=okp


### PR DESCRIPTION
## Summary

- Add rootless podman quadlet files (`quadlet/`) as a declarative alternative to the manual `podman pod create` + `podman run` workflow from #189
- Containers communicate via a shared network with DNS name resolution (not a pod)
- MCP server image pulls from quay.io with `AutoUpdate=registry` support
- Solr access key stays out of quadlet files via `EnvironmentFile=`
- `quadlet/README.md` covers setup, management, auto-updates, lingering, troubleshooting, and cleanup

## Files

| File | Purpose |
|------|---------|
| `quadlet/okp.network` | Shared podman network for container DNS |
| `quadlet/okp-solr-data.volume` | Persistent Solr index storage |
| `quadlet/okp-solr.container` | OKP Solr search engine |
| `quadlet/okp-mcp.container` | OKP MCP server (depends on Solr) |
| `quadlet/README.md` | Install, usage, and troubleshooting docs |
| `README.md` | Added link to quadlet README in "Running Locally" |
| `AGENTS.md` | Added quadlet/ to project layout and lookup table |