### PR TITLE
RSPEED-2926: Add optional GlitchTip error reporting

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md - okp-mcp
 
-MCP server bridging LLM tool calls to a Solr-indexed Red Hat knowledge base (docs, CVEs, errata, solutions). Built on FastMCP + httpx + pydantic-settings.
+MCP server bridging LLM tool calls to a Solr-indexed Red Hat knowledge base (docs, CVEs, errata, solutions). Built on FastMCP + httpx + pydantic-settings + sentry-sdk.
 
 ## Maintenance Rule
 
@@ -58,6 +58,7 @@ src/okp_mcp/
   __init__.py    # entry point, main(), logging config, re-exports mcp
   build_info.py  # Build-time metadata: git commit SHA + package version
   config.py      # ServerConfig (pydantic BaseSettings, MCP_* env vars)
+  telemetry.py   # Optional GlitchTip/Sentry exception reporting setup
   server.py      # FastMCP instance (single `mcp` object), AppContext, lifespan
   request_id.py  # Request ID context vars, FastMCP middleware, Starlette header middleware, logging filter
   metrics.py     # Prometheus metrics: counters, histograms, /metrics endpoint, ASGI middleware
@@ -125,8 +126,9 @@ uv run okp-mcp [--transport ...] [--port ...]
   → __init__.py: main()
        ├─ CliApp.run(ServerConfig)     # parse CLI + MCP_* env vars
        ├─ _configure_logging()
-        ├─ log version + commit SHA     # build_info.py reads /app/COMMIT_SHA
-        └─ mcp.run(transport=...)       # start FastMCP server
+       ├─ telemetry.initialize_error_reporting()  # no-op unless MCP_GLITCHTIP_DSN is set
+       ├─ log version + commit SHA     # build_info.py reads /app/COMMIT_SHA
+       └─ mcp.run(transport=...)       # start FastMCP server
             → server.py: _app_lifespan()
                 ├─ creates shared httpx.AsyncClient
                 └─ yields AppContext(...)
@@ -137,7 +139,7 @@ uv run okp-mcp [--transport ...] [--port ...]
 ## Module Dependencies
 
 ```text
-__init__.py → build_info, config, metrics (side-effect import), request_id, server, tools (side-effect import)
+__init__.py → build_info, config, metrics (side-effect import), request_id, server, telemetry, tools (side-effect import)
 build_info.py → (standalone, reads ./COMMIT_SHA file)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
 tools/search.py → config, metrics, portal, server
@@ -150,6 +152,7 @@ portal.py   → config, content, formatting, intent, solr
 formatting.py → content, solr
 solr.py     → config, metrics
 server.py   → config
+telemetry.py → build_info, config, sentry_sdk
 content.py  → (standalone)
 ```
 
@@ -221,6 +224,8 @@ No circular imports. `content.py` has zero internal dependencies.
 ## Configuration Pattern
 
 Config uses `pydantic_settings.BaseSettings` with `MCP_` env prefix. CLI via `CliApp.run()`. Precedence: CLI > env vars > defaults. Derived values use `@computed_field`.
+
+Optional GlitchTip/Sentry exception reporting is configured with `MCP_GLITCHTIP_DSN` / `--glitchtip_dsn`. Missing or empty DSNs are handled as a no-op for local development.
 
 Module-level constant `STOP_WORDS` lives in `config.py` outside the class to avoid circular import issues. The Solr endpoint is no longer a module-level constant — it flows through `ServerConfig.solr_endpoint` → `AppContext.solr_endpoint` at runtime.
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Settings come from CLI arguments and `MCP_*` environment variables. CLI args tak
 | `--transport` | `MCP_TRANSPORT` | `streamable-http` | `stdio`, `sse`, or `streamable-http` |
 | `--host` | `MCP_HOST` | `0.0.0.0` | Bind address for HTTP transports |
 | `--port` | `MCP_PORT` | `8000` | Bind port for HTTP transports |
