### PR TITLE
fix(renovate): override broken tekton managerFilePatterns from org config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["local>rhel-lightspeed/renovate-config"]
+  "extends": ["local>rhel-lightspeed/renovate-config"],
+  "tekton": {
+    "managerFilePatterns": ["/\\.tekton/.+\\.ya?ml$/"]
+  }
 }


### PR DESCRIPTION
The org-level `rhel-lightspeed/renovate-config` sets `managerFilePatterns` for the tekton manager without regex delimiters (`\\.tekton/.+\\.ya?ml$`), so Renovate interprets it as a glob pattern and matches zero files. This is why Tekton never appears on the Dependency Dashboard.

This PR overrides the pattern locally with properly delimited regex (`/\\.tekton/.+\\.ya?ml$/`) until the org config is fixed.

Once Renovate picks up Tekton deps successfully, the fix should be pushed to `rhel-lightspeed/renovate-config/default.json` and this local override removed.