### PR TITLE
fix(ci): use full version tag for astral-sh/setup-uv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -73,7 +73,7 @@ jobs:
           exit 1
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
Renovate logs show:

```text
DEBUG: github/tags.findCommitOfTag: Tag v8 not found for astral-sh/setup-uv
DEBUG: Could not determine new digest for update.
```

`astral-sh/setup-uv` does not publish rolling major version tags (`v8`), only point releases (`v8.0.0`, `v8.1.0`). The `# v8` comment in the SHA-pinned action reference caused Renovate to fail digest lookups.

Bumps from v8.0.0 to v8.1.0 and uses the full version tag in the comment so Renovate can resolve it.