-| `--log-level` | `MCP_LOG_LEVEL` | `INFO` | Python log level |
-| `--solr-url` | `MCP_SOLR_URL` | `http://localhost:8983` | Base URL of the Solr instance |
+| `--log_level` | `MCP_LOG_LEVEL` | `INFO` | Python log level |
+| `--solr_url` | `MCP_SOLR_URL` | `http://localhost:8983` | Base URL of the Solr instance |
+| `--glitchtip_dsn` | `MCP_GLITCHTIP_DSN` | unset | Optional GlitchTip/Sentry DSN for exception reporting |
 
 Run `okp-mcp --help` for the full list.
 

--- a/openshift/okp-mcp.yml
+++ b/openshift/okp-mcp.yml
@@ -59,6 +59,12 @@ objects:
                   value: "${LOG_LEVEL}"
                 - name: MCP_SOLR_URL
                   value: "${SOLR_BASE_URL}"
+                - name: MCP_GLITCHTIP_DSN
+                  valueFrom:
+                    secretKeyRef:
+                      name: "${GLITCHTIP_SECRET_NAME}"
+                      key: dsn
+                      optional: true
               livenessProbe:
                 tcpSocket:
                   port: 8000
@@ -143,3 +149,11 @@ parameters:
     displayName: Solr Base URL
     description: Base URL of the OKP Solr instance.
     value: http://redhat-okp:8983
+  - name: GLITCHTIP_SECRET_NAME
+    displayName: GlitchTip Secret Name
+    description: >-
+      Name of the OpenShift secret containing the GlitchTip DSN
+      (key: dsn). The secret must exist in the namespace when
+      configured; error reporting is disabled at the application
+      level when the DSN value is blank.
+    value: okp-mcp-glitchtip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "prometheus_client>=0.25.0",
     "pydantic-settings>=2.13.1",
     "rank-bm25",
+    "sentry-sdk[httpx]>=2.35.0",
 ]
 
 [project.scripts]
@@ -54,5 +55,4 @@ select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "SIM", "TID252"]
 
 [tool.ty.environment]
 python-version = "3.12"
-
 

--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -13,6 +13,7 @@ from okp_mcp.config import ServerConfig
 from okp_mcp.metrics import PrometheusMiddleware
 from okp_mcp.request_id import RequestIDLogFilter, build_http_request_id_middleware
 from okp_mcp.server import mcp
+from okp_mcp.telemetry import initialize_error_reporting
 
 __all__ = ["mcp", "main"]
 
@@ -47,6 +48,7 @@ def main() -> None:
     config = CliApp.run(ServerConfig)
     _server._server_config = config
     _configure_logging(config.log_level)
+    initialize_error_reporting(config)
 
     logger.info("okp-mcp %s (%s)", get_package_version(), get_commit_sha())
     logger.info("Starting MCP server with transport=%s", config.transport)

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -3,7 +3,7 @@
 import logging
 from typing import Literal
 
-from pydantic import Field, computed_field
+from pydantic import Field, SecretStr, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 # Configure logging
@@ -120,6 +120,10 @@ class ServerConfig(BaseSettings):
         default=30_000,
         ge=1,
         description="Maximum characters in a single tool response",
+    )
+    glitchtip_dsn: SecretStr | None = Field(
+        default=None,
+        description="GlitchTip/Sentry DSN for exception reporting",
     )
 
     @computed_field

