### PR TITLE
ci: add OpenSSF Scorecard, security policy, and workflow permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches: [main, 'release/**']
 
+permissions: read-all
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -6,6 +6,8 @@ on:
     workflows: [CI/CD]
     types: [completed]
 
+permissions: read-all
+
 env:
   OKP_IMAGE_TAG: '1.1.9-1775158501'
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Weekly Monday 6am UTC (1am CT)
+
+permissions: read-all
+
+jobs:
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          persist-credentials: false
+
+      - name: Run Scorecard analysis
+        uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@95e58e9a2cdfd71adc6e0353d5c52f41a045d225 # v4.35.2
+        with:
+          sarif_file: results.sarif

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,6 +77,12 @@ tests/
   test_functional.py   # functional test runner: calls _run_portal_search() against live Solr, asserts on PortalChunk results
   test_portal.py       # portal.py unit tests: query builders, chunk conversion, RRF, formatting, single/multi-query orchestrators
   test_*.py            # unit test modules mirror src structure
+.github/
+  CODEOWNERS               # PR review assignment (@rhel-lightspeed/developers)
+  workflows/
+    build.yml              # CI/CD: lint, typecheck, radon, pytest matrix, container build+push
+    functional.yml         # Functional tests against live Solr (triggered after build.yml)
+    scorecard.yml          # OpenSSF Scorecard: security posture, weekly + push-to-main
 docs/
   SOLR_EXPLORATION.md     # Historical: original redhat-okp container schema map
 openshift/
@@ -87,6 +93,7 @@ quadlet/
   okp-solr.container   # OKP Solr search engine (rootless quadlet)
   okp-mcp.container    # OKP MCP server (rootless quadlet, depends on Solr)
   README.md            # quadlet install, usage, management, troubleshooting
+SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 ```
 
 ## Where to Look
@@ -105,6 +112,7 @@ quadlet/
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |
 | Run locally with systemd | `quadlet/` | Rootless quadlet files: `.container`, `.network`, `.volume`; see `quadlet/README.md` |
+| Modify CI/CD workflows | `.github/workflows/` | `build.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 
 ## Boot Sequence

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # okp-mcp
 
+[![CI](https://github.com/rhel-lightspeed/okp-mcp/actions/workflows/build.yml/badge.svg)](https://github.com/rhel-lightspeed/okp-mcp/actions/workflows/build.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/rhel-lightspeed/okp-mcp/badge)](https://scorecard.dev/viewer/?uri=github.com/rhel-lightspeed/okp-mcp)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![Python: 3.12+](https://img.shields.io/badge/Python-3.12%2B-blue.svg)](https://www.python.org/)
+
 MCP server for the Red Hat Offline Knowledge Portal (OKP). Bridges LLM tool calls to the OKP Solr index so agents can search RHEL documentation, CVEs, errata, solutions, and articles.
 
 ## Quickstart

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest release is supported with security updates.
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately using
+[GitHub's security advisory feature](https://github.com/rhel-lightspeed/okp-mcp/security/advisories/new).
+
+Do not open a public issue for security vulnerabilities.
+
+You should expect an initial response within 72 hours. If accepted, a fix will
+be released as soon as practical.


### PR DESCRIPTION
## Summary

- Add `scorecard.yml` workflow: runs on push to main + weekly Monday 6am UTC, publishes SARIF to code scanning with 5-day artifact retention
- Add `SECURITY.md` with private vulnerability reporting via GitHub security advisories
- Add top-level `permissions: read-all` to `build.yml` and `functional.yml` to restrict default token permissions

All three changes target specific [OpenSSF Scorecard](https://scorecard.dev/) checks: Security-Policy and Token-Permissions.