### PR TITLE
feat: add Prometheus metrics for HTTP, tool, and Solr instrumentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -60,6 +60,7 @@ src/okp_mcp/
   config.py      # ServerConfig (pydantic BaseSettings, MCP_* env vars)
   server.py      # FastMCP instance (single `mcp` object), AppContext, lifespan
   request_id.py  # Request ID context vars, FastMCP middleware, Starlette header middleware, logging filter
+  metrics.py     # Prometheus metrics: counters, histograms, /metrics endpoint, ASGI middleware
   intent.py      # Intent detection: IntentRule dataclass, INTENT_RULES registry, boost application
   portal.py      # Unified portal search: query builders, chunk conversion, RRF, single/multi-query orchestrators, formatting
   tools/
@@ -102,6 +103,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 |------|----------|-------|
 | Add a new MCP tool | `src/okp_mcp/tools/` | Add `@mcp.tool` async function in the relevant module and re-export it from `tools/__init__.py` |
 | Change request ID propagation or response headers | `src/okp_mcp/request_id.py`, `src/okp_mcp/__init__.py`, `src/okp_mcp/server.py` | `RequestIDContextMiddleware` mirrors FastMCP request IDs into logs, `RequestIDHeaderMiddleware` adds `X-Request-ID` to HTTP/SSE responses |
+| Add/modify Prometheus metrics | `src/okp_mcp/metrics.py` | Counters, histograms, `PrometheusMiddleware` ASGI class, `/metrics` custom route |
 | Add/modify intent detection | `src/okp_mcp/intent.py` | Append `IntentRule` to `INTENT_RULES` at the correct priority position |
 | Change portal search logic | `src/okp_mcp/portal.py` | Query builders, chunk conversion, RRF fusion, single/multi-query orchestrators, formatting |
 | Change Solr query logic | `src/okp_mcp/solr.py` | `_solr_query()` builds edismax params; `_clean_query()` for tokenization |
@@ -128,23 +130,25 @@ uv run okp-mcp [--transport ...] [--port ...]
             → server.py: _app_lifespan()
                 ├─ creates shared httpx.AsyncClient
                 └─ yields AppContext(...)
+            → metrics.py: registers /metrics custom_route + PrometheusMiddleware
             → tools/__init__.py: imports tool modules for @mcp.tool registration
 ```
 
 ## Module Dependencies
 
 ```text
-__init__.py → build_info, config, request_id, server, tools (side-effect import)
+__init__.py → build_info, config, metrics (side-effect import), request_id, server, tools (side-effect import)
 build_info.py → (standalone, reads ./COMMIT_SHA file)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
-tools/search.py → config, portal, server
-tools/document.py → content, server, solr, tools/shared.py
+tools/search.py → config, metrics, portal, server
+tools/document.py → content, metrics, server, solr, tools/shared.py
 tools/run_code.py → config, server
+metrics.py  → server (imports mcp for custom_route)
 request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starlette
 intent.py   → config
 portal.py   → config, content, formatting, intent, solr
 formatting.py → content, solr
-solr.py     → config
+solr.py     → config, metrics
 server.py   → config
 content.py  → (standalone)
 ```

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,11 +161,11 @@ No circular imports. `content.py` has zero internal dependencies.
 - **Target**: Python 3.12+ (CI tests 3.12, 3.13, 3.14)
 - **Line length**: 120 characters
 - **Formatter**: ruff format
-- **Linter**: ruff check with rules: E, F, W, I (isort), UP, S (security), B (bugbear), A, C4, SIM
+- **Linter**: ruff check with rules: E, F, W, I (isort), UP, S (security), B (bugbear), A, C4, SIM, TID252 (ban relative imports)
 
 ### Imports
 - Order: stdlib, third-party, first-party (enforced by ruff `I` rule)
-- **Never use relative imports.** Always use absolute imports with the full package name (`from okp_mcp.config import ServerConfig`, not `from .config import ServerConfig`)
+- **ZERO relative imports.** Always use absolute imports with the full package name (`from okp_mcp.config import ServerConfig`, not `from .config import ServerConfig`). This is enforced by ruff rule `TID252` and will fail CI.
 - Side-effect imports get a `noqa` comment explaining why:
   ```python
   from okp_mcp import tools as _tools  # noqa: F401 -- triggers @mcp.tool registration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ requires-python = ">=3.12"
 dependencies = [
     "fastmcp>=3.2.4",
     "httpx",
+    "prometheus_client>=0.21",
     "pydantic-settings>=2.13.1",
     "rank-bm25",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "SIM"]