--- a/src/okp_mcp/telemetry.py
+++ b/src/okp_mcp/telemetry.py
@@ -1,0 +1,66 @@
+"""Error reporting setup for GlitchTip-compatible Sentry DSNs."""
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+import sentry_sdk
+from sentry_sdk.utils import BadDsn
+
+from okp_mcp.build_info import get_commit_sha, get_package_version
+from okp_mcp.config import ServerConfig
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import Event
+
+logger = logging.getLogger(__name__)
+
+# Paths whose errors are monitoring noise, not actionable incidents.
+_EXCLUDED_PATHS: frozenset[str] = frozenset({"/metrics"})
+
+
+def _before_send(event: "Event", hint: dict[str, Any]) -> "Event | None":
+    """Drop error events originating from health-check or metrics paths.
+
+    Filters two categories of noise:
+    * HTTP errors on ``/metrics`` (scraper hiccups, not real faults).
+    * ``ConnectionResetError`` anywhere (TCP health probes disconnecting).
+    """
+    # Drop errors from excluded paths (metrics scraping, health checks)
+    request_info = event.get("request", {})
+    url = str(request_info.get("url", "")) if isinstance(request_info, dict) else ""
+    if any(url.endswith(path) for path in _EXCLUDED_PATHS):
+        return None
+
+    # Drop connection resets (typically from liveness/readiness probe disconnects)
+    exc_info = hint.get("exc_info")
+    if exc_info:
+        exc_type = exc_info[0]
+        if exc_type is ConnectionResetError:
+            return None
+
+    return event
+
+
+def initialize_error_reporting(config: ServerConfig) -> None:
+    """Configure GlitchTip/Sentry exception reporting when a DSN is available."""
+    if config.glitchtip_dsn is None:
+        logger.debug("GlitchTip DSN is not configured; exception reporting is disabled")
+        return
+
+    glitchtip_dsn = config.glitchtip_dsn.get_secret_value()
+    if not glitchtip_dsn:
+        logger.debug("GlitchTip DSN is not configured; exception reporting is disabled")
+        return
+
+    release = f"okp-mcp@{get_package_version()}+{get_commit_sha()}"
+    logger.info("GlitchTip DSN found; enabling exception reporting")
+    try:
+        sentry_sdk.init(
+            dsn=glitchtip_dsn,
+            release=release,
+            send_default_pii=False,
+            traces_sample_rate=0.0,
+            before_send=_before_send,
+        )
+    except BadDsn:
+        logger.warning("GlitchTip DSN is invalid; exception reporting is disabled", exc_info=True)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,6 +18,7 @@ def test_defaults():
     assert config.port == 8000
     assert config.log_level == "INFO"
     assert config.solr_url == "http://localhost:8983"
