### PR TITLE
fix: improve SLO dashboard reliability

### DIFF
--- a/openshift/dashboards/grafana-dashboard-okp-mcp-slo.configmap.yaml
+++ b/openshift/dashboards/grafana-dashboard-okp-mcp-slo.configmap.yaml
@@ -72,7 +72,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status!~\"5..\"}[5m])) / sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) * 100",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status!~\"5..\"}[5m])) / clamp_min(sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])), 1e-10) * 100",
               "legendFormat": "HTTP Success",
               "instant": true,
               "refId": "A"
@@ -114,7 +114,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\", status=\"success\"}[5m])) / sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) * 100",
+              "expr": "sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\", status=\"success\"}[5m])) / clamp_min(sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])), 1e-10) * 100",
               "legendFormat": "Solr Success",
               "instant": true,
               "refId": "A"
@@ -419,7 +419,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "time() - process_start_time_seconds{namespace=\"$namespace\", job=\"okp-mcp\"}",
+              "expr": "min(time() - process_start_time_seconds{namespace=\"$namespace\", job=\"okp-mcp\"})",
               "legendFormat": "Uptime",
               "instant": true,
               "refId": "A"
@@ -444,7 +444,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status!~\"5..\"}[5m])) / sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) * 100",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", status!~\"5..\"}[5m])) / clamp_min(sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])), 1e-10) * 100",
               "legendFormat": "HTTP",
               "range": true,
               "refId": "A"
@@ -452,7 +452,7 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\", status=\"success\"}[5m])) / sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])) * 100",
+              "expr": "sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\", status=\"success\"}[5m])) / clamp_min(sum(rate(okp_solr_queries_total{namespace=\"$namespace\", job=\"okp-mcp\"}[5m])), 1e-10) * 100",
               "legendFormat": "Solr",
               "range": true,
               "refId": "B"
@@ -496,7 +496,7 @@ data:
         }
       ],
       "schemaVersion": 39,
-      "tags": [],
+      "tags": ["okp-mcp", "slo"],
       "templating": {
         "list": [
           {


### PR DESCRIPTION
## Summary

Three reliability improvements to the SLO Grafana dashboard:

### 1. Division by zero protection (`clamp_min`)

Wrapped all rate denominators with `clamp_min(..., 1e-10)` to prevent NaN values during no-traffic windows. Affected expressions:

- **Line 75** – HTTP Success Rate gauge
- **Line 117** – Solr Success Rate gauge
- **Line 447** – HTTP success rate in Success Rate Trend timeseries
- **Line 455** – Solr success rate in Success Rate Trend timeseries

Before:
```promql
/ sum(rate(okp_http_requests_total{...}[5m]))
```
After:
```promql
/ clamp_min(sum(rate(okp_http_requests_total{...}[5m])), 1e-10)
```

### 2. Dashboard tags

Added `["okp-mcp", "slo"]` tags (was `[]`) so the dashboard is discoverable in Grafana's tag-based search.

### 3. Uptime multi-pod fix

Changed the Service Uptime expression from a bare metric selector to `min(...)` so it shows the youngest pod (the most restart-prone one) rather than an arbitrary pod in multi-replica deployments.

Before:
```promql
time() - process_start_time_seconds{namespace="$namespace", job="okp-mcp"}
```
After:
```promql
min(time() - process_start_time_seconds{namespace="$namespace", job="okp-mcp"})
```