+select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "SIM", "TID252"]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S104"]

--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -3,11 +3,14 @@
 import logging
 
 from pydantic_settings import CliApp
+from starlette.middleware import Middleware as StarletteMiddleware
 
+from okp_mcp import metrics as _metrics  # noqa: F401 -- import registers @mcp.custom_route("/metrics")
 from okp_mcp import server as _server
-from okp_mcp import tools as _tools  # noqa: F401 — import triggers @mcp.tool registration
+from okp_mcp import tools as _tools  # noqa: F401 -- import triggers @mcp.tool registration
 from okp_mcp.build_info import get_commit_sha, get_package_version
 from okp_mcp.config import ServerConfig
+from okp_mcp.metrics import PrometheusMiddleware
 from okp_mcp.request_id import RequestIDLogFilter, build_http_request_id_middleware
 from okp_mcp.server import mcp
 
@@ -49,11 +52,13 @@ def main() -> None:
     logger.info("Starting MCP server with transport=%s", config.transport)
 
     if config.transport in ("sse", "streamable-http"):
+        http_middleware = build_http_request_id_middleware()
+        http_middleware.insert(0, StarletteMiddleware(PrometheusMiddleware))
         mcp.run(
             transport=config.transport,
             host=config.host,
             port=config.port,
-            middleware=build_http_request_id_middleware(),
+            middleware=http_middleware,
         )
     else:
         mcp.run(transport="stdio")

--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -1,0 +1,101 @@
+"""Prometheus metrics, HTTP middleware, and /metrics scrape endpoint for the OKP MCP server."""
+
+import time
+
+from prometheus_client import CONTENT_TYPE_LATEST as _CONTENT_TYPE  # noqa: N812 -- upstream naming
+from prometheus_client import Counter, Histogram, generate_latest
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+from okp_mcp.server import mcp
+
+# ---------------------------------------------------------------------------
+# HTTP-level metrics (recorded by PrometheusMiddleware)
+# ---------------------------------------------------------------------------
+HTTP_REQUESTS = Counter(
+    "okp_http_requests_total",
+    "Total HTTP requests received by the MCP server",
+    ["method", "status"],
+)
+HTTP_REQUEST_DURATION = Histogram(
+    "okp_http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "status"],
+)
+
+# ---------------------------------------------------------------------------
+# MCP tool metrics (recorded by tool instrumentation in tools/)
+# ---------------------------------------------------------------------------
+TOOL_CALLS = Counter(
+    "okp_tool_calls_total",
+    "Total MCP tool invocations",
+    ["tool"],
+)
+TOOL_DURATION = Histogram(
+    "okp_tool_duration_seconds",
+    "MCP tool execution duration in seconds",
+    ["tool"],
+)
+
+# ---------------------------------------------------------------------------
+# Solr backend metrics (recorded by solr.py instrumentation)
+# ---------------------------------------------------------------------------
+SOLR_QUERIES = Counter(
+    "okp_solr_queries_total",
+    "Total Solr queries executed",
+    ["status"],
+)
+SOLR_QUERY_DURATION = Histogram(
+    "okp_solr_query_duration_seconds",
+    "Solr query round-trip duration in seconds",
+    ["status"],
+)
+
+
+class PrometheusMiddleware:
+    """ASGI middleware that records HTTP request count and duration."""
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Wrap the downstream ASGI application."""
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Track request metrics for HTTP connections, pass through everything else."""
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        method = scope.get("method", "UNKNOWN")
+        start = time.monotonic()
+        status_code = 500
+        recorded = False
+
+        async def send_wrapper(message: Message) -> None:
+            nonlocal status_code, recorded
+            if message["type"] == "http.response.start":
+                status_code = message.get("status", 500)
+                # Record TTFB so SSE/streaming connections don't inflate the histogram
+                # with full connection lifetime.
+                if not recorded:
+                    duration = time.monotonic() - start
+                    HTTP_REQUESTS.labels(method=method, status=str(status_code)).inc()
+                    HTTP_REQUEST_DURATION.labels(method=method, status=str(status_code)).observe(duration)
+                    recorded = True
+            await send(message)
+
+        try:
+            await self.app(scope, receive, send_wrapper)
+        finally:
+            # Fallback for cases where headers never sent (e.g. app crash before response).
+            if not recorded:
+                duration = time.monotonic() - start
+                HTTP_REQUESTS.labels(method=method, status=str(status_code)).inc()
+                HTTP_REQUEST_DURATION.labels(method=method, status=str(status_code)).observe(duration)
+
+
+@mcp.custom_route("/metrics", methods=["GET"])
+async def metrics_endpoint(request: Request) -> Response:
+    """Expose Prometheus metrics for scraping."""
+    del request
+    return Response(content=generate_latest(), media_type=_CONTENT_TYPE)

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -1,11 +1,13 @@
 """SOLR client and query utilities."""
 
 import re
