### PR TITLE
ci(konflux): enable package registry proxy on prefetch task

### DIFF
--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -177,6 +177,9 @@ spec:
         - name: ociArtifactExpiresAfter
           value: $(params.image-expires-after)
 
+        - name: enable-package-registry-proxy
+          value: "true"
+
       runAfter:
         - clone-repository
 


### PR DESCRIPTION
## Summary
- Unblock Konflux builds after EC policy `prefetch_dependencies.package_registry_proxy_enabled` took effect on 2026-05-13.
- Without this param, EC verify fails on all three image components (arm64, amd64, index).

## Changes
- Add `enable-package-registry-proxy: \"true\"` to the `prefetch-dependencies-oci-ta` task params in `.tekton/pipeline-build-multiarch.yaml`.

## Testing
Konflux pipeline run on this branch will confirm EC verify passes.

## Related
- Refs: RSPEED-3084