### PR TITLE
RSPEED-3018: Add Prometheus metrics for document retrieval outcomes

### DIFF
--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -125,6 +125,44 @@ SEARCH_DEPRECATION_DETECTED = Counter(
 )
 
 
+# ---------------------------------------------------------------------------
+# Document retrieval metrics (recorded by tools/document.py instrumentation)
+# ---------------------------------------------------------------------------
+
+# Fires when a get_document lookup returns no matching Solr document,
+# indicating the LLM passed a stale or fabricated doc ID.  A sustained
+# high rate suggests search_portal result URLs are drifting from the
+# Solr index.
+DOCUMENT_NOT_FOUND = Counter(
+    "okp_document_not_found_total",
+    "Document ID lookups that returned no results",
+)
+
+# Fires when a documentation page is requested without a query, causing
+# a nudge response instead of content.  Tracks how often LLMs skip the
+# query parameter on large docs.
+DOCUMENT_NUDGE = Counter(
+    "okp_document_nudge_total",
+    "Documentation pages served a nudge instead of content (no query)",
+)
+
+# Fires when Solr highlighting produces usable snippets for a document
+# retrieval.  Compare against DOCUMENT_HIGHLIGHT_FALLBACK to gauge
+# highlighting health.
+DOCUMENT_HIGHLIGHT_USED = Counter(
+    "okp_document_highlight_used_total",
+    "Document retrievals that used Solr highlight snippets",
+)
+
+# Fires when a query-based document retrieval falls back to local BM25
+# paragraph extraction because Solr returned no highlights.  A high
+# ratio vs DOCUMENT_HIGHLIGHT_USED signals Solr highlighting issues.
+DOCUMENT_HIGHLIGHT_FALLBACK = Counter(
+    "okp_document_highlight_fallback_total",
+    "Document retrievals that fell back to BM25 extraction (no highlights)",
+)
+
+
 class PrometheusMiddleware:
     """ASGI middleware that records HTTP request count and duration."""
 

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -8,7 +8,14 @@ import httpx
 from fastmcp import Context
 
 from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate, truncate_content
-from okp_mcp.metrics import TOOL_CALLS, TOOL_DURATION
+from okp_mcp.metrics import (
+    DOCUMENT_HIGHLIGHT_FALLBACK,
+    DOCUMENT_HIGHLIGHT_USED,
+    DOCUMENT_NOT_FOUND,
+    DOCUMENT_NUDGE,
+    TOOL_CALLS,
+    TOOL_DURATION,
+)
 from okp_mcp.server import get_app_context, mcp
 from okp_mcp.solr import _clean_query, _extract_relevant_section, _get_highlight_snippets, _solr_query
 from okp_mcp.tools.shared import DOCUMENT_FL