+import time
 
 import httpx
 from rank_bm25 import BM25Plus  # pyright: ignore[reportMissingImports]
 
 from okp_mcp.config import STOP_WORDS, logger
+from okp_mcp.metrics import SOLR_QUERIES, SOLR_QUERY_DURATION
 
 
 def _split_quoted_and_plain(text: str) -> list[str]:
@@ -106,6 +108,7 @@ def _clean_query(query: str) -> str:
 
 async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, solr_endpoint: str) -> dict:
     """Execute a SOLR query and return the parsed JSON response."""
+    _start = time.monotonic()
     close_client = client is None
     if client is None:
         client = httpx.AsyncClient(timeout=30.0)
@@ -172,35 +175,48 @@ async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, 
     }
     base_params.update(params)
     logger.info("SOLR query: q=%r, fq=%r", params.get("q"), params.get("fq"))
+    _solr_status = "success"
     try:
         response = await client.get(solr_endpoint, params=base_params)
         response.raise_for_status()
         data = response.json()
     except httpx.TimeoutException:
-        logger.warning("SOLR query timed out after 30s")
+        _solr_status = "timeout"
+        SOLR_QUERIES.labels(status="timeout").inc()
+        logger.warning("SOLR query timed out after 30s", exc_info=True)
         raise
     except httpx.HTTPStatusError as e:
-        logger.error("SOLR returned HTTP %d: %s", e.response.status_code, e.response.text[:200])
+        _solr_status = "error"
+        SOLR_QUERIES.labels(status="error").inc()
+        logger.exception("SOLR returned HTTP %d: %s", e.response.status_code, e.response.text[:200])
         raise
     except httpx.RequestError as e:
-        logger.error("SOLR connection error: %s", e)
+        _solr_status = "error"
+        SOLR_QUERIES.labels(status="error").inc()
+        logger.exception("SOLR connection error: %s", e)
         raise
     except ValueError as e:
-        logger.error("SOLR returned non-JSON response: %s", e)
+        _solr_status = "error"
+        SOLR_QUERIES.labels(status="error").inc()
+        logger.exception("SOLR returned non-JSON response: %s", e)
         raise
     finally:
+        SOLR_QUERY_DURATION.labels(status=_solr_status).observe(time.monotonic() - _start)
         if close_client:
             await client.aclose()
 
     _empty_response = {"response": {"numFound": 0, "docs": []}, "highlighting": {}}
 
     if "error" in data:
+        SOLR_QUERIES.labels(status="error").inc()
         logger.error("SOLR returned error: %s", data["error"])
         return _empty_response
     if "response" not in data or not isinstance(data.get("response", {}).get("docs"), list):
+        SOLR_QUERIES.labels(status="error").inc()
         logger.error("SOLR returned unexpected structure: %s", list(data.keys()))
         return _empty_response
 
+    SOLR_QUERIES.labels(status="success").inc()
     num_found = data["response"]["numFound"]
     num_docs = len(data["response"]["docs"])
     logger.info("SOLR query matched %d total, returning %d docs", num_found, num_docs)

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -1,12 +1,14 @@
 """Document retrieval MCP tool and supporting helpers."""
 
 import logging
