### PR TITLE
feat(metrics): add path label to HTTP metrics and filter /metrics in dashboards

### DIFF
--- a/openshift/dashboards/grafana-dashboard-okp-mcp-slo.configmap.yaml
+++ b/openshift/dashboards/grafana-dashboard-okp-mcp-slo.configmap.yaml
@@ -72,7 +72,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status!~\"5..\"}[5m])) / clamp_min(sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])), 1e-10) * 100",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", status!~\"5..\"}[5m])) / clamp_min(sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[5m])), 1e-10) * 100",
               "legendFormat": "HTTP Success",
               "instant": true,
               "refId": "A"
@@ -156,7 +156,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[5m])) by (le))",
               "legendFormat": "P95",
               "instant": true,
               "refId": "A"
@@ -247,7 +247,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status=~\"5..\"}[5m]))",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", status=~\"5..\"}[5m]))",
               "legendFormat": "5xx",
               "instant": true,
               "refId": "A"
@@ -288,7 +288,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status=~\"4..\"}[5m]))",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", status=~\"4..\"}[5m]))",
               "legendFormat": "4xx",
               "instant": true,
               "refId": "A"
@@ -444,7 +444,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status!~\"5..\"}[5m])) / clamp_min(sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])), 1e-10) * 100",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", status!~\"5..\"}[5m])) / clamp_min(sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[5m])), 1e-10) * 100",
               "legendFormat": "HTTP",
               "range": true,
               "refId": "A"
@@ -477,7 +477,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) by (le))",
+              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[5m])) by (le))",
               "legendFormat": "HTTP P95",
               "range": true,
               "refId": "A"

--- a/openshift/dashboards/grafana-dashboard-okp-mcp.configmap.yaml
+++ b/openshift/dashboards/grafana-dashboard-okp-mcp.configmap.yaml
@@ -55,7 +55,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) by (method)",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[5m])) by (method)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -80,7 +80,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status=~\"[45]..\"}[5m])) by (method, status)",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", status=~\"[45]..\"}[5m])) by (method, status)",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"
@@ -105,7 +105,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) by (le, method))",
+              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[5m])) by (le, method))",
               "legendFormat": "__auto",
               "range": true,
               "refId": "A"

--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -10,18 +10,23 @@ from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 from okp_mcp.server import mcp
 
+# Allowlist of known paths to prevent unbounded label cardinality.
+# Unknown paths are bucketed as "OTHER" so rogue or scan traffic
+# cannot create arbitrary time series.
+_KNOWN_PATHS: frozenset[str] = frozenset({"/mcp", "/sse", "/metrics"})
+
 # ---------------------------------------------------------------------------
 # HTTP-level metrics (recorded by PrometheusMiddleware)
 # ---------------------------------------------------------------------------
 HTTP_REQUESTS = Counter(
     "okp_http_requests_total",
     "Total HTTP requests received by the MCP server",
-    ["method", "status"],
+    ["method", "path", "status"],
 )
 HTTP_REQUEST_DURATION = Histogram(
     "okp_http_request_duration_seconds",
     "HTTP request duration in seconds",
-    ["method", "status"],
+    ["method", "path", "status"],
 )
 
 # ---------------------------------------------------------------------------
@@ -67,6 +72,8 @@ class PrometheusMiddleware:
             return
 
         method = scope.get("method", "UNKNOWN")
+        raw_path = scope.get("path", "UNKNOWN")
+        path = raw_path if raw_path in _KNOWN_PATHS else "OTHER"
         start = time.monotonic()
         status_code = 500
         recorded = False
@@ -79,8 +86,8 @@ class PrometheusMiddleware:
                 # with full connection lifetime.
                 if not recorded:
                     duration = time.monotonic() - start
-                    HTTP_REQUESTS.labels(method=method, status=str(status_code)).inc()
-                    HTTP_REQUEST_DURATION.labels(method=method, status=str(status_code)).observe(duration)
+                    HTTP_REQUESTS.labels(method=method, path=path, status=str(status_code)).inc()
+                    HTTP_REQUEST_DURATION.labels(method=method, path=path, status=str(status_code)).observe(duration)
                     recorded = True
             await send(message)
 
