### PR TITLE
ci(tekton): add source-build-oci-ta task for source container images

### DIFF
--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -83,6 +83,11 @@ spec:
       default: "false"
       type: string
 
+    - name: build-source-image
+      description: Build a source image.
+      default: "false"
+      type: string
+
     - name: tag-prefix
       description: Prefix added to additional tags
       type: string
@@ -319,6 +324,41 @@ spec:
 
           - name: kind
             value: task
+
+    - name: build-source-image
+      params:
+        - name: BINARY_IMAGE
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+
+        - name: BINARY_IMAGE_DIGEST
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+
+        - name: SOURCE_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+
+        - name: CACHI2_ARTIFACT
+          value: $(tasks.prefetch-dependencies.results.CACHI2_ARTIFACT)
+
+      runAfter:
+        - build-image-index
+
+      taskRef:
+        resolver: bundles
+        params:
+          - name: name
+            value: source-build-oci-ta
+
+          - name: bundle
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06
+
+          - name: kind
+            value: task
+
+      when:
+        - input: $(params.build-source-image)
+          operator: in
+          values:
+            - "true"
 
     - name: deprecated-base-image-check
       params:


### PR DESCRIPTION
## Summary

Add the `source-build-oci-ta` task to the Tekton pipeline, aligning with the canonical Konflux `docker-build-multi-platform-oci-ta` pipeline.

## Why

During a full audit of our Tekton pipeline against the [canonical Konflux pipeline](https://github.com/konflux-ci/build-definitions/blob/main/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml) (see #238), this task was identified as missing. The `source-build-oci-ta` task builds a source container image from the binary image and prefetched sources, which is required for source container compliance in Konflux builds.

## Changes

- Add `build-source-image` pipeline parameter (default: `"false"`) so existing builds are unaffected
- Add `build-source-image` task after `build-image-index`, gated by the new parameter
- Task uses `source-build-oci-ta:0.3` pinned to `sha256:0917cfc7772e82cb8e74743c2104f43bcf2596aceafe87eec6fce69a8cac5f06`

## Testing

- `make ci` passes (387 tests, lint, typecheck, radon all clean)
- YAML validated with `yaml.safe_load()`
- No Python source changes, only pipeline YAML