### PR TITLE
feat(metrics): add search quality Prometheus metrics

### DIFF
--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -89,6 +89,41 @@ SOLR_QUERY_DURATION = Histogram(
     ["status"],
 )
 
+# ---------------------------------------------------------------------------
+# Search quality metrics (recorded by portal.py pipeline instrumentation)
+# ---------------------------------------------------------------------------
+
+# Distribution of final result counts returned to the caller.  The zero
+# bucket doubles as a zero-result detector when read as a rate, but the
+# dedicated counter below is cheaper for alerting.
+SEARCH_RESULT_COUNT = Histogram(
+    "okp_search_result_count",
+    "Number of chunks returned by a portal search",
+    buckets=(0, 1, 2, 3, 5, 7, 10, 15, 25),
+)
+
+# Fires when a portal search pipeline produces zero results, enabling
+# direct alerting without histogram bucket arithmetic.
+SEARCH_ZERO_RESULTS = Counter(
+    "okp_search_zero_results_total",
+    "Portal searches that returned zero results",
+)
+
+# Counts low-quality chunks removed by the score filter.  A sustained
+# high rate may indicate Solr relevance tuning issues.
+SEARCH_SCORE_FILTER_DROPPED = Counter(
+    "okp_search_score_filter_dropped_total",
+    "Chunks dropped by the score quality filter",
+)
+
+# Fires when at least one deprecation-sourced document survives into the
+# final result set.  Useful for tracking how often users hit deprecated
+# or removed features.
+SEARCH_DEPRECATION_DETECTED = Counter(
+    "okp_search_deprecation_detected_total",
+    "Searches where deprecated/removed content appeared in results",
+)
+
 
 class PrometheusMiddleware:
     """ASGI middleware that records HTTP request count and duration."""

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -13,6 +13,12 @@ from okp_mcp.config import logger
 from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate
 from okp_mcp.formatting import _annotate_result
 from okp_mcp.intent import apply_deprecation_boosts, apply_main_boosts
+from okp_mcp.metrics import (
+    SEARCH_DEPRECATION_DETECTED,
+    SEARCH_RESULT_COUNT,
+    SEARCH_SCORE_FILTER_DROPPED,
+    SEARCH_ZERO_RESULTS,
+)
 from okp_mcp.solr import _clean_query, _filter_rhv_sentences, _solr_query
 
 
@@ -502,9 +508,14 @@ def _filter_by_score(chunks: list[PortalChunk]) -> list[PortalChunk]:
     kept = [c for c in chunks if c.score is None or c.score >= threshold]
 
     if len(kept) < len(chunks):
