### PR TITLE
Install Red Hat CA in trigger Job for gitlab.cee.redhat.com

### DIFF
--- a/openshift/qe-gating-stage-trigger.yml
+++ b/openshift/qe-gating-stage-trigger.yml
@@ -88,6 +88,11 @@ objects:
                     microdnf install -y curl && microdnf clean all
                   fi
 
+                  # Install Red Hat internal CA so curl trusts gitlab.cee.redhat.com
+                  curl -sk -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CAs.pem \
+                    https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem \
+                    && update-ca-trust
+
                   POLL_INTERVAL=60
                   MAX_WAIT=7200  # 2 hours
 


### PR DESCRIPTION
The ubi9/ubi-minimal image does not trust the Red Hat internal CA. Add the Red Hat IT root CA bundle before making API calls so curl can verify gitlab.cee.redhat.com's certificate.