### PR TITLE
ci: add pre-commit hooks for lint, secrets, and whitespace enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,9 +195,9 @@ cython_debug/
 .abstra/
 
 # Visual Studio Code
-#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore 
+#   Visual Studio Code specific template is maintained in a separate VisualStudioCode.gitignore
 #   that can be found at https://github.com/github/gitignore/blob/main/Global/VisualStudioCode.gitignore
-#   and can be added to the global gitignore or merged into this file. However, if you prefer, 
+#   and can be added to the global gitignore or merged into this file. However, if you prefer,
 #   you could uncomment the following to ignore the entire vscode folder
 # .vscode/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.11
+    rev: v0.15.11
     hooks:
       - id: ruff
         args: [--fix]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.11.11
+    hooks:
+      - id: ruff
+        args: [--fix]
+
+      - id: ruff-format
+        args: [--diff]
+
+      - id: ruff-format
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.23.1
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: check-toml
+      - id: check-yaml
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,12 +19,24 @@ uv run okp-mcp --transport streamable-http --port 8000  # explicit HTTP mode
 
 ```bash
 make ci          # full suite: lint + typecheck + radon + test
+make setup       # install deps + pre-commit hooks
 make lint        # ruff check src/ tests/
 make format      # ruff format src/ tests/
 make typecheck   # ty check src/
 make radon       # cyclomatic complexity gate (A/B only, C+ fails)
 make test        # pytest with coverage
 ```
+
+## Pre-commit Hooks
+
+Install with `pre-commit install` (or `make setup`). Hooks run automatically on `git commit`:
+
+- **ruff** (lint + format): Auto-fixes lint issues and enforces formatting
+- **gitleaks**: Blocks commits containing secrets or credentials
+- **trailing-whitespace**: Strips trailing spaces (preserves markdown line breaks)
+- **end-of-file-fixer**: Ensures files end with a newline
+- **check-toml / check-yaml**: Validates config file syntax
+- **check-merge-conflict**: Catches unresolved merge conflict markers
 
 ## Running Tests
 
@@ -79,6 +91,7 @@ tests/
   test_functional.py   # functional test runner: calls _run_portal_search() against live Solr, asserts on PortalChunk results
   test_portal.py       # portal.py unit tests: query builders, chunk conversion, RRF, formatting, single/multi-query orchestrators
   test_*.py            # unit test modules mirror src structure
+.pre-commit-config.yaml  # pre-commit hook definitions (ruff, gitleaks, whitespace, YAML/TOML checks)
 .github/
   CODEOWNERS               # PR review assignment (@rhel-lightspeed/developers)
   workflows/
@@ -115,6 +128,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |
 | Run locally with systemd | `quadlet/` | Rootless quadlet files: `.container`, `.network`, `.volume`; see `quadlet/README.md` |
+| Modify pre-commit hooks | `.pre-commit-config.yaml` | Runs on every commit: ruff, gitleaks, whitespace, YAML/TOML checks |
 | Modify CI/CD workflows | `.github/workflows/` | `build.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format typecheck radon test ci
+.PHONY: lint format typecheck radon test ci setup
 
 lint:
 	uv run ruff check src/ tests/
@@ -18,3 +18,7 @@ test:
 	uv run pytest -v --cov=okp_mcp --cov-report=term-missing
 
 ci: lint typecheck radon test
+
+setup:
+	uv sync --group dev
+	pre-commit install

--- a/README.md
+++ b/README.md
@@ -129,10 +129,11 @@ OKP_ACCESS_KEY=<your-access-key> podman-compose up -d
 
 ## Development
 
-Install dev dependencies:
+Install dev dependencies and pre-commit hooks:
 
 ```
 uv sync --group dev
+pre-commit install
 ```
 
 Run the full CI suite locally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,3 @@ select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "SIM", "TID252"]
 
 [tool.ty.environment]
 python-version = "3.12"
-


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with hooks: ruff (lint+format), gitleaks (secret detection), trailing-whitespace, end-of-file-fixer, check-toml, check-yaml, check-merge-conflict
- Add `make setup` target for one-step dev environment setup (`uv sync --group dev` + `pre-commit install`)
- Update README Development section with `pre-commit install` instruction
- Update AGENTS.md with Pre-commit Hooks section, project layout entry, and "Where to Look" row
- Fix pre-existing trailing whitespace in `.gitignore` and extra blank lines in `pyproject.toml` (caught by the new hooks)

Hook set matches the pattern used across `digital-roadmap-backend`, `docs2db`, and `codex`.