### PR TITLE
chore(tekton): update all task digests to latest

### DIFF
--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -119,7 +119,7 @@ spec:
             value: init
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:288f3106118edc1d0f0c79a89c960abf5841a4dd8bc3f38feb10527253105b19
+            value: quay.io/konflux-ci/tekton-catalog/task-init:0.4@sha256:5a423246792ac501ea279229b42ee57da9927da441c04b5c9ff86817b0856b08
 
           - name: kind
             value: task
@@ -154,7 +154,7 @@ spec:
             value: git-clone-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:2c388d28651457db60bb90287e7d8c3680303197196e4476878d98d81e8b6dc9
+            value: quay.io/konflux-ci/tekton-catalog/task-git-clone-oci-ta:0.1@sha256:13d49df7dc9ae301627e45f95a236011422996152f1bea46cd60217b0f057407
 
           - name: kind
             value: task
@@ -190,7 +190,7 @@ spec:
             value: prefetch-dependencies-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a579d00fe370b6d9a1cb1751c883ecd0ec9f663604344e2fd61e1f6d5bf4e990
+            value: quay.io/konflux-ci/tekton-catalog/task-prefetch-dependencies-oci-ta:0.3@sha256:a2efbcdcecfa5293a622eb356a18f5c88e5714046b214fe8730b43b1a7dbb77d
 
           - name: kind
             value: task
@@ -277,7 +277,7 @@ spec:
             value: buildah-remote-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:a9ca472e297388d6ef8d1f51ee205abee6076aed7c5356ec0df84f14a2e78ad8
+            value: quay.io/konflux-ci/tekton-catalog/task-buildah-remote-oci-ta:0.9@sha256:f667d1146533b1d49829c08097e31faf27db24563da576434a707353de62099f
 
           - name: kind
             value: task
@@ -315,7 +315,7 @@ spec:
             value: build-image-index
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b65a1e0961e0e768dda1f118bc5b5cab9c7ca7f4ed094e6a4352e66f82b9fa0b
+            value: quay.io/konflux-ci/tekton-catalog/task-build-image-index:0.3@sha256:b33bfa8dc27dbf459f0779598ba45dcaa490bcc9f8efe1652bcf360ec8cb5582
 
           - name: kind
             value: task
@@ -338,7 +338,7 @@ spec:
             value: deprecated-image-check
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:5ff16b7e6b4a8aa1adb352e74b9f831f77ff97bafd1b89ddb0038d63335f1a67
+            value: quay.io/konflux-ci/tekton-catalog/task-deprecated-image-check:0.5@sha256:e78d0d3baf3c8cfc1a5ad278196b74032d9568b143a87c7a79ab780fedfb296e
 
           - name: kind
             value: task
@@ -367,7 +367,7 @@ spec:
             value: clair-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:cd49cdea7e5403a87c4774bd8ea10bc4e6aeb83841ff490cbe42b782779513a7
+            value: quay.io/konflux-ci/tekton-catalog/task-clair-scan:0.3.2@sha256:8fad4c2e2f470f82ee43d6b2ac72327b4d9c6e9cb514a678911c1c9359c29894
 
           - name: kind
             value: task
@@ -392,7 +392,7 @@ spec:
             value: ecosystem-cert-preflight-checks
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:b4ac586edea81dcd25dfc17f1bd57899825be2b443e48d572cd05ce058f153bb
+            value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.2@sha256:9c300728a03f41beee9a689422d66513d32ab5f804664fe561b11cebacd07799
 
           - name: kind
             value: task
@@ -429,7 +429,7 @@ spec:
             value: sast-snyk-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:d83becbfefe2aa39971c3d37bdc23489b745e22fd86cf4872455a133f8cb274f
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-snyk-check-oci-ta:0.4@sha256:8f3ecbeaff579e41b8278f82d7fabac27845db17a8e687ea6c510c0c9aceabbb
 
           - name: kind
             value: task
@@ -458,7 +458,7 @@ spec:
             value: clamav-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3.1@sha256:171eca520b545a0c860c6d59249796ffe5db5be1dab87f3a328fc5ef1fd68af2
+            value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.3.1@sha256:567cb66bd2e1f4b58b9d4d756f3317fc62479e0b40aa0de66094b1f12d296cfc
 
           - name: kind
             value: task
@@ -493,7 +493,7 @@ spec:
             value: sast-shell-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:6f047f52c04ee6e4d2cb25af46e3ea92b235f6c5e02da540fb7ef0b90718bc0a
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-shell-check-oci-ta:0.1@sha256:c4ef47e3b4e0508572d266fb745be7e374c29dc02580328cbe9f4d472a8aca57
 
           - name: kind
             value: task
@@ -528,7 +528,7 @@ spec:
             value: sast-unicode-check-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:55006815522c57c1f83451dc0cba723ff7427dbac48553538b75cda7bf886d79
+            value: quay.io/konflux-ci/tekton-catalog/task-sast-unicode-check-oci-ta:0.4@sha256:90efa582de7770d55102b74014a765cd16a25a56f2cf644b56a788c70c4dc749
 
           - name: kind
             value: task
@@ -563,7 +563,7 @@ spec:
             value: apply-tags
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:510b6d2a3b188adeb716e49566b57d611ab36bd69a2794b5ddfc11dbf014c2ca
+            value: quay.io/konflux-ci/tekton-catalog/task-apply-tags:0.3@sha256:a291081de7fb27f832c6fc3c4b078acf7e6162ca4c085db38b118ca87e8b5b66
 
           - name: kind
             value: task
