### PR TITLE
chore(coderabbit): disable auto-review to conserve quota

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -30,8 +30,12 @@ reviews:
     description:
       mode: warning
 
+  # Auto-review disabled to conserve quota. Trigger reviews manually by
+  # commenting `@coderabbitai review` on a PR, or run locally via the
+  # CodeRabbit CLI (see AGENTS.md). Pre-PR local reviews use the same
+  # config when invoked with `-c .coderabbit.yaml`.
   auto_review:
-    enabled: true
+    enabled: false
     drafts: false
     auto_pause_after_reviewed_commits: 0
     base_branches:


### PR DESCRIPTION
Auto-reviews on every push and PR were burning through our CodeRabbit quota faster than we needed. Switch to manual triggering.

After this:

- No automatic reviews on PR open or push
- Comment `@coderabbitai review` on a PR to request one on demand
- Local pre-PR reviews via the CodeRabbit CLI still work (`coderabbit review --agent -c .coderabbit.yaml`); they already use this same config

Pre-merge docstring/description checks remain enabled. They only fire when a review is triggered, so this stays consistent with the manual-trigger model.