### PR TITLE
fix(renovate): extend org-level shared config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["local>rhel-lightspeed/renovate-config"]
 }


### PR DESCRIPTION
The org preset from rhel-lightspeed/renovate-config wasn't being inherited automatically. Adds explicit `extends` so Tekton task tracking, weekend schedule, and other org rules take effect.

Closes #9