### PR TITLE
refactor(metrics): deduplicate emission and harden cardinality test

### DIFF
--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -78,6 +78,13 @@ class PrometheusMiddleware:
         status_code = 500
         recorded = False
 
+        def _emit_metrics(current_status_code: int) -> None:
+            """Record HTTP request count and duration once per request."""
+            duration = time.monotonic() - start
+            labels = {"method": method, "path": path, "status": str(current_status_code)}
+            HTTP_REQUESTS.labels(**labels).inc()
+            HTTP_REQUEST_DURATION.labels(**labels).observe(duration)
+
         async def send_wrapper(message: Message) -> None:
             nonlocal status_code, recorded
             if message["type"] == "http.response.start":
@@ -85,9 +92,7 @@ class PrometheusMiddleware:
                 # Record TTFB so SSE/streaming connections don't inflate the histogram
                 # with full connection lifetime.
                 if not recorded:
-                    duration = time.monotonic() - start
-                    HTTP_REQUESTS.labels(method=method, path=path, status=str(status_code)).inc()
-                    HTTP_REQUEST_DURATION.labels(method=method, path=path, status=str(status_code)).observe(duration)
+                    _emit_metrics(status_code)
                     recorded = True
             await send(message)
 
@@ -96,9 +101,7 @@ class PrometheusMiddleware:
         finally:
             # Fallback for cases where headers never sent (e.g. app crash before response).
             if not recorded:
-                duration = time.monotonic() - start
-                HTTP_REQUESTS.labels(method=method, path=path, status=str(status_code)).inc()
-                HTTP_REQUEST_DURATION.labels(method=method, path=path, status=str(status_code)).observe(duration)
+                _emit_metrics(status_code)
 
 
 @mcp.custom_route("/metrics", methods=["GET"])

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -189,13 +189,19 @@ async def test_prometheus_middleware_normalizes_unknown_paths_to_other():
         """Return an empty HTTP request body."""
         return {"type": "http.request", "body": b""}
 
-    before = _get_counter("okp_http_requests", {"method": "GET", "path": "OTHER", "status": "404"})
+    other_labels = {"method": "GET", "path": "OTHER", "status": "404"}
+    raw_labels = {"method": "GET", "path": "/some/random/scan", "status": "404"}
+    before = _get_counter("okp_http_requests", other_labels)
+    before_raw = _get_counter("okp_http_requests", raw_labels)
 
     middleware = PrometheusMiddleware(mock_app)
     await middleware({"type": "http", "method": "GET", "path": "/some/random/scan"}, mock_receive, mock_send)
 
-    after = _get_counter("okp_http_requests", {"method": "GET", "path": "OTHER", "status": "404"})
+    after = _get_counter("okp_http_requests", other_labels)
     assert after == before + 1
+
+    # The raw path must never appear as its own label value (cardinality guard).
+    assert _get_counter("okp_http_requests", raw_labels) == before_raw
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Extract duplicated `HTTP_REQUESTS`/`HTTP_REQUEST_DURATION` label calls into a `_emit_metrics()` closure to reduce drift risk when labels evolve
- Add negative assertion to the unknown-path normalization test to catch cardinality regressions (raw path must never appear as its own label value)

Addresses CodeRabbit nitpicks from #209.