@@ -595,7 +595,7 @@ spec:
             value: push-dockerfile-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:1bc2d0f26b89259db090a47bb38217c82c05e335d626653d184adf1d196ca131
+            value: quay.io/konflux-ci/tekton-catalog/task-push-dockerfile-oci-ta:0.3@sha256:7855471abfe87de080b914f2f3ca27c59e64f6448a7c2435e51435b764494c71
 
           - name: kind
             value: task
@@ -618,7 +618,7 @@ spec:
             value: rpms-signature-scan
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:35a4ccda7e213d83d9f5e7ea5cad91dd180cbcebcb6c46f8d41a579478dd2072
+            value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2.1@sha256:41720da9dfe26f33b0bdc46bbf8667a27dae4790d8e5c5f4412224658de7b213
 
           - name: kind
             value: task

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,51 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Modify CI/CD workflows | `.github/workflows/` | `build.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 
+## Tekton Pipeline Maintenance
+
+### Pipeline Files
+
+- `.tekton/pipeline-build-multiarch.yaml`: Konflux multi-arch build Pipeline with task references pinned to `quay.io/konflux-ci/tekton-catalog/<task>:<version>@sha256:<digest>`.
+- `.tekton/pull_request.yaml`: PipelineRun triggered on PR events.
+- `.tekton/push.yaml`: PipelineRun triggered on push to main/release branches.
+- `.tekton/task-get-version.yaml`: Local Task (not from catalog, no version tracking needed).
+
+Renovate (`renovate.json`) tracks Tekton task updates automatically (weekly on Mondays, non-major updates automerged).
+
+### Auditing Task Versions
+
+To check whether pinned tasks are current:
+
+1. Extract task references: `grep 'quay.io/konflux-ci/tekton-catalog/' .tekton/pipeline-build-multiarch.yaml`
+2. For each task, list available version tags:
+   ```bash
+   skopeo list-tags docker://quay.io/konflux-ci/tekton-catalog/<task> \
+     | jq -r '.Tags[]' | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -5
+   ```
+3. Get the latest digest for the current (or newer) version tag:
+   ```bash
+   skopeo inspect docker://quay.io/konflux-ci/tekton-catalog/<task>:<version> | jq -r '.Digest'
+   ```
+4. Compare the canonical upstream pipeline to detect missing/added tasks or structural changes:
+   ```bash
+   curl -sL https://raw.githubusercontent.com/konflux-ci/build-definitions/main/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+   ```
+
+**zsh gotcha**: The bash tool runs in zsh. Bash-only syntax like `declare -A` associative arrays will fail. Write the script to a temp file and run it with `bash /tmp/script.sh` instead.
+
+### Known Gaps (as of 2026-05-20)
+
+**Missing task**: `source-build-oci-ta:0.3` - builds a source container image. Present in the canonical pipeline but absent from ours. Runs after `build-image-index`, gated by a `build-source-image` param. Needs `BINARY_IMAGE`, `BINARY_IMAGE_DIGEST`, `SOURCE_ARTIFACT`, `CACHI2_ARTIFACT` params.
+
+**Matrix strategy migrations**: The canonical pipeline uses `matrix.params` for per-platform execution on these tasks, but our pipeline does not:
+- `clair-scan` (matrix on `image-platform`)
+- `clamav-scan` (matrix on `image-arch`)
+- `ecosystem-cert-preflight-checks` (matrix on `platform`)
+
+Adopting matrix strategies requires adding `matrix.params` blocks and adjusting the task param wiring. This is a structural change, not just a version bump.
+
+**Patch version divergence**: Our `clair-scan` (0.3.2) and `clamav-scan` (0.3.1) use patch versions ahead of the canonical pipeline's `0.3`. These patch versions exist in the catalog and are valid, but may drift from canonical expectations.
+
 ## Boot Sequence
 
 ```text


### PR DESCRIPTION
## Summary

- Refresh all 15 Tekton task bundle digests to current latest from `quay.io/konflux-ci/tekton-catalog` via `skopeo inspect`
- Bump `rpms-signature-scan` from 0.2 to 0.2.1 (only task with a newer version tag)
- Document the Tekton audit process in AGENTS.md for future maintenance

## Changes

- **`.tekton/pipeline-build-multiarch.yaml`**: Updated all 15 `sha256:` digest pins. Version bump for `rpms-signature-scan` (0.2 -> 0.2.1). No structural changes.
- **`AGENTS.md`**: New "Tekton Pipeline Maintenance" section covering auditing commands (`skopeo list-tags` / `skopeo inspect`), canonical pipeline comparison, zsh gotcha for bash-only syntax, and known gaps (missing `source-build-oci-ta` task, matrix strategy migrations for scan tasks, patch version divergence).

## Known Gaps (not addressed in this PR)

These are documented in AGENTS.md for future work:

- **Missing task**: `source-build-oci-ta:0.3` is in the canonical Konflux pipeline but not in ours
- **Matrix strategies**: canonical pipeline uses `matrix.params` for `clair-scan`, `clamav-scan`, and `ecosystem-cert-preflight-checks` (per-platform execution); we don't
- **Patch version divergence**: our `clair-scan` (0.3.2) and `clamav-scan` (0.3.1) are ahead of canonical's `0.3`

## Testing

- [x] `make ci` passes (lint, typecheck, radon, 387 tests)
- [x] No Python source changes, only YAML and markdown