+import time
 from urllib.parse import urlsplit
 
 import httpx
 from fastmcp import Context
 
 from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate, truncate_content
+from okp_mcp.metrics import TOOL_CALLS, TOOL_DURATION
 from okp_mcp.server import get_app_context, mcp
 from okp_mcp.solr import _clean_query, _extract_relevant_section, _get_highlight_snippets, _solr_query
 from okp_mcp.tools.shared import DOCUMENT_FL
@@ -222,6 +224,9 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
     Use the URL from search results as doc_id. Pass query (the original
     search question) to get BM25-scored relevant passages instead of raw truncated content.
     """
+    TOOL_CALLS.labels(tool="get_document").inc()
+    _start = time.monotonic()
+
     doc_id = _normalize_doc_id(doc_id)
     logger.info("get_document: doc_id=%r query=%r", doc_id, query)
     try:
@@ -244,3 +249,5 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
     except (httpx.HTTPError, ValueError):
         logger.exception("get_document failed for doc_id=%r query=%r", doc_id, query)
         return f"Unable to fetch document {doc_id}. The knowledge base may be temporarily unavailable."
+    finally:
+        TOOL_DURATION.labels(tool="get_document").observe(time.monotonic() - _start)

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -1,10 +1,12 @@
 """Portal search MCP tool."""
 
 import logging
+import time
 
 import httpx
 from fastmcp import Context
 
+from okp_mcp.metrics import TOOL_CALLS, TOOL_DURATION
 from okp_mcp.portal import _MAX_QUERIES, _format_portal_results, _run_multi_query_search, _run_portal_search
 from okp_mcp.server import get_app_context, mcp
 
@@ -94,17 +96,20 @@ async def search_portal(
     - When results list specific releases or dates (e.g. EUS availability per
       minor release), enumerate every release explicitly in your answer.
     """
-    normalized = _normalize_queries(query)
-    if isinstance(normalized, str):
-        return normalized  # validation error message
-    # Cap at _MAX_QUERIES to bound Solr load (research shows diminishing
-    # returns past 3 queries).
-    queries = normalized[:_MAX_QUERIES]
-
-    max_results = max(1, min(max_results, 20))
-    logger.info("search_portal: queries=%r max_results=%d", queries, max_results)
+    TOOL_CALLS.labels(tool="search_portal").inc()
+    _start = time.monotonic()
 
     try:
+        normalized = _normalize_queries(query)
+        if isinstance(normalized, str):
+            return normalized  # validation error message
+        # Cap at _MAX_QUERIES to bound Solr load (research shows diminishing
+        # returns past 3 queries).
+        queries = normalized[:_MAX_QUERIES]
+
+        max_results = max(1, min(max_results, 20))
+        logger.info("search_portal: queries=%r max_results=%d", queries, max_results)
+
         app = get_app_context(ctx)
 
         if len(queries) == 1:
