### PR TITLE
feat(metrics): add Prometheus counters for intent detection

### DIFF
--- a/src/okp_mcp/intent.py
+++ b/src/okp_mcp/intent.py
@@ -15,6 +15,7 @@ import re
 from dataclasses import dataclass
 
 from okp_mcp.config import logger
+from okp_mcp.metrics import INTENT_DEPRECATION_SKIPPED, INTENT_MATCHED, INTENT_NO_MATCH
 
 # ---------------------------------------------------------------------------
 # Intent rule dataclass
@@ -315,7 +316,10 @@ def apply_main_boosts(params: dict, query_lower: str, cleaned_query: str) -> Non
                 params["hl.q"] = f"{cleaned_query} {rule.highlight_terms}"
             boosted = "bq + hl.q" if rule.highlight_terms else "bq"
             logger.info("Intent boost: applied '%s' to main query (%s)", rule.name, boosted)
+            INTENT_MATCHED.labels(intent=rule.name, query_path="main").inc()
             return
+
+    INTENT_NO_MATCH.labels(query_path="main").inc()
 
 
 def apply_deprecation_boosts(params: dict, query_lower: str) -> None:
@@ -346,6 +350,7 @@ def apply_deprecation_boosts(params: dict, query_lower: str) -> None:
         # release_date first (no dep terms) and must not fall through
         # to VM deprecation boosts.
         if not rule.dep_title_terms:
