### PR TITLE
Simplify container image build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ uv run okp-mcp [--transport ...] [--port ...]
        ├─ CliApp.run(ServerConfig)     # parse CLI + MCP_* env vars
        ├─ _configure_logging()
        ├─ telemetry.initialize_error_reporting()  # no-op unless MCP_GLITCHTIP_DSN is set
-       ├─ log version + commit SHA     # build_info.py reads /app/COMMIT_SHA
+       ├─ log version + commit SHA     # build_info.py reads /opt/app-root/COMMIT_SHA
        └─ mcp.run(transport=...)       # start FastMCP server
             → server.py: _app_lifespan()
                 ├─ creates shared httpx.AsyncClient

--- a/Containerfile
+++ b/Containerfile
@@ -1,26 +1,30 @@
-# Stage 1: Builder - UBI 10 full image has Python 3.12 + pip
-FROM registry.access.redhat.com/ubi10:latest@sha256:0dd39702a460602f3c15a9f5abd7620de550a8d23ffcb249c0ad4aa163ec60ae AS builder
+# Common base image
+FROM registry.access.redhat.com/ubi10/python-312-minimal:latest@sha256:da336bc214ac27e4c5c096f3f5f058b5292529720468f479395c108e4fd836a0 AS base
+
+# Stage 1: Builder
+FROM base AS builder
 
 WORKDIR /build
 
-# Install pip then uv for fast, reproducible dependency resolution
-RUN dnf install -y python3-pip && dnf clean all && python3 -m pip install uv
+# Install uv for fast, reproducible dependency resolution
+RUN python3 -m venv tools && tools/bin/pip install uv
 
 # Copy dependency files first for layer caching
 COPY pyproject.toml uv.lock README.md ./
 
-# Install production dependencies only (skip the project itself for now)
-RUN uv sync --no-dev --no-install-project
+# Specify uv project, virtual environment, and Python executable
+ENV UV_PROJECT=/build
+ENV UV_PROJECT_ENVIRONMENT="${APP_ROOT}"
+ENV UV_PYTHON=/usr/bin/python3
 
-# Copy source and install the package itself (no deps, already installed)
+# Copy source and install the package
 COPY src/ ./src/
-RUN uv pip install . --no-deps && \
-    sed -i 's|^#!.*python.*|#!/app/.venv/bin/python3|' /build/.venv/bin/okp-mcp
+RUN tools/bin/uv sync --no-cache --locked --no-dev --no-editable
 
 # Stage 2: Runtime - minimal UBI 10 Python 3.12 image
-FROM registry.access.redhat.com/ubi10/python-312-minimal:latest@sha256:da336bc214ac27e4c5c096f3f5f058b5292529720468f479395c108e4fd836a0
+FROM base
 
-WORKDIR /app
+WORKDIR "${APP_ROOT}"
 
 LABEL com.redhat.component=okp-mcp
 LABEL description="MCP server for the RHEL Offline Knowledge Portal"
@@ -29,19 +33,18 @@ LABEL summary="OKP MCP Server"
 LABEL vendor="Red Hat, Inc."
 
 # Copy the virtual environment from builder
-COPY --from=builder /build/.venv /app/.venv
+COPY --from=builder "$APP_ROOT" "$APP_ROOT"
 
 # License required by Red Hat preflight certification
 COPY LICENSE /licenses/LICENSE
 
-ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
 # Bake the git commit SHA into the image at build time.
 # Tekton passes this via --build-arg; defaults to "development" for local builds.
 ARG COMMIT_SHA=development
-RUN printf '%s\n' "${COMMIT_SHA}" > /app/COMMIT_SHA
+RUN printf '%s\n' "${COMMIT_SHA}" > "${APP_ROOT}/COMMIT_SHA"
 
 # Default to streamable-http for networked container deployments.
 # Override with MCP_TRANSPORT=sse or MCP_TRANSPORT=stdio as needed.

--- a/src/okp_mcp/build_info.py
+++ b/src/okp_mcp/build_info.py
@@ -1,16 +1,17 @@
 """Build-time metadata baked into the container image."""
 
+import os
 from importlib.metadata import version
 
 # Absolute path matching the Containerfile WORKDIR (/app).
 # Using an absolute path avoids breakage if Kubernetes overrides workingDir.
-_COMMIT_SHA_PATH = "/app/COMMIT_SHA"
+_COMMIT_SHA_PATH = f"{os.getenv('APP_ROOT', '/opt/app-root')}/COMMIT_SHA"
 
 
 def get_commit_sha() -> str:
     """Read the git commit SHA written during the container build.
 
-    The Containerfile writes the SHA to ``/app/COMMIT_SHA`` via a build arg
+    The Containerfile writes the SHA to ``/opt/app-root/COMMIT_SHA`` via a build arg
     supplied by the Tekton pipeline.  Falls back to ``"development"`` for
     local runs where the file does not exist or is unreadable.
     """


### PR DESCRIPTION
Install `uv` in a dedicated virtual environment so that it is not included in the final base image.

Use the same image for build and final stages to reduce the number of base image updates that need to happen.

Explicitly configure the project, virtual environment, and Python executable used by `uv`. Installing the application into the this virtual environment removes the need to modify the shebang of the installed application.

Use `APP_ROOT` as the final working directory to better align with the intended use of the base image.

Instead of hardcoding the path for `_COMMIT_SHA` use an environment variable.