@@ -134,3 +139,5 @@ async def search_portal(
     except ValueError:
         logger.exception("Search failed for queries: %r", queries)
         return "The knowledge base search returned an unexpected response. Please try again."
+    finally:
+        TOOL_DURATION.labels(tool="search_portal").observe(time.monotonic() - _start)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,277 @@
+"""Tests for Prometheus metrics, middleware, and /metrics endpoint."""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+import respx
+from prometheus_client import REGISTRY
+
+from okp_mcp.config import ServerConfig
+from okp_mcp.metrics import (
+    HTTP_REQUEST_DURATION,
+    HTTP_REQUESTS,
+    SOLR_QUERIES,
+    SOLR_QUERY_DURATION,
+    TOOL_CALLS,
+    TOOL_DURATION,
+    PrometheusMiddleware,
+    metrics_endpoint,
+)
+from okp_mcp.solr import _solr_query
+
+_SOLR_ENDPOINT = ServerConfig().solr_endpoint
+
+
+def _get_counter(name: str, labels: dict) -> float:
+    """Read the current value of a Prometheus counter, defaulting to 0."""
+    return REGISTRY.get_sample_value(f"{name}_total", labels) or 0.0
+
+
+def _get_histogram_count(name: str, labels: dict | None = None) -> float:
+    """Read the sample count of a Prometheus histogram."""
+    return REGISTRY.get_sample_value(f"{name}_count", labels or {}) or 0.0
+
+
+# ---------------------------------------------------------------------------
+# PrometheusMiddleware
+# ---------------------------------------------------------------------------
+
+
+async def test_prometheus_middleware_records_http_request_counter():
+    """Middleware increments the request counter with method and status labels."""
+    sent: list[dict] = []
+
+    async def mock_app(scope, receive, send):
+        """Minimal ASGI app returning 200."""
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b"ok"})
+
+    async def mock_receive():
+        """Return an empty HTTP request body."""
+        return {"type": "http.request", "body": b""}
+
+    async def mock_send(message):
+        """Capture sent ASGI messages."""
+        sent.append(message)
+
+    before = _get_counter("okp_http_requests", {"method": "POST", "status": "200"})
+
+    middleware = PrometheusMiddleware(mock_app)
+    await middleware({"type": "http", "method": "POST", "path": "/mcp"}, mock_receive, mock_send)
+
+    after = _get_counter("okp_http_requests", {"method": "POST", "status": "200"})
+    assert after == before + 1
+    assert len(sent) == 2
+
+
+async def test_prometheus_middleware_records_duration_histogram():
+    """Middleware observes request duration in the histogram."""
+    sent: list[dict] = []
+
+    async def mock_app(scope, receive, send):
+        """Minimal ASGI app returning 200."""
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async def mock_send(message):
+        """Capture sent ASGI messages."""
+        sent.append(message)
+
+    async def mock_receive():
+        """Return an empty HTTP request body."""
+        return {"type": "http.request", "body": b""}
+
+    before = _get_histogram_count("okp_http_request_duration_seconds", {"method": "GET", "status": "200"})
+
+    middleware = PrometheusMiddleware(mock_app)
+    await middleware({"type": "http", "method": "GET", "path": "/metrics"}, mock_receive, mock_send)
+
+    after = _get_histogram_count("okp_http_request_duration_seconds", {"method": "GET", "status": "200"})
+    assert after == before + 1
+
+
+async def test_prometheus_middleware_captures_error_status_codes():
+    """Middleware records non-200 status codes from the downstream app."""
+    sent: list[dict] = []
+
+    async def error_app(scope, receive, send):
+        """ASGI app returning 500."""
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b"error"})
+
+    async def mock_send(message):
+        """Capture sent ASGI messages."""
+        sent.append(message)
+
+    async def mock_receive():
+        """Return an empty HTTP request body."""
+        return {"type": "http.request", "body": b""}
+
+    before = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
+
+    middleware = PrometheusMiddleware(error_app)
+    await middleware({"type": "http", "method": "POST", "path": "/mcp"}, mock_receive, mock_send)
+
+    after = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
+    assert after == before + 1
+
+
+async def test_prometheus_middleware_passes_through_non_http_scopes():
+    """Non-HTTP scopes (websocket, lifespan) are forwarded without metrics."""
+    called = False
+
+    async def mock_app(scope, receive, send):
+        """Track that the app was called."""
+        nonlocal called
+        called = True
+
+    before_get = _get_counter("okp_http_requests", {"method": "GET", "status": "200"})
+    before_post = _get_counter("okp_http_requests", {"method": "POST", "status": "200"})
+
+    middleware = PrometheusMiddleware(mock_app)
+    await middleware({"type": "websocket"}, None, None)
+
+    assert called
+    # No HTTP metrics should have been recorded.
+    assert _get_counter("okp_http_requests", {"method": "GET", "status": "200"}) == before_get
+    assert _get_counter("okp_http_requests", {"method": "POST", "status": "200"}) == before_post
+
+
+async def test_prometheus_middleware_records_metrics_on_app_exception():
+    """Metrics are recorded even when the downstream app raises."""
+
+    async def crashing_app(scope, receive, send):
+        """ASGI app that crashes before sending a response."""
+        raise RuntimeError("boom")
+
+    before = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
+    before_duration = _get_histogram_count("okp_http_request_duration_seconds", {"method": "POST", "status": "500"})
+
+    async def receive():
+        """Stub ASGI receive callable."""
+        return {"type": "http.request", "body": b""}
+
+    async def send(msg):
+        """Stub ASGI send callable."""
+
+    middleware = PrometheusMiddleware(crashing_app)
+    with pytest.raises(RuntimeError, match="boom"):
+        await middleware(
+            {"type": "http", "method": "POST", "path": "/mcp"},
+            receive,
+            send,
+        )
+
+    # Status defaults to 500 when no http.response.start was sent.
+    after = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
+    after_duration = _get_histogram_count("okp_http_request_duration_seconds", {"method": "POST", "status": "500"})
+    assert after == before + 1
+    assert after_duration == before_duration + 1
+
+
+# ---------------------------------------------------------------------------
+# /metrics endpoint
+# ---------------------------------------------------------------------------
+
+
+async def test_metrics_endpoint_returns_prometheus_format():
+    """The /metrics custom route returns Prometheus exposition text format."""
+    response = await metrics_endpoint(MagicMock())
+    assert response.status_code == 200
+    assert b"okp_http_requests_total" in response.body
+    assert b"okp_tool_calls_total" in response.body
+    assert b"okp_solr_queries_total" in response.body
+
+
+async def test_metrics_endpoint_content_type():
+    """The /metrics response uses the standard Prometheus content type."""
+    response = await metrics_endpoint(MagicMock())
+    assert "text/plain" in response.media_type
+
+
+# ---------------------------------------------------------------------------
+# Metric definitions
+# ---------------------------------------------------------------------------
+
+
+def test_metric_label_names():
+    """Verify expected label names on each metric family."""
+    assert HTTP_REQUESTS._labelnames == ("method", "status")
+    assert HTTP_REQUEST_DURATION._labelnames == ("method", "status")
+    assert TOOL_CALLS._labelnames == ("tool",)
+    assert TOOL_DURATION._labelnames == ("tool",)
+    assert SOLR_QUERIES._labelnames == ("status",)
+    assert SOLR_QUERY_DURATION._labelnames == ("status",)
+
+
+# ---------------------------------------------------------------------------
+# Solr query metrics integration
+# ---------------------------------------------------------------------------
+
+
+async def test_solr_query_records_success_metrics(sample_solr_response):
+    """Successful Solr queries increment the success counter and record duration."""
+    before_success = _get_counter("okp_solr_queries", {"status": "success"})
+    before_duration = _get_histogram_count("okp_solr_query_duration_seconds", {"status": "success"})
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=sample_solr_response))
+        await _solr_query({"q": "test"}, solr_endpoint=_SOLR_ENDPOINT)
+
+    assert _get_counter("okp_solr_queries", {"status": "success"}) == before_success + 1
+    assert _get_histogram_count("okp_solr_query_duration_seconds", {"status": "success"}) == before_duration + 1
+
+
+@pytest.mark.parametrize(
+    ("status_label", "mock_kwargs", "expected_exc"),
+    [
+        pytest.param(
+            "timeout",
+            {"side_effect": httpx.TimeoutException("slow")},
+            httpx.TimeoutException,
+            id="timeout",
+        ),
+        pytest.param(
+            "error",
+            {"return_value": httpx.Response(500, text="Internal Server Error")},
+            httpx.HTTPStatusError,
+            id="http-500",
+        ),
+    ],
+)
+async def test_solr_query_records_failure_metrics(status_label, mock_kwargs, expected_exc):
+    """Failed Solr queries increment the matching failure counter."""
+    before = _get_counter("okp_solr_queries", {"status": status_label})
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_SOLR_ENDPOINT).mock(**mock_kwargs)
+        with pytest.raises(expected_exc):
+            await _solr_query({"q": "test"}, solr_endpoint=_SOLR_ENDPOINT)
+
+    assert _get_counter("okp_solr_queries", {"status": status_label}) == before + 1
+
+
+async def test_solr_query_records_error_metrics_on_solr_error_response():
+    """Solr responses containing an 'error' key increment the error counter."""
+    before = _get_counter("okp_solr_queries", {"status": "error"})
+    error_response = {"error": {"msg": "bad query", "code": 400}}
+
+    with respx.mock(assert_all_called=True) as router:
+        router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=error_response))
+        result = await _solr_query({"q": "bad"}, solr_endpoint=_SOLR_ENDPOINT)
+
+    assert _get_counter("okp_solr_queries", {"status": "error"}) == before + 1
+    assert result["response"]["numFound"] == 0
+
+
+async def test_solr_query_always_records_duration():
+    """Duration histogram is recorded on both success and failure paths."""
+    before = _get_histogram_count("okp_solr_query_duration_seconds", {"status": "timeout"})
+
+    with respx.mock:
+        respx.get(_SOLR_ENDPOINT).mock(side_effect=httpx.TimeoutException("slow"))
+        with pytest.raises(httpx.TimeoutException):
+            await _solr_query({"q": "test"}, solr_endpoint=_SOLR_ENDPOINT)
+
+    assert _get_histogram_count("okp_solr_query_duration_seconds", {"status": "timeout"}) == before + 1

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
+from okp_mcp.metrics import PrometheusMiddleware
 from okp_mcp.request_id import RequestIDHeaderMiddleware
 
 
