### PR TITLE
chore: bump version to 1.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "okp-mcp"
-version = "1.0.0"
+version = "1.0.1"
 description = "MCP server for the Offline Knowledge Portal"
 readme = "README.md"
 authors = [{ name = "Major Hayden", email = "major@redhat.com" }]


### PR DESCRIPTION
Trivial version bump to trigger Konflux build and verify auto-deploy to stage (RSPEED-3081).