@@ -90,8 +97,8 @@ class PrometheusMiddleware:
             # Fallback for cases where headers never sent (e.g. app crash before response).
             if not recorded:
                 duration = time.monotonic() - start
-                HTTP_REQUESTS.labels(method=method, status=str(status_code)).inc()
-                HTTP_REQUEST_DURATION.labels(method=method, status=str(status_code)).observe(duration)
+                HTTP_REQUESTS.labels(method=method, path=path, status=str(status_code)).inc()
+                HTTP_REQUEST_DURATION.labels(method=method, path=path, status=str(status_code)).observe(duration)
 
 
 @mcp.custom_route("/metrics", methods=["GET"])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -55,12 +55,12 @@ async def test_prometheus_middleware_records_http_request_counter():
         """Capture sent ASGI messages."""
         sent.append(message)
 
-    before = _get_counter("okp_http_requests", {"method": "POST", "status": "200"})
+    before = _get_counter("okp_http_requests", {"method": "POST", "path": "/mcp", "status": "200"})
 
     middleware = PrometheusMiddleware(mock_app)
     await middleware({"type": "http", "method": "POST", "path": "/mcp"}, mock_receive, mock_send)
 
-    after = _get_counter("okp_http_requests", {"method": "POST", "status": "200"})
+    after = _get_counter("okp_http_requests", {"method": "POST", "path": "/mcp", "status": "200"})
     assert after == before + 1
     assert len(sent) == 2
 
@@ -82,12 +82,13 @@ async def test_prometheus_middleware_records_duration_histogram():
         """Return an empty HTTP request body."""
         return {"type": "http.request", "body": b""}
 
-    before = _get_histogram_count("okp_http_request_duration_seconds", {"method": "GET", "status": "200"})
+    duration_labels = {"method": "GET", "path": "/mcp", "status": "200"}
+    before = _get_histogram_count("okp_http_request_duration_seconds", duration_labels)
 
     middleware = PrometheusMiddleware(mock_app)
-    await middleware({"type": "http", "method": "GET", "path": "/metrics"}, mock_receive, mock_send)
+    await middleware({"type": "http", "method": "GET", "path": "/mcp"}, mock_receive, mock_send)
 
-    after = _get_histogram_count("okp_http_request_duration_seconds", {"method": "GET", "status": "200"})
+    after = _get_histogram_count("okp_http_request_duration_seconds", duration_labels)
     assert after == before + 1
 
 
@@ -108,12 +109,12 @@ async def test_prometheus_middleware_captures_error_status_codes():
         """Return an empty HTTP request body."""
         return {"type": "http.request", "body": b""}
 
-    before = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
+    before = _get_counter("okp_http_requests", {"method": "POST", "path": "/mcp", "status": "500"})
 
     middleware = PrometheusMiddleware(error_app)
     await middleware({"type": "http", "method": "POST", "path": "/mcp"}, mock_receive, mock_send)
 
-    after = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
+    after = _get_counter("okp_http_requests", {"method": "POST", "path": "/mcp", "status": "500"})
     assert after == before + 1
 
 
@@ -126,16 +127,16 @@ async def test_prometheus_middleware_passes_through_non_http_scopes():
         nonlocal called
         called = True
 
-    before_get = _get_counter("okp_http_requests", {"method": "GET", "status": "200"})
-    before_post = _get_counter("okp_http_requests", {"method": "POST", "status": "200"})
+    before_get = _get_counter("okp_http_requests", {"method": "GET", "path": "/mcp", "status": "200"})
+    before_post = _get_counter("okp_http_requests", {"method": "POST", "path": "/mcp", "status": "200"})
 
     middleware = PrometheusMiddleware(mock_app)
     await middleware({"type": "websocket"}, None, None)
 
     assert called
     # No HTTP metrics should have been recorded.