+            INTENT_DEPRECATION_SKIPPED.labels(intent=rule.name).inc()
             return
         existing_bq = params.get("bq", "")
         params["bq"] = (
@@ -356,4 +361,7 @@ def apply_deprecation_boosts(params: dict, query_lower: str) -> None:
         logger.info(
             "Intent boost: applied '%s' to deprecation query (^%d/^%d)", rule.name, _DEP_TITLE_BOOST, _DEP_CONTENT_BOOST
         )
+        INTENT_MATCHED.labels(intent=rule.name, query_path="deprecation").inc()
         return
+
+    INTENT_NO_MATCH.labels(query_path="deprecation").inc()

--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -44,6 +44,38 @@ TOOL_DURATION = Histogram(
 )
 
 # ---------------------------------------------------------------------------
+# Intent detection metrics (recorded by intent.py instrumentation)
+# ---------------------------------------------------------------------------
+
+# Tracks which intent rules fire and on which query path (main vs deprecation).
+# Labels: intent=<rule name>, query_path=<"main"|"deprecation">
+# Bounded cardinality: current 12 rule names x 2 paths = 24 series.
+INTENT_MATCHED = Counter(
+    "okp_intent_matched_total",
+    "Intent rule matched a user query",
+    ["intent", "query_path"],
+)
+
+# Incremented when no intent rule matches a query, indicating a coverage gap
+# in the intent registry.  High values suggest new rules are needed.
+# Labels: query_path=<"main"|"deprecation">
+INTENT_NO_MATCH = Counter(
+    "okp_intent_no_match_total",
+    "No intent rule matched the user query",
+    ["query_path"],
+)
+
+# Counts queries where an intent rule matched in the deprecation path but
+# the rule has no dep_title_terms, causing an early return with no boost.
+# Distinguishes "deliberately no deprecation boost" from "no match at all".
+# Labels: intent=<rule name that caused the skip>
+INTENT_DEPRECATION_SKIPPED = Counter(
+    "okp_intent_deprecation_skipped_total",
+    "Intent matched but skipped deprecation boost (no dep_title_terms)",
+    ["intent"],
+)
+
+# ---------------------------------------------------------------------------
 # Solr backend metrics (recorded by solr.py instrumentation)
 # ---------------------------------------------------------------------------
 SOLR_QUERIES = Counter(

--- a/tests/test_intent_metrics.py
+++ b/tests/test_intent_metrics.py
@@ -1,0 +1,100 @@
+"""Tests for intent detection Prometheus metrics instrumentation."""
+
+from prometheus_client import REGISTRY
+
+from okp_mcp.intent import apply_deprecation_boosts, apply_main_boosts
+
+
+def _get_counter(name: str, labels: dict) -> float:
+    """Read the current value of a Prometheus counter, defaulting to 0."""
+    return REGISTRY.get_sample_value(f"{name}_total", labels) or 0.0
+
+
+# ---------------------------------------------------------------------------
+# apply_main_boosts metrics
+# ---------------------------------------------------------------------------
+
+
+def test_main_boost_match_increments_intent_matched():
+    """Matching a rule in the main path increments okp_intent_matched_total."""
+    labels = {"intent": "spice", "query_path": "main"}
+    before = _get_counter("okp_intent_matched", labels)
+
+    params: dict = {}
+    apply_main_boosts(params, "how to use spice on rhel", "spice rhel")
+
+    assert _get_counter("okp_intent_matched", labels) == before + 1
+
+
+def test_main_boost_no_match_increments_no_match():
+    """Exhausting all rules without a match increments okp_intent_no_match_total."""
+    labels = {"query_path": "main"}
+    before = _get_counter("okp_intent_no_match", labels)
+
+    params: dict = {}
+    apply_main_boosts(params, "completely unrelated topic xyz", "unrelated topic xyz")
+
+    assert _get_counter("okp_intent_no_match", labels) == before + 1
+
+
+def test_main_boost_match_does_not_increment_no_match():
+    """A successful match must not also increment the no-match counter."""
+    no_match_labels = {"query_path": "main"}
+    before_no_match = _get_counter("okp_intent_no_match", no_match_labels)
+
+    params: dict = {}
+    apply_main_boosts(params, "eus support policy", "eus support policy")
+
+    assert _get_counter("okp_intent_no_match", no_match_labels) == before_no_match
+
+
+# ---------------------------------------------------------------------------
+# apply_deprecation_boosts metrics
+# ---------------------------------------------------------------------------
+
+
+def test_deprecation_boost_match_increments_intent_matched():
+    """Matching a rule with dep_title_terms increments okp_intent_matched_total for deprecation."""
+    labels = {"intent": "spice", "query_path": "deprecation"}
+    before = _get_counter("okp_intent_matched", labels)
+
+    params: dict = {}
+    apply_deprecation_boosts(params, "is spice deprecated in rhel 10")
+
+    assert _get_counter("okp_intent_matched", labels) == before + 1
+
+
+def test_deprecation_boost_skipped_increments_skipped_counter():
+    """Rule match with empty dep_title_terms increments okp_intent_deprecation_skipped_total."""
+    labels = {"intent": "release_date"}
+    before = _get_counter("okp_intent_deprecation_skipped", labels)
+
+    params: dict = {}
+    apply_deprecation_boosts(params, "when was rhel 10 released")
+
+    assert _get_counter("okp_intent_deprecation_skipped", labels) == before + 1
+
+
+def test_deprecation_boost_no_match_increments_no_match():
+    """Exhausting all rules without a match increments okp_intent_no_match_total for deprecation."""
+    labels = {"query_path": "deprecation"}
+    before = _get_counter("okp_intent_no_match", labels)
+
+    params: dict = {}
+    apply_deprecation_boosts(params, "completely unrelated topic xyz")
+
+    assert _get_counter("okp_intent_no_match", labels) == before + 1
+
+
+def test_deprecation_skipped_does_not_increment_matched_or_no_match():
+    """A skipped deprecation must not also increment the matched or no-match counters."""
+    matched_labels = {"intent": "release_date", "query_path": "deprecation"}
+    no_match_labels = {"query_path": "deprecation"}
+    before_matched = _get_counter("okp_intent_matched", matched_labels)
+    before_no_match = _get_counter("okp_intent_no_match", no_match_labels)
+
+    params: dict = {}
+    apply_deprecation_boosts(params, "when was rhel 10 released")
+
+    assert _get_counter("okp_intent_matched", matched_labels) == before_matched
+    assert _get_counter("okp_intent_no_match", no_match_labels) == before_no_match

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -11,6 +11,9 @@ from okp_mcp.config import ServerConfig
 from okp_mcp.metrics import (
     HTTP_REQUEST_DURATION,
     HTTP_REQUESTS,
+    INTENT_DEPRECATION_SKIPPED,
+    INTENT_MATCHED,
+    INTENT_NO_MATCH,
     SOLR_QUERIES,
     SOLR_QUERY_DURATION,
     TOOL_CALLS,
@@ -216,6 +219,9 @@ async def test_metrics_endpoint_returns_prometheus_format():
     assert b"okp_http_requests_total" in response.body
     assert b"okp_tool_calls_total" in response.body
     assert b"okp_solr_queries_total" in response.body
+    assert b"okp_intent_matched_total" in response.body
+    assert b"okp_intent_no_match_total" in response.body
+    assert b"okp_intent_deprecation_skipped_total" in response.body
 
 
 async def test_metrics_endpoint_content_type():
@@ -237,6 +243,9 @@ def test_metric_label_names():
     assert TOOL_DURATION._labelnames == ("tool",)
     assert SOLR_QUERIES._labelnames == ("status",)
     assert SOLR_QUERY_DURATION._labelnames == ("status",)
+    assert INTENT_MATCHED._labelnames == ("intent", "query_path")
+    assert INTENT_NO_MATCH._labelnames == ("query_path",)
+    assert INTENT_DEPRECATION_SKIPPED._labelnames == ("intent",)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds three Prometheus counters to track intent detection behavior in production, giving us visibility into which intent rules fire, how often queries fall through without matching, and when deprecation boosts are deliberately skipped.

## New metrics

### `okp_intent_matched_total`

**Labels**: `intent` (rule name), `query_path` ("main" or "deprecation")

Incremented when an intent rule matches a user query. The `query_path` label distinguishes whether the match happened in `apply_main_boosts()` (main search path) or `apply_deprecation_boosts()` (deprecation side-query path).

Cardinality is bounded: 12 current rule names x 2 query paths = 24 max series. New intent rules added to `INTENT_RULES` will create new label values, but the registry is intentionally kept small.

**Example queries**:
- Top intent rules by volume: `topk(5, sum by (intent) (rate(okp_intent_matched_total[1h])))`
- Main vs deprecation match ratio: `sum by (query_path) (rate(okp_intent_matched_total[1h]))`

### `okp_intent_no_match_total`

**Labels**: `query_path` ("main" or "deprecation")

Incremented when the `INTENT_RULES` loop exhausts without any rule matching the query. High values indicate coverage gaps in the intent registry, meaning users are asking questions we have no topic-specific boosts for.

**Example queries**:
- Coverage gap rate: `rate(okp_intent_no_match_total{query_path="main"}[1h]) / (rate(okp_intent_matched_total{query_path="main"}[1h]) + rate(okp_intent_no_match_total{query_path="main"}[1h]))`

### `okp_intent_deprecation_skipped_total`

**Labels**: `intent` (rule name that caused the skip)

Incremented in `apply_deprecation_boosts()` when a rule matches but has empty `dep_title_terms`, causing an early return with no deprecation boost applied. This distinguishes "matched but deliberately no deprecation boost" from "no match at all" (the latter increments `okp_intent_no_match_total` instead).

For example, the `release_date` rule matches "when was RHEL 10 released" but has no deprecation terms because release date queries don't need deprecation content. This counter tracks those intentional skips.

## How intent detection works

The intent system (`intent.py`) uses a first-match-wins registry of regex rules (`INTENT_RULES`) to detect query topics and inject Solr boost queries (`bq`) and highlight terms (`hl.q`). Each query goes through two paths:

1. **Main path** (`apply_main_boosts`): adds topic-specific boosts to the primary search query
2. **Deprecation path** (`apply_deprecation_boosts`): adds topic-specific boosts to the deprecation side-query that looks for deprecation/removal notices

A rule can participate in both paths (e.g., `spice` has both `bq` and `dep_title_terms`) or only the main path (e.g., `release_date` has `bq` but no `dep_title_terms`).

## Instrumentation points

- `intent.py:apply_main_boosts()`: increments `INTENT_MATCHED` on rule match, `INTENT_NO_MATCH` when loop exhausts
- `intent.py:apply_deprecation_boosts()`: increments `INTENT_MATCHED` on rule match with dep terms, `INTENT_DEPRECATION_SKIPPED` on rule match without dep terms, `INTENT_NO_MATCH` when loop exhausts

## Files changed

- `src/okp_mcp/metrics.py`: 3 new `Counter` declarations with descriptive comments
- `src/okp_mcp/intent.py`: import + `.inc()` calls at the 5 instrumentation points
- `tests/test_intent_metrics.py` (new): 7 tests covering all counter paths (match, no-match, skipped) and mutual exclusivity
- `tests/test_metrics.py`: updated label name assertions + `/metrics` endpoint checks for new counters