### PR TITLE
refactor: replace relative imports with absolute package imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,8 +160,8 @@ No circular imports. `content.py` has zero internal dependencies.
 - **Linter**: ruff check with rules: E, F, W, I (isort), UP, S (security), B (bugbear), A, C4, SIM
 
 ### Imports
-- Order: stdlib, third-party, relative (enforced by ruff `I` rule)
-- Use relative imports within the package (`from .config import ServerConfig`)
+- Order: stdlib, third-party, first-party (enforced by ruff `I` rule)
+- **Never use relative imports.** Always use absolute imports with the full package name (`from okp_mcp.config import ServerConfig`, not `from .config import ServerConfig`)
 - Side-effect imports get a `noqa` comment explaining why:
   ```python
   from okp_mcp import tools as _tools  # noqa: F401 -- triggers @mcp.tool registration

--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -2,8 +2,8 @@
 
 import re
 
-from .content import doc_uri, strip_boilerplate
-from .solr import _extract_relevant_section, _get_highlights
+from okp_mcp.content import doc_uri, strip_boilerplate
+from okp_mcp.solr import _extract_relevant_section, _get_highlights
 
 EOL_PRODUCT_MENTIONS = [
     ("Red Hat Virtualization", "RHV"),

--- a/src/okp_mcp/intent.py
+++ b/src/okp_mcp/intent.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 
-from .config import logger
+from okp_mcp.config import logger
 
 # ---------------------------------------------------------------------------
 # Intent rule dataclass

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -9,11 +9,11 @@ from dataclasses import dataclass, field, replace
 
 import httpx
 
-from .config import logger
-from .content import _select_within_budget, doc_uri, strip_boilerplate
-from .formatting import _annotate_result
-from .intent import apply_deprecation_boosts, apply_main_boosts
-from .solr import _clean_query, _filter_rhv_sentences, _solr_query
+from okp_mcp.config import logger
+from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate
+from okp_mcp.formatting import _annotate_result
+from okp_mcp.intent import apply_deprecation_boosts, apply_main_boosts
+from okp_mcp.solr import _clean_query, _filter_rhv_sentences, _solr_query
 
 
 @dataclass

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -10,8 +10,8 @@ from dataclasses import dataclass
 import httpx
 from fastmcp import Context, FastMCP
 
-from .config import ServerConfig
-from .request_id import RequestIDContextMiddleware
+from okp_mcp.config import ServerConfig
+from okp_mcp.request_id import RequestIDContextMiddleware
 
 logger = logging.getLogger(__name__)
 

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -5,7 +5,7 @@ import re
 import httpx
 from rank_bm25 import BM25Plus  # pyright: ignore[reportMissingImports]
 
-from .config import STOP_WORDS, logger
+from okp_mcp.config import STOP_WORDS, logger
 
 
 def _split_quoted_and_plain(text: str) -> list[str]:

--- a/src/okp_mcp/tools/__init__.py
+++ b/src/okp_mcp/tools/__init__.py
@@ -1,6 +1,6 @@
 """MCP tool definitions for RHEL OKP knowledge base search."""
 
-from .document import (
+from okp_mcp.tools.document import (
     _doc_id_filter,
     _escape_solr_phrase,
     _fetch_document_raw,
@@ -9,8 +9,8 @@ from .document import (
     _normalize_doc_id,
     get_document,
 )
-from .run_code import run_code
-from .search import search_portal
+from okp_mcp.tools.run_code import run_code
+from okp_mcp.tools.search import search_portal
 
 __all__ = [
     "_doc_id_filter",

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -6,10 +6,10 @@ from urllib.parse import urlsplit
 import httpx
 from fastmcp import Context
 
-from ..content import _select_within_budget, doc_uri, strip_boilerplate, truncate_content
-from ..server import get_app_context, mcp
-from ..solr import _clean_query, _extract_relevant_section, _get_highlight_snippets, _solr_query
-from .shared import DOCUMENT_FL
+from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate, truncate_content
+from okp_mcp.server import get_app_context, mcp
+from okp_mcp.solr import _clean_query, _extract_relevant_section, _get_highlight_snippets, _solr_query
+from okp_mcp.tools.shared import DOCUMENT_FL
 
 logger = logging.getLogger("okp_mcp.tools.get_document")
 

--- a/src/okp_mcp/tools/run_code.py
+++ b/src/okp_mcp/tools/run_code.py
@@ -4,7 +4,7 @@ import logging
 
 from fastmcp import Context
 
-from ..server import mcp
+from okp_mcp.server import mcp
 
 logger = logging.getLogger("okp_mcp.tools.run_code")
 

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -5,8 +5,8 @@ import logging
 import httpx
 from fastmcp import Context
 
-from ..portal import _MAX_QUERIES, _format_portal_results, _run_multi_query_search, _run_portal_search
-from ..server import get_app_context, mcp
+from okp_mcp.portal import _MAX_QUERIES, _format_portal_results, _run_multi_query_search, _run_portal_search
+from okp_mcp.server import get_app_context, mcp
 
 logger = logging.getLogger("okp_mcp.tools.search_portal")
 


### PR DESCRIPTION
Consistent absolute imports improve readability and make move/rename refactors safer.  Updated AGENTS.md to codify the convention.