-    assert _get_counter("okp_http_requests", {"method": "GET", "status": "200"}) == before_get
-    assert _get_counter("okp_http_requests", {"method": "POST", "status": "200"}) == before_post
+    assert _get_counter("okp_http_requests", {"method": "GET", "path": "/mcp", "status": "200"}) == before_get
+    assert _get_counter("okp_http_requests", {"method": "POST", "path": "/mcp", "status": "200"}) == before_post
 
 
 async def test_prometheus_middleware_records_metrics_on_app_exception():
@@ -145,8 +146,9 @@ async def test_prometheus_middleware_records_metrics_on_app_exception():
         """ASGI app that crashes before sending a response."""
         raise RuntimeError("boom")
 
-    before = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
-    before_duration = _get_histogram_count("okp_http_request_duration_seconds", {"method": "POST", "status": "500"})
+    error_labels = {"method": "POST", "path": "/mcp", "status": "500"}
+    before = _get_counter("okp_http_requests", error_labels)
+    before_duration = _get_histogram_count("okp_http_request_duration_seconds", error_labels)
 
     async def receive():
         """Stub ASGI receive callable."""
@@ -164,10 +166,36 @@ async def test_prometheus_middleware_records_metrics_on_app_exception():
         )
 
     # Status defaults to 500 when no http.response.start was sent.
-    after = _get_counter("okp_http_requests", {"method": "POST", "status": "500"})
-    after_duration = _get_histogram_count("okp_http_request_duration_seconds", {"method": "POST", "status": "500"})
+    after = _get_counter("okp_http_requests", error_labels)
+    after_duration = _get_histogram_count("okp_http_request_duration_seconds", error_labels)
     assert after == before + 1
     assert after_duration == before_duration + 1
+
+
+async def test_prometheus_middleware_normalizes_unknown_paths_to_other():
+    """Unknown paths are bucketed as OTHER to prevent label cardinality explosion."""
+    sent: list[dict] = []
+
+    async def mock_app(scope, receive, send):
+        """Minimal ASGI app returning 404."""
+        await send({"type": "http.response.start", "status": 404, "headers": []})
+        await send({"type": "http.response.body", "body": b"not found"})
+
+    async def mock_send(message):
+        """Capture sent ASGI messages."""
+        sent.append(message)
+
+    async def mock_receive():
+        """Return an empty HTTP request body."""
+        return {"type": "http.request", "body": b""}
+
+    before = _get_counter("okp_http_requests", {"method": "GET", "path": "OTHER", "status": "404"})
+
+    middleware = PrometheusMiddleware(mock_app)
+    await middleware({"type": "http", "method": "GET", "path": "/some/random/scan"}, mock_receive, mock_send)
+
+    after = _get_counter("okp_http_requests", {"method": "GET", "path": "OTHER", "status": "404"})
+    assert after == before + 1
 
 
 # ---------------------------------------------------------------------------
@@ -197,8 +225,8 @@ async def test_metrics_endpoint_content_type():
 
 def test_metric_label_names():
     """Verify expected label names on each metric family."""
-    assert HTTP_REQUESTS._labelnames == ("method", "status")
-    assert HTTP_REQUEST_DURATION._labelnames == ("method", "status")
+    assert HTTP_REQUESTS._labelnames == ("method", "path", "status")
+    assert HTTP_REQUEST_DURATION._labelnames == ("method", "path", "status")
     assert TOOL_CALLS._labelnames == ("tool",)
     assert TOOL_DURATION._labelnames == ("tool",)
     assert SOLR_QUERIES._labelnames == ("status",)


### PR DESCRIPTION
## Summary

- Add `path` label to `okp_http_requests_total` and `okp_http_request_duration_seconds` so PromQL queries can filter by request path
- Normalize unknown paths to `"OTHER"` via a `_KNOWN_PATHS` allowlist (`/mcp`, `/sse`, `/metrics`) to prevent cardinality explosion
- Filter `path!="/metrics"` in all Grafana dashboard PromQL queries (both okp-mcp and okp-mcp-slo dashboards) to exclude Prometheus scrape noise from request rate, error rate, latency, and SLO panels