+    assert config.glitchtip_dsn is None
 
 
 @pytest.mark.parametrize(
@@ -34,7 +35,7 @@ def test_valid_transports(transport):
 def test_invalid_transport_rejected():
     """Transport values outside the Literal choices raise ValidationError."""
     with pytest.raises(ValidationError, match="transport"):
-        ServerConfig(transport="websocket")
+        CliApp.run(ServerConfig, cli_args=["--transport", "websocket"])
 
 
 def test_env_var_loading():
@@ -63,12 +64,23 @@ def test_cli_args_via_cli_app():
     """CliApp.run parses CLI arguments into ServerConfig."""
     config = CliApp.run(
         ServerConfig,
-        cli_args=["--transport", "sse", "--host", "127.0.0.1", "--port", "3000"],
+        cli_args=[
+            "--transport",
+            "sse",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            "3000",
+            "--glitchtip_dsn",
+            "https://example.com/1",
+        ],
     )
 
     assert config.transport == "sse"
     assert config.host == "127.0.0.1"
     assert config.port == 3000
+    assert config.glitchtip_dsn is not None
+    assert config.glitchtip_dsn.get_secret_value() == "https://example.com/1"
 
 
 def test_cli_overrides_env_var():
@@ -88,6 +100,23 @@ def test_env_var_overrides_default():
         config = ServerConfig()
 
     assert config.port == 9999
+
+
+def test_glitchtip_dsn_from_env():
+    """MCP_GLITCHTIP_DSN env var configures exception reporting."""
+    with patch.dict("os.environ", {"MCP_GLITCHTIP_DSN": "https://glitchtip.example.com/1"}):
+        config = ServerConfig()
+
+    assert config.glitchtip_dsn is not None
+    assert config.glitchtip_dsn.get_secret_value() == "https://glitchtip.example.com/1"
+
+
+def test_glitchtip_dsn_is_masked_in_config_repr():
+    """Configured GlitchTip DSNs are masked when config objects are represented."""
+    config = ServerConfig(glitchtip_dsn="https://glitchtip.example.com/1")
+
+    assert "https://glitchtip.example.com/1" not in repr(config)
+    assert "**********" in repr(config)
 
 
 def test_port_type_coercion():

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -61,6 +61,29 @@ def test_main_defaults_to_streamable_http(_mock_mcp_run):
     _assert_http_run(_mock_mcp_run, transport="streamable-http", host="0.0.0.0", port=8000)
 
 
+def test_main_initializes_error_reporting(_mock_mcp_run):
+    """Configured GlitchTip setup runs before the server starts."""
+    from okp_mcp import main
+
+    call_order: list[str] = []
+
+    with (
+        patch("sys.argv", ["okp-mcp"]),
+        patch.dict("os.environ", {"MCP_GLITCHTIP_DSN": "https://glitchtip.example.com/1"}),
+        patch("okp_mcp.initialize_error_reporting") as initialize_error_reporting,
+    ):
+        initialize_error_reporting.side_effect = lambda _cfg: call_order.append("init")
+        _mock_mcp_run.run.side_effect = lambda *args, **kwargs: call_order.append("run")
+        main()
+
+    initialize_error_reporting.assert_called_once()
+    glitchtip_dsn = initialize_error_reporting.call_args.args[0].glitchtip_dsn
+    assert glitchtip_dsn is not None
+    assert glitchtip_dsn.get_secret_value() == "https://glitchtip.example.com/1"
+    assert call_order == ["init", "run"]
+    _assert_http_run(_mock_mcp_run, transport="streamable-http", host="0.0.0.0", port=8000)
+
+
 def test_main_stdio_transport(_mock_mcp_run):
     """stdio transport calls mcp.run without host/port."""
     from okp_mcp import main

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,87 @@
+"""Tests for GlitchTip/Sentry error reporting setup."""
+
+from unittest.mock import patch
+
+import pytest
+import sentry_sdk
+from pydantic import SecretStr
+
+from okp_mcp.config import ServerConfig
+from okp_mcp.telemetry import _before_send, initialize_error_reporting
+
+
+@pytest.mark.parametrize(
+    "dsn_value",
+    [
+        pytest.param(None, id="missing"),
+        pytest.param(SecretStr(""), id="empty"),
+    ],
+)
+def test_initialize_error_reporting_skips_blank_or_missing_dsn(dsn_value):
+    """Sentry is not initialized when the GlitchTip DSN is missing or empty."""
+    config = ServerConfig(glitchtip_dsn=dsn_value)
+
+    with patch("okp_mcp.telemetry.sentry_sdk.init") as sentry_init:
+        initialize_error_reporting(config)
+
+    sentry_init.assert_not_called()
+
+
+def test_initialize_error_reporting_uses_configured_dsn():
+    """Sentry receives the configured GlitchTip DSN with sampling and before_send hook."""
+    config = ServerConfig(glitchtip_dsn=SecretStr("https://glitchtip.example.com/1"))
+
+    with (
+        patch("okp_mcp.telemetry.get_commit_sha", return_value="abc123"),
+        patch("okp_mcp.telemetry.get_package_version", return_value="1.2.3"),
+        patch("okp_mcp.telemetry.sentry_sdk.init") as sentry_init,
+    ):
+        initialize_error_reporting(config)
+
+    sentry_init.assert_called_once_with(
+        dsn="https://glitchtip.example.com/1",
+        release="okp-mcp@1.2.3+abc123",
+        send_default_pii=False,
+        traces_sample_rate=0.0,
+        before_send=_before_send,
+    )
+
+
+def test_initialize_error_reporting_handles_invalid_dsn(caplog):
+    """Invalid GlitchTip DSNs do not block application startup."""
+    config = ServerConfig(glitchtip_dsn=SecretStr("not-a-dsn"))
+
+    initialize_error_reporting(config)
+
+    assert "GlitchTip DSN is invalid" in caplog.text
+    assert sentry_sdk.is_initialized() is False
+
+
+def test_before_send_drops_metrics_path_errors():
+    """Errors from /metrics requests are filtered out as monitoring noise."""
+    event = {"request": {"url": "http://localhost:8000/metrics"}}
+    assert _before_send(event, {}) is None
+
+
+def test_before_send_drops_connection_reset_errors():
+    """ConnectionResetError (health probe disconnects) is filtered out."""
+    event = {"exception": {"values": [{"type": "ConnectionResetError"}]}}
+    try:
+        raise ConnectionResetError("peer disconnected")
+    except ConnectionResetError:
+        import sys
+
+        hint = {"exc_info": sys.exc_info()}
+    assert _before_send(event, hint) is None
+
+
+def test_before_send_keeps_regular_errors():
+    """Normal application errors pass through the filter unchanged."""
+    event = {"request": {"url": "http://localhost:8000/mcp"}, "exception": {"values": [{"type": "ValueError"}]}}
+    assert _before_send(event, {}) is event
+
+
+def test_before_send_keeps_events_without_request():
+    """Events with no request info are not filtered."""
+    event = {"level": "error", "message": "something broke"}
+    assert _before_send(event, {}) is event

--- a/uv.lock
+++ b/uv.lock
@@ -774,6 +774,7 @@ dependencies = [
     { name = "prometheus-client" },
     { name = "pydantic-settings" },
     { name = "rank-bm25" },
+    { name = "sentry-sdk", extra = ["httpx"] },
 ]
 
 [package.dev-dependencies]
@@ -797,6 +798,7 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "pydantic-settings", specifier = ">=2.13.1" },
     { name = "rank-bm25" },
