### PR TITLE
fix(dashboards): focus okp mcp HTTP panels

### DIFF
--- a/openshift/dashboards/grafana-dashboard-okp-mcp.configmap.yaml
+++ b/openshift/dashboards/grafana-dashboard-okp-mcp.configmap.yaml
@@ -64,8 +64,8 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[$__rate_interval])) by (method)",
-              "legendFormat": "{{method}}",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", method=\"POST\"}[$__rate_interval]))",
+              "legendFormat": "POST",
               "range": true,
               "refId": "A"
             }
@@ -98,8 +98,8 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", status=~\"[45]..\"}[$__rate_interval])) by (method, status)",
-              "legendFormat": "{{method}} {{status}}",
+              "expr": "sum(rate(okp_http_requests_total{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", method=\"POST\", status=~\"[45]..\"}[$__rate_interval])) by (status)",
+              "legendFormat": "POST {{status}}",
               "range": true,
               "refId": "A"
             }
@@ -132,8 +132,8 @@ data:
             {
               "datasource": { "type": "prometheus", "uid": "${datasource}" },
               "editorMode": "code",
-              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\"}[$__rate_interval])) by (le, method))",
-              "legendFormat": "{{method}}",
+              "expr": "histogram_quantile(0.95, sum(rate(okp_http_request_duration_seconds_bucket{namespace=\"$namespace\", job=\"okp-mcp\", path!=\"/metrics\", method=\"POST\"}[$__rate_interval])) by (le))",
+              "legendFormat": "POST",
               "range": true,
               "refId": "A"
             }
@@ -160,7 +160,7 @@ data:
                 "lineInterpolation": "linear",
                 "fillOpacity": 10
               },
-              "color": { "mode": "shades", "fixedColor": "blue" }
+              "color": { "mode": "palette-classic" }
             },
             "overrides": []
           },
@@ -194,7 +194,7 @@ data:
                 "lineInterpolation": "linear",
                 "fillOpacity": 10
               },
-              "color": { "mode": "fixed", "fixedColor": "yellow" }
+              "color": { "mode": "palette-classic" }
             },
             "overrides": []
           },
@@ -228,7 +228,7 @@ data:
                 "lineInterpolation": "linear",
                 "fillOpacity": 10
               },
-              "color": { "mode": "fixed", "fixedColor": "yellow" }
+              "color": { "mode": "palette-classic" }
             },
             "overrides": []
           },


### PR DESCRIPTION
## Summary
- Limit the top HTTP dashboard row to POST traffic while continuing to exclude `/metrics`.
- Switch MCP tool operation panels to Grafana's classic palette so tool series use distinct colors.

## Verification
- Parsed the embedded Grafana dashboard JSON successfully.
- Verified the updated dashboard in the Grafana playground as version 2.
- Checked LSP diagnostics for the dashboard ConfigMap.