@@ -123,6 +130,7 @@ def _format_document_content(
     # Documentation without a query is almost always useless (first 1500 chars
     # is typically a table of contents). Nudge the caller to be specific.
     if is_documentation and not query:
+        DOCUMENT_NUDGE.inc()
         return (
             "\n\nThis is a large documentation page. "
             "Pass a query to get_document to extract the most relevant passages."
@@ -140,15 +148,19 @@ def _format_document_content(
 
     if is_documentation:
         if highlight_snippets:
+            DOCUMENT_HIGHLIGHT_USED.inc()
             doc_budget = min(max_chars, _DOCUMENTATION_MAX_CHARS)
             return _format_document_passages(highlight_snippets, query, doc_budget, current_result)
+        DOCUMENT_HIGHLIGHT_FALLBACK.inc()
         extracted = _extract_relevant_section(
             content, query, per_section=_DOCUMENTATION_PER_SECTION, max_sections=_DOCUMENTATION_MAX_SECTIONS
         )
         return f"\n\nContent:\n{extracted}"
 
     if not highlight_snippets:
+        DOCUMENT_HIGHLIGHT_FALLBACK.inc()
         return f"\n\nContent:\n{_extract_relevant_section(content, query, max_sections=8)}"
+    DOCUMENT_HIGHLIGHT_USED.inc()
     return f"\n\nContent:\n{' ... '.join(highlight_snippets)}"
 
 
@@ -240,6 +252,7 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
 
         docs = data["response"]["docs"]
         if not docs:
+            DOCUMENT_NOT_FOUND.inc()
             return f"Document not found: {doc_id}"
 
         return await _format_document(docs[0], data, doc_id, query, app.max_response_chars)

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,7 +1,13 @@
 """Tests for document retrieval tool formatting functions."""
 
-import pytest
+from unittest.mock import AsyncMock, Mock, patch
 
+import httpx
+import pytest
+from prometheus_client import REGISTRY
+
+from okp_mcp import tools
+from okp_mcp.config import ServerConfig
 from okp_mcp.tools.document import (
     _DOCUMENTATION_MAX_CHARS,
     _DOCUMENTATION_MAX_SECTIONS,
@@ -11,6 +17,8 @@ from okp_mcp.tools.document import (
     _format_metadata,
     _uses_document_passages,
 )
+
+_SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
 
 def _make_doc(
@@ -268,3 +276,155 @@ def test_format_document_passages_negative_budget():
     """If metadata already exhausted the budget, passages return empty."""
     result = _format_document_passages(["snippet"], query="test", max_chars=100, current_result="x" * 200)
     assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Helpers for Prometheus metric assertions
+# ---------------------------------------------------------------------------
+
+
+def _get_counter(name: str, labels: dict | None = None) -> float:
+    """Read the current value of a Prometheus counter, defaulting to 0."""
+    return REGISTRY.get_sample_value(f"{name}_total", labels or {}) or 0.0
+
+
+# ---------------------------------------------------------------------------
+# Document retrieval metric assertions
+# ---------------------------------------------------------------------------
+
+
+class TestDocumentRetrievalMetrics:
+    """Verify Prometheus metric increments for document retrieval outcomes."""
+
+    @pytest.mark.parametrize(
+        "kind, view_uri, query, expected_delta",
+        [
+            pytest.param("documentation", "/documentation/en-US/test", "", 1, id="documentation-no-query"),
+            pytest.param("documentation", "/documentation/en-US/test", "RHEL", 0, id="documentation-with-query"),
+            pytest.param("solution", "/solutions/12345", "", 0, id="non-documentation-no-query"),
+        ],
+    )
+    def test_nudge_counter(self, kind, view_uri, query, expected_delta):
+        """Nudge counter fires only for documentation pages without a query."""
+        doc = _make_doc(kind=kind, view_uri=view_uri, content="x" * 1000)
+        data = _make_data()
+        before = _get_counter("okp_document_nudge")
+
+        _format_document_content(doc, data, doc["view_uri"], query=query, max_chars=30_000, current_result="")
+
+        assert _get_counter("okp_document_nudge") == before + expected_delta
+
+    @pytest.mark.parametrize(
+        "kind, view_uri, content, snippets, query, counter_name, expected_delta",
+        [
+            pytest.param(
+                "documentation", "/documentation/en-US/test", "Content", ["Snippet about kernel configuration"],
+                "kernel", "okp_document_highlight_used", 1, id="doc-with-highlights",
+            ),
+            pytest.param(
+                "solution", "/solutions/12345", "Full body.", ["Fix for the network issue"],
+                "network", "okp_document_highlight_used", 1, id="non-doc-with-highlights",
+            ),
+            pytest.param(
+                "documentation", "/documentation/en-US/test", "Content about systemd units " + "w" * 300, None,
+                "systemd", "okp_document_highlight_fallback", 1, id="doc-no-highlights",
+            ),
+            pytest.param(
+                "solution", "/solutions/12345", "Solution about networking " + "z" * 300, None,
+                "networking", "okp_document_highlight_fallback", 1, id="non-doc-no-highlights",
+            ),
+        ],
+    )
+    def test_highlight_counter(self, kind, view_uri, content, snippets, query, counter_name, expected_delta):
+        """Highlight-used or fallback counter fires based on snippet availability."""
+        doc = _make_doc(kind=kind, view_uri=view_uri, content=content)
+        data = _make_data(highlight_key=view_uri, snippets=snippets) if snippets else _make_data()
+        before = _get_counter(counter_name)
+
+        _format_document_content(doc, data, view_uri, query=query, max_chars=30_000, current_result="")
+
+        assert _get_counter(counter_name) == before + expected_delta
+
+    def test_no_highlight_metrics_without_query(self):
+        """Non-documentation without query fires neither highlight counter."""
+        doc = _make_doc(kind="solution", view_uri="/solutions/12345", content="Solution body")
+        data = _make_data()
+        before_used = _get_counter("okp_document_highlight_used")
+        before_fallback = _get_counter("okp_document_highlight_fallback")
+
+        _format_document_content(doc, data, doc["view_uri"], query="", max_chars=30_000, current_result="")
+
+        assert _get_counter("okp_document_highlight_used") == before_used
+        assert _get_counter("okp_document_highlight_fallback") == before_fallback
+
+    def test_no_highlight_metrics_without_main_content(self):
+        """Missing main_content fires neither highlight counter."""
+        doc = _make_doc(kind="documentation", content="x")
+        doc["main_content"] = None
+        data = _make_data()
+        before_used = _get_counter("okp_document_highlight_used")
+        before_fallback = _get_counter("okp_document_highlight_fallback")
+
+        _format_document_content(doc, data, doc["view_uri"], query="kernel", max_chars=30_000, current_result="")
+
+        assert _get_counter("okp_document_highlight_used") == before_used
+        assert _get_counter("okp_document_highlight_fallback") == before_fallback
+
+
+# ---------------------------------------------------------------------------
+# Document not-found metric (requires tool-level mock)
+# ---------------------------------------------------------------------------
+
+
+async def test_not_found_counter_incremented():
+    """get_document increments the not-found counter when Solr returns no docs."""
+    mock_ctx = Mock()
+    mock_app = Mock()
+    mock_app.http_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_app.solr_endpoint = _SOLR_ENDPOINT
+    mock_app.max_response_chars = 5000
+
+    before = _get_counter("okp_document_not_found")
+
+    with (
+        patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),
+        patch("okp_mcp.tools.document._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_fetch.return_value = {"response": {"docs": []}}
+        result = await tools.get_document(mock_ctx, "/solutions/nonexistent")
+
+    assert _get_counter("okp_document_not_found") == before + 1
+    assert "Document not found" in result
+
+
+async def test_not_found_counter_not_incremented_when_doc_exists():
+    """get_document does not fire the not-found counter when a doc is returned."""
+    mock_ctx = Mock()
+    mock_app = Mock()
+    mock_app.http_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_app.solr_endpoint = _SOLR_ENDPOINT
+    mock_app.max_response_chars = 30_000
+
+    before = _get_counter("okp_document_not_found")
+
+    with (
+        patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),
+        patch("okp_mcp.tools.document._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
+    ):
+        mock_fetch.return_value = {
+            "response": {
+                "docs": [
+                    {
+                        "allTitle": "Test Solution",
+                        "documentKind": "solution",
+                        "view_uri": "/solutions/12345",
+                        "id": "/solutions/12345",
+                        "main_content": "Solution content here.",
+                    }
+                ]
+            },
+            "highlighting": {},
+        }
+        await tools.get_document(mock_ctx, "/solutions/12345")
+
+    assert _get_counter("okp_document_not_found") == before

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -9,6 +9,10 @@ from prometheus_client import REGISTRY
 
 from okp_mcp.config import ServerConfig
 from okp_mcp.metrics import (
+    DOCUMENT_HIGHLIGHT_FALLBACK,
+    DOCUMENT_HIGHLIGHT_USED,
+    DOCUMENT_NOT_FOUND,
+    DOCUMENT_NUDGE,
     HTTP_REQUEST_DURATION,
     HTTP_REQUESTS,
     INTENT_DEPRECATION_SKIPPED,
@@ -230,6 +234,10 @@ async def test_metrics_endpoint_returns_prometheus_format():
     assert b"okp_search_zero_results_total" in response.body
     assert b"okp_search_score_filter_dropped_total" in response.body
     assert b"okp_search_deprecation_detected_total" in response.body
+    assert b"okp_document_not_found_total" in response.body
+    assert b"okp_document_nudge_total" in response.body
+    assert b"okp_document_highlight_used_total" in response.body
+    assert b"okp_document_highlight_fallback_total" in response.body
 
 
 async def test_metrics_endpoint_content_type():
@@ -258,6 +266,10 @@ def test_metric_label_names():
     assert SEARCH_ZERO_RESULTS._labelnames == ()
     assert SEARCH_SCORE_FILTER_DROPPED._labelnames == ()
     assert SEARCH_DEPRECATION_DETECTED._labelnames == ()
+    assert DOCUMENT_NOT_FOUND._labelnames == ()
+    assert DOCUMENT_NUDGE._labelnames == ()
+    assert DOCUMENT_HIGHLIGHT_USED._labelnames == ()
+    assert DOCUMENT_HIGHLIGHT_FALLBACK._labelnames == ()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Add 4 label-free Prometheus counters tracking document retrieval quality: not-found rate (`okp_document_not_found_total`), documentation nudge rate (`okp_document_nudge_total`), highlight hit rate (`okp_document_highlight_used_total`), and BM25 fallback rate (`okp_document_highlight_fallback_total`)
- Metrics record at decision points in `get_document()` and `_format_document_content()`, giving visibility into whether users get useful content or silent degradation
- 12 parameterized + standalone tests covering all counter branches and edge cases

Jira: [RSPEED-3018](https://redhat.atlassian.net/browse/RSPEED-3018)

[RSPEED-3018]: https://redhat.atlassian.net/browse/RSPEED-3018?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