@@ -17,15 +18,17 @@ def _mock_mcp_run():
 
 
 def _assert_http_run(mock_mcp, transport: str, host: str, port: int) -> None:
-    """HTTP transports include the request ID response middleware."""
+    """HTTP transports include Prometheus and request ID response middleware."""
     mock_mcp.run.assert_called_once()
     _, kwargs = mock_mcp.run.call_args
 
     assert kwargs["transport"] == transport
     assert kwargs["host"] == host
     assert kwargs["port"] == port
-    assert len(kwargs["middleware"]) == 1
-    assert kwargs["middleware"][0].cls is RequestIDHeaderMiddleware
+    assert len(kwargs["middleware"]) == 2
+    middleware_classes = [m.cls for m in kwargs["middleware"]]
+    assert middleware_classes[0] is PrometheusMiddleware
+    assert middleware_classes[1] is RequestIDHeaderMiddleware
 
 
 def test_module_imports():

--- a/uv.lock
+++ b/uv.lock
@@ -771,6 +771,7 @@ source = { editable = "." }
 dependencies = [
     { name = "fastmcp" },
     { name = "httpx" },
+    { name = "prometheus-client" },
     { name = "pydantic-settings" },
     { name = "rank-bm25" },
 ]
@@ -793,6 +794,7 @@ dev = [
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.2.4" },
     { name = "httpx" },
+    { name = "prometheus-client", specifier = ">=0.21" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "rank-bm25" },
 ]