+        dropped = len(chunks) - len(kept)
+        # Intentionally ungated: fires per Solr sub-query (not per user
+        # search) so it measures raw Solr relevance quality, unlike the
+        # other three search quality metrics which emit once per user search.
+        SEARCH_SCORE_FILTER_DROPPED.inc(dropped)
         logger.info(
             "Score filter: dropped %d/%d chunks below %.1f%% of top score (%.1f)",
-            len(chunks) - len(kept),
+            dropped,
             len(chunks),
             _MIN_SCORE_RATIO * 100,
             top_score,
@@ -540,6 +551,7 @@ async def _run_portal_search(
     # current status, but avoids returning low-relevance tail results
     # that inflate the tool response without improving answer quality.
     max_results: int = 7,
+    emit_quality_metrics: bool = True,
 ) -> tuple[list[PortalChunk], bool]:
     """Execute the unified portal search pipeline.
 
@@ -553,6 +565,10 @@ async def _run_portal_search(
             at module level; the actual type is enforced by ``_solr_query``).
         solr_endpoint: Full Solr endpoint URL for the portal core.
         max_results: Maximum chunks to return after deduplication.
+        emit_quality_metrics: Whether to record search quality Prometheus
+            metrics.  Set to ``False`` when called as a sub-query inside
+            ``_run_multi_query_search`` so metrics count user-visible
+            searches, not individual query variants.
 
     Returns:
         Tuple of (top-N PortalChunk list, has_deprecation bool).
@@ -587,6 +603,13 @@ async def _run_portal_search(
 
     dep_parent_ids = {d.parent_id for d in dep_chunks if d.parent_id is not None}
     has_deprecation = any(c.parent_id in dep_parent_ids for c in top_n if c.parent_id is not None)
+
+    if emit_quality_metrics:
+        SEARCH_RESULT_COUNT.observe(len(top_n))
+        if not top_n:
+            SEARCH_ZERO_RESULTS.inc()
+        if has_deprecation:
+            SEARCH_DEPRECATION_DETECTED.inc()
 
     logger.info(
         "Portal search: query=%r main=%d dep=%d merged=%d deduped=%d returned=%d",
@@ -638,6 +661,7 @@ async def _run_multi_query_search(
                 client=client,
                 solr_endpoint=solr_endpoint,
                 max_results=max_results,
+                emit_quality_metrics=False,
             )
             for q in queries
         ],
@@ -671,6 +695,13 @@ async def _run_multi_query_search(
     # from different query variants with different highlight snippets.
     deduped = _deduplicate_by_parent(merged)
 
+    top_n = deduped[:max_results]
+    SEARCH_RESULT_COUNT.observe(len(top_n))
+    if not top_n:
+        SEARCH_ZERO_RESULTS.inc()
+    if has_deprecation:
+        SEARCH_DEPRECATION_DETECTED.inc()
+
     logger.info(
         "Multi-query search: queries=%d succeeded=%d failed=%d chunks_per_query=%s merged=%d deduped=%d returned=%d",
         len(queries),
@@ -679,10 +710,10 @@ async def _run_multi_query_search(
         [len(cl) for cl in chunk_lists],
         len(merged),
         len(deduped),
-        min(len(deduped), max_results),
+        len(top_n),
     )
 
-    return deduped[:max_results], has_deprecation
+    return top_n, has_deprecation
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -14,6 +14,10 @@ from okp_mcp.metrics import (
     INTENT_DEPRECATION_SKIPPED,
     INTENT_MATCHED,
     INTENT_NO_MATCH,
+    SEARCH_DEPRECATION_DETECTED,
+    SEARCH_RESULT_COUNT,
+    SEARCH_SCORE_FILTER_DROPPED,
+    SEARCH_ZERO_RESULTS,
     SOLR_QUERIES,
     SOLR_QUERY_DURATION,
     TOOL_CALLS,
@@ -222,6 +226,10 @@ async def test_metrics_endpoint_returns_prometheus_format():
     assert b"okp_intent_matched_total" in response.body
     assert b"okp_intent_no_match_total" in response.body
     assert b"okp_intent_deprecation_skipped_total" in response.body
+    assert b"okp_search_result_count" in response.body
+    assert b"okp_search_zero_results_total" in response.body
+    assert b"okp_search_score_filter_dropped_total" in response.body
+    assert b"okp_search_deprecation_detected_total" in response.body
 
 
 async def test_metrics_endpoint_content_type():
@@ -246,6 +254,10 @@ def test_metric_label_names():
     assert INTENT_MATCHED._labelnames == ("intent", "query_path")
     assert INTENT_NO_MATCH._labelnames == ("query_path",)
     assert INTENT_DEPRECATION_SKIPPED._labelnames == ("intent",)
+    assert SEARCH_RESULT_COUNT._labelnames == ()
+    assert SEARCH_ZERO_RESULTS._labelnames == ()
+    assert SEARCH_SCORE_FILTER_DROPPED._labelnames == ()
+    assert SEARCH_DEPRECATION_DETECTED._labelnames == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -3,6 +3,7 @@
 import httpx
 import pytest
 import respx
+from prometheus_client import REGISTRY
 
 from okp_mcp.intent import INTENT_RULES, IntentRule, apply_deprecation_boosts, apply_main_boosts
 from okp_mcp.portal import (
@@ -20,6 +21,7 @@ from okp_mcp.portal import (
     _docs_to_chunks,
     _fallback_cve,
     _fallback_errata,
+    _filter_by_score,
     _format_portal_chunk,
     _format_portal_results,
     _reciprocal_rank_fusion,
@@ -1469,3 +1471,166 @@ class TestRunMultiQuerySearch:
                         client=client,
                         solr_endpoint=_SOLR_ENDPOINT,
                     )
+
+
+# ---------------------------------------------------------------------------
+# Search quality metrics
+# ---------------------------------------------------------------------------
+
+
+def _get_counter(name: str, labels: dict | None = None) -> float:
+    """Read the current value of a Prometheus counter, defaulting to 0."""
+    return REGISTRY.get_sample_value(f"{name}_total", labels or {}) or 0.0
+
+
+def _get_histogram_count(name: str, labels: dict | None = None) -> float:
+    """Read the sample count of a Prometheus histogram."""
+    return REGISTRY.get_sample_value(f"{name}_count", labels or {}) or 0.0
+
+
+class TestSearchQualityMetrics:
+    """Verify search quality Prometheus metrics fire at the correct pipeline stages."""
+
+    async def test_result_count_histogram_observed(self):
+        """_run_portal_search observes the result count histogram."""
+        doc = _make_doc(doc_id="m1", allTitle="Metric Doc")
+        hl = {"m1": {"main_content": ["Some content."]}}
+        before = _get_histogram_count("okp_search_result_count")
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=_make_solr_json([doc], hl)))
+            async with httpx.AsyncClient() as client:
+                await _run_portal_search("metric test", client=client, solr_endpoint=_SOLR_ENDPOINT)
+
+        assert _get_histogram_count("okp_search_result_count") == before + 1
+
+    async def test_zero_results_counter_incremented(self):
+        """Zero-result searches increment the dedicated counter."""
+        before = _get_counter("okp_search_zero_results")
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=_make_solr_json([])))
+            async with httpx.AsyncClient() as client:
+                await _run_portal_search("nonexistent query", client=client, solr_endpoint=_SOLR_ENDPOINT)
+
+        assert _get_counter("okp_search_zero_results") == before + 1
+
+    async def test_zero_results_counter_not_incremented_for_hits(self):
+        """Searches that return results do not increment the zero-result counter."""
+        doc = _make_doc(doc_id="hit1", allTitle="Found Doc")
+        hl = {"hit1": {"main_content": ["Found this."]}}
+        before = _get_counter("okp_search_zero_results")
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=_make_solr_json([doc], hl)))
+            async with httpx.AsyncClient() as client:
+                await _run_portal_search("found query", client=client, solr_endpoint=_SOLR_ENDPOINT)
+
+        assert _get_counter("okp_search_zero_results") == before
+
+    async def test_deprecation_detected_counter_incremented(self):
+        """Deprecation content in results increments the detection counter."""
+        normal_doc = _make_doc(doc_id="norm1", allTitle="Normal Doc")
+        dep_doc = _make_doc(doc_id="dep1", allTitle="Removed Feature")
+        hl_normal = {"norm1": {"main_content": ["Normal content."]}}
+        hl_dep = {"dep1": {"main_content": ["Feature was removed."]}}
+        before = _get_counter("okp_search_deprecation_detected")
+
+        def side_effect(request):
+            """Return deprecation doc only for the deprecation sub-query."""
+            q = str(request.url.params.get("q", ""))
+            if "deprecated" in q:
+                return httpx.Response(200, json=_make_solr_json([dep_doc], hl_dep))
+            return httpx.Response(200, json=_make_solr_json([normal_doc], hl_normal))
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
+            async with httpx.AsyncClient() as client:
+                _, has_dep = await _run_portal_search(
+                    "deprecated feature", client=client, solr_endpoint=_SOLR_ENDPOINT
+                )
+
+        assert has_dep is True
+        assert _get_counter("okp_search_deprecation_detected") == before + 1
+
+    async def test_deprecation_counter_not_incremented_without_deprecation(self):
+        """Non-deprecation searches do not increment the deprecation counter."""
+        doc = _make_doc(doc_id="clean1", allTitle="Clean Doc")
+        hl = {"clean1": {"main_content": ["Clean content."]}}
+        before = _get_counter("okp_search_deprecation_detected")
+
+        def side_effect(request):
+            """Return the doc only for the main query, empty for deprecation."""
+            q = str(request.url.params.get("q", ""))
+            if "deprecated" in q:
+                return httpx.Response(200, json=_make_solr_json([]))
+            return httpx.Response(200, json=_make_solr_json([doc], hl))
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
+            async with httpx.AsyncClient() as client:
+                _, has_dep = await _run_portal_search(
+                    "clean query", client=client, solr_endpoint=_SOLR_ENDPOINT
+                )
+
+        assert has_dep is False
+        assert _get_counter("okp_search_deprecation_detected") == before
+
+    async def test_multi_query_emits_metrics_once(self):
+        """Multi-query search emits quality metrics once per user search, not per sub-query."""
+        doc = _make_doc(doc_id="mq1", allTitle="Multi Query Doc")
+        hl = {"mq1": {"main_content": ["Multi query content."]}}
+        hist_before = _get_histogram_count("okp_search_result_count")
+        zero_before = _get_counter("okp_search_zero_results")
+
+        def side_effect(request):
+            """Return doc for main queries, empty for deprecation sub-queries."""
+            q = str(request.url.params.get("q", ""))
+            if "deprecated" in q:
+                return httpx.Response(200, json=_make_solr_json([]))
+            return httpx.Response(200, json=_make_solr_json([doc], hl))
+
+        with respx.mock(assert_all_called=False) as router:
+            router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
+            async with httpx.AsyncClient() as client:
+                await _run_multi_query_search(
+                    ["query one", "query two"],
+                    client=client,
+                    solr_endpoint=_SOLR_ENDPOINT,
+                )
+
+        # Histogram should increment exactly once (the fused result), not twice (per sub-query).
+        assert _get_histogram_count("okp_search_result_count") == hist_before + 1
+        assert _get_counter("okp_search_zero_results") == zero_before
+
+    def test_score_filter_dropped_counter_incremented(self):
+        """Score filter increments the dropped counter for low-quality chunks."""
+        high = PortalChunk(doc_id="h1", score=100.0)
+        low = PortalChunk(doc_id="l1", score=1.0)
+        before = _get_counter("okp_search_score_filter_dropped")
+
+        result = _filter_by_score([high, low])
+
+        assert len(result) == 1
+        assert result[0].doc_id == "h1"
+        assert _get_counter("okp_search_score_filter_dropped") == before + 1
+
+    def test_score_filter_no_increment_when_all_kept(self):
+        """Score filter does not increment when all chunks pass."""
+        c1 = PortalChunk(doc_id="c1", score=100.0)
+        c2 = PortalChunk(doc_id="c2", score=95.0)
+        before = _get_counter("okp_search_score_filter_dropped")
+
+        result = _filter_by_score([c1, c2])
+
+        assert len(result) == 2
+        assert _get_counter("okp_search_score_filter_dropped") == before
+
+    def test_score_filter_empty_input_no_increment(self):
+        """Empty input does not trigger the score filter counter."""
+        before = _get_counter("okp_search_score_filter_dropped")
+
+        result = _filter_by_score([])
+
+        assert result == []
+        assert _get_counter("okp_search_score_filter_dropped") == before


### PR DESCRIPTION
## Summary

Add 4 Prometheus metrics to the portal search pipeline for monitoring search quality:

- `okp_search_result_count` (Histogram): Distribution of result counts per search, with buckets tuned for typical ranges (0-25)
- `okp_search_zero_results_total` (Counter): Searches returning zero results, for alerting on degraded retrieval
- `okp_search_score_filter_dropped_total` (Counter): Chunks dropped by the score quality filter in `_filter_by_score()`
- `okp_search_deprecation_detected_total` (Counter): Searches where deprecated/EOL content was detected

All metrics use the `okp_` prefix and have no labels (following the pattern established in #224 for intent metrics).

## Changes

- **`src/okp_mcp/metrics.py`**: Define 4 new metrics with descriptive comment blocks
- **`src/okp_mcp/portal.py`**: Record metrics at natural co-location points alongside existing log calls
- **`tests/test_metrics.py`**: Shape assertions (metric names in exposition, empty label names)
- **`tests/test_portal.py`**: 8 behavioral tests in `TestSearchQualityMetrics` class with before/after delta assertions

## Ref

[RSPEED-3018](https://redhat.atlassian.net/browse/RSPEED-3018)

[RSPEED-3018]: https://redhat.atlassian.net/browse/RSPEED-3018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