### PR TITLE
fix: suppress noisy /metrics access logs from Prometheus scrapes

### DIFF
--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -20,6 +20,14 @@ __all__ = ["mcp", "main"]
 logger = logging.getLogger(__name__)
 
 
+class _MetricsAccessLogFilter(logging.Filter):
+    """Drop uvicorn access log entries for GET /metrics (Prometheus scrapes)."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """Return False to suppress /metrics lines, True for everything else."""
+        return '"GET /metrics HTTP/' not in record.getMessage()
+
+
 def _configure_logging(log_level: str) -> None:
     """Configure logging at the given level."""
     logging.basicConfig(
@@ -31,6 +39,9 @@ def _configure_logging(log_level: str) -> None:
     # httpx logs every HTTP request at INFO with the full URL-encoded query string.
     # Our solr.py already logs query params in readable form, so this is redundant noise.
     logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    # Prometheus scrapes /metrics every ~15s, flooding logs with useless access lines.
+    logging.getLogger("uvicorn.access").addFilter(_MetricsAccessLogFilter())
 
     request_id_filter = RequestIDLogFilter()
     root_logger = logging.getLogger()


### PR DESCRIPTION
## Summary

- Add a `logging.Filter` on `uvicorn.access` that drops access log lines for `GET /metrics`
- Prometheus scrapers hit `/metrics` every ~15s, generating two log lines per interval (one per scraper pod), drowning out useful access logs in production

## What it does

`_MetricsAccessLogFilter` checks the rendered uvicorn access log message for the exact pattern `"GET /metrics HTTP/`. This matches only the `/metrics` path (not `/metrics-dashboard` or similar prefixed routes). All other access log entries pass through unchanged.

## Before

```
okp-mcp INFO:     10.128.26.81:39022 - "GET /metrics HTTP/1.1" 200 OK
okp-mcp INFO:     10.131.21.248:43590 - "GET /metrics HTTP/1.1" 200 OK
okp-mcp INFO:     10.128.26.81:46856 - "GET /metrics HTTP/1.1" 200 OK
okp-mcp INFO:     10.131.21.248:57700 - "GET /metrics HTTP/1.1" 200 OK
(repeats every ~15s, hundreds of lines per hour)
```

## After

These lines are silently dropped. Actual MCP traffic access logs remain visible.