+    { name = "sentry-sdk", extras = ["httpx"], specifier = ">=2.35.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -1425,6 +1427,24 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.58.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/b3/fb8291170d0e844173164709fc0fa0c221ed75a5da740c8746f2a83b4eb1/sentry_sdk-2.58.0.tar.gz", hash = "sha256:c1144d947352d54e5b7daa63596d9f848adf684989c06c4f5a659f0c85a18f6f", size = 438764, upload-time = "2026-04-13T17:23:26.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/eb/d875669993b762556ae8b2efd86219943b4c0864d22204d622a9aee3052b/sentry_sdk-2.58.0-py2.py3-none-any.whl", hash = "sha256:688d1c704ddecf382ea3326f21a67453d4caa95592d722b7c780a36a9d23109e", size = 460919, upload-time = "2026-04-13T17:23:24.675Z" },
+]
+
+[package.optional-dependencies]
+httpx = [
+    { name = "httpx" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1520,6 +1540,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e1/68/35c1d87e608940badbcfeb630347aa0509897284684f61fab6423d02b253/uncalled_for-0.3.1.tar.gz", hash = "sha256:5e412ac6708f04b56bef5867b5dcf6690ebce4eb7316058d9c50787492bb4bca", size = 49693, upload-time = "2026-04-07T13:05:06.462Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/11/e1/7ec67882ad8fc9f86384bef6421fa252c9cbe5744f8df6ce77afc9eca1f5/uncalled_for-0.3.1-py3-none-any.whl", hash = "sha256:074cdc92da8356278f93d0ded6f2a66dd883dbecaf9bc89437646ee2289cc200", size = 11361, upload-time = "2026-04-07T13:05:05.341Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add optional GlitchTip/Sentry exception reporting, configured with `MCP_GLITCHTIP_DSN` or `--glitchtip_dsn`.
- Keep local/dev startup safe by treating missing, empty, or invalid DSNs as non-fatal.
- Mask the configured DSN with Pydantic `SecretStr` so config representations do not leak credentials.

## Jira
- https://redhat.atlassian.net/browse/RSPEED-2926

## Verification
- `make ci`

## CodeRabbit
- Initial local review found one DSN secrecy issue, fixed in `9e40cb7dd3`.
- Follow-up local reruns were blocked by CodeRabbit rate limiting.