@@ -870,6 +872,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Add `prometheus_client` with counters and histograms for HTTP requests, MCP tool calls, and Solr queries
- Expose `/metrics` via FastMCP `custom_route` (invisible to MCP `tools/list`)
- `PrometheusMiddleware` ASGI layer auto-tracks HTTP request count and latency (TTFB, not connection lifetime)
- Enforce absolute imports project-wide with ruff `TID252`

## Metrics

| Layer | Counter | Histogram | Labels |
|-------|---------|-----------|--------|
| HTTP | `okp_http_requests_total` | `okp_http_request_duration_seconds` | method, status |
| Tool | `okp_tool_calls_total` | `okp_tool_duration_seconds` | tool |
| Solr | `okp_solr_queries_total` | `okp_solr_query_duration_seconds` | status |

## Changes

- **`src/okp_mcp/metrics.py`** (new): metric definitions, `/metrics` endpoint, `PrometheusMiddleware`
- **`src/okp_mcp/__init__.py`**: wire `PrometheusMiddleware` into HTTP middleware stack
- **`src/okp_mcp/tools/search.py`**, **`tools/document.py`**: tool call counters + duration histograms
- **`src/okp_mcp/solr.py`**: Solr query counters (success/timeout/error) + duration histogram with status labels
- **`tests/test_metrics.py`** (new): 13 tests, 100% coverage on `metrics.py`
- **`tests/test_smoke.py`**: assert Prometheus middleware is first in HTTP middleware list
- **`pyproject.toml`**: add `prometheus_client` dependency, add `TID252` to ruff rules
- **`AGENTS.md`**: updated project layout, dependency graph, boot sequence, "Where to Look" table, import rules

## Testing

`make ci` passes: lint, typecheck (ty), radon (all A/B), 348 tests, 92% overall coverage.