### PR TITLE
feat(bm25): replace rank-bm25 with pure-Python BM25Plus

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ src/okp_mcp/
     run_code.py  # placeholder run_code MCP tool
     shared.py    # shared tool constants
   solr.py        # Solr query builder, BM25 paragraph extraction, RHV filtering
+  bm25.py        # Pure-Python BM25Plus scorer (drop-in for rank_bm25, no numpy)
   content.py     # Boilerplate stripping, content truncation, text cleaning
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
 tests/
@@ -211,13 +212,14 @@ request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starle
 intent.py   → config
 portal.py   → config, content, formatting, intent, solr
 formatting.py → content, solr
-solr.py     → config, metrics
+solr.py     → bm25, config, metrics
+bm25.py     → (standalone)
 server.py   → config
 telemetry.py → build_info, config, sentry_sdk
 content.py  → (standalone)
 ```
 
-No circular imports. `content.py` has zero internal dependencies.
+No circular imports. `content.py` and `bm25.py` have zero internal dependencies.
 
 ## Code Style
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ dependencies = [
     "httpx",
     "prometheus_client>=0.25.0",
     "pydantic-settings>=2.14.1",
-    "rank-bm25",
     "sentry-sdk[httpx]>=2.60.0",
 ]
 

--- a/src/okp_mcp/bm25.py
+++ b/src/okp_mcp/bm25.py
@@ -1,0 +1,77 @@
+"""Pure-Python BM25+ scorer (drop-in for rank_bm25.BM25Plus, no numpy)."""
+
+import math
+from collections import Counter
+from collections.abc import Sequence
+
+
+class BM25Plus:
+    """BM25+ ranking over a tokenized corpus, matching rank_bm25.BM25Plus.
+
+    Covers the subset of behavior okp-mcp relies on: construct with a tokenized
+    corpus, then call :meth:`get_scores` with a list of query terms. Implemented
+    without numpy so the runtime container needs no C/C++ extension libraries.
+
+    The scoring formula mirrors rank_bm25 v0.2.2's ``BM25Plus`` exactly::
+
+        idf(q)   = log((N + 1) / df(q))
+        score(d) = sum over q in query of
+                   idf(q) * (delta + (f(q,d) * (k1 + 1))
+                                     / (k1 * (1 - b + b * |d| / avgdl) + f(q,d)))
+
+    where N is the corpus size, df(q) the document frequency of term q, f(q,d)
+    the term frequency in document d, |d| the document length, and avgdl the
+    mean document length. Unknown query terms contribute 0.
+
+    Divergence from rank_bm25: a corpus of only empty documents yields scores of
+    0.0 here, where rank_bm25 returns NaN (numpy divide-by-zero on avgdl=0).
+    Callers (okp_mcp.solr) filter empty paragraphs before scoring, so this case
+    is unreachable in practice; 0.0 is the more sensible result regardless.
+    """
+
+    def __init__(
+        self,
+        corpus: Sequence[Sequence[str]],
+        k1: float = 1.5,
+        b: float = 0.75,
+        delta: float = 1,
+    ) -> None:
+        """Index ``corpus`` (a sequence of token lists) for scoring.
+
+        ``k1``, ``b``, and ``delta`` default to the same values as
+        rank_bm25.BM25Plus.
+        """
+        self.k1 = k1
+        self.b = b
+        self.delta = delta
+
+        self.corpus_size = 0
+        self.doc_len: list[int] = []
+        self.doc_freqs: list[dict[str, int]] = []
+        nd: dict[str, int] = {}  # term -> number of documents containing it
+        num_tokens = 0
+
+        for document in corpus:
+            self.doc_len.append(len(document))
+            num_tokens += len(document)
+            frequencies = Counter(document)
+            self.doc_freqs.append(dict(frequencies))
+            for term in frequencies:
+                nd[term] = nd.get(term, 0) + 1
+            self.corpus_size += 1
+
+        self.avgdl = num_tokens / self.corpus_size if self.corpus_size else 0.0
+        self.idf = {term: math.log((self.corpus_size + 1) / freq) for term, freq in nd.items()}
+
+    def get_scores(self, query: Sequence[str]) -> list[float]:
+        """Return one BM25+ score per document, indexed by corpus position."""
+        scores = [0.0] * self.corpus_size
+        for q in query:
+            idf = self.idf.get(q) or 0
+            if not idf:
+                continue
+            for idx in range(self.corpus_size):
+                q_freq = self.doc_freqs[idx].get(q) or 0
+                denom = self.k1 * (1 - self.b + self.b * self.doc_len[idx] / self.avgdl) + q_freq
+                scores[idx] += idf * (self.delta + (q_freq * (self.k1 + 1)) / denom)
+        return scores

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -4,8 +4,8 @@ import re
 import time
 
 import httpx
-from rank_bm25 import BM25Plus  # pyright: ignore[reportMissingImports]
 
+from okp_mcp.bm25 import BM25Plus
 from okp_mcp.config import STOP_WORDS, logger
 from okp_mcp.metrics import SOLR_QUERIES, SOLR_QUERY_DURATION
 
@@ -417,9 +417,10 @@ def _extract_relevant_section(content: str, query: str, per_section: int = 1500,
     """Extract the most relevant sections using BM25 paragraph scoring.
 
     Splits content on blank lines (paragraphs), scores each paragraph using
-    BM25 (Okapi BM25 via rank-bm25), and returns the top non-overlapping
-    paragraphs joined with separator markers. For book-sized documents (>10KB),
-    skips the first 5% to avoid matching on the table of contents.
+    BM25+ (pure-Python BM25Plus in okp_mcp.bm25), and returns the top
+    non-overlapping paragraphs joined with separator markers. For book-sized
+    documents (>10KB), skips the first 5% to avoid matching on the table of
+    contents.
 
     Paragraphs containing deprecation/critical keywords get a 2x boost, while
     paragraphs about RHV/RHEV are demoted 20x when the query has no RHV intent.

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -1,0 +1,113 @@
+"""Characterization tests for the pure-Python BM25Plus implementation."""
+
+import math
+
+import pytest
+
+from okp_mcp.bm25 import BM25Plus
+
+# (corpus, query, expected_scores) triples captured from rank_bm25.BM25Plus.
+GOLDEN_CASES = [
+    pytest.param(
+        [
+            ["the", "quick", "brown", "fox"],
+            ["the", "lazy", "dog"],
+            ["quick", "fox", "jumps", "over", "lazy", "dog"],
+        ],
+        ["quick", "fox"],
+        [2.822296488176351, 1.3862943611198906, 2.5680534886319286],
+        id="basic",
+    ),
+    pytest.param(
+        [["alpha", "beta"], ["gamma"]],
+        ["zeta"],
+        [0.0, 0.0],
+        id="term_absent_all",
+    ),
+    pytest.param(
+        [["a", "a", "a", "b"], ["a", "b", "b"], ["c"]],
+        ["a", "b"],
+        [2.9790135061707095, 2.9944901712617655, 1.3862943611198906],
+        id="repeated_terms",
+    ),
+    pytest.param(
+        [["solr", "query", "timeout"]],
+        ["timeout", "solr"],
+        [2.772588722239781],
+        id="single_doc",
+    ),
+    pytest.param(
+        [["x", "y"], ["z"]],
+        [],
+        [0.0, 0.0],
+        id="empty_query",
+    ),
+    pytest.param(
+        [
+            ["red", "hat", "enterprise", "linux"],
+            ["fedora", "linux"],
+            ["debian"],
+        ],
+        ["linux", "windows"],
+        [1.2176909928755797, 1.4339151597843143, 0.6931471805599453],
+        id="mixed_known_unknown",
+    ),
+    pytest.param(
+        [["a"], []],
+        ["a"],
+        [1.8562759360254268, 1.0986122886681098],
+        id="mixed_one_empty_doc_known_term",
+    ),
+    pytest.param(
+        [["a"], []],
+        ["b"],
+        [0.0, 0.0],
+        id="mixed_one_empty_doc_unknown_term",
+    ),
+]
+
+
+@pytest.mark.parametrize(("corpus", "query", "expected"), GOLDEN_CASES)
+def test_get_scores_matches_rank_bm25(corpus, query, expected):
+    """get_scores reproduces rank_bm25.BM25Plus output exactly."""
+    bm25 = BM25Plus(corpus)
+    scores = bm25.get_scores(query)
+    assert len(scores) == len(expected)
+    for got, want in zip(scores, expected, strict=True):
+        assert math.isclose(got, want, rel_tol=1e-12, abs_tol=1e-12)
+
+
+def test_get_scores_returns_indexable_floats():
+    """Scores are positionally indexable and float-coercible (solr.py contract)."""
+    bm25 = BM25Plus([["a", "b"], ["b", "c"]])
+    scores = bm25.get_scores(["b"])
+    assert float(scores[0]) >= 0.0
+    assert float(scores[1]) >= 0.0
+
+
+def test_default_parameters_match_library():
+    """Default k1/b/delta match rank_bm25.BM25Plus defaults."""
+    bm25 = BM25Plus([["a"]])
+    assert bm25.k1 == 1.5
+    assert bm25.b == 0.75
+    assert bm25.delta == 1
+
+
+@pytest.mark.parametrize(
+    ("corpus", "query"),
+    [
+        pytest.param([[]], ["a"], id="single_empty_doc"),
+        pytest.param([[], []], ["a"], id="all_empty_docs"),
+        pytest.param([], ["a"], id="empty_corpus"),
+    ],
+)
+def test_degenerate_empty_corpora_do_not_crash(corpus, query):
+    """All-empty / empty corpora return finite zeros instead of NaN or raising.
+
+    rank_bm25 returns NaN here (numpy divide-by-zero on avgdl=0). This impl
+    deliberately returns 0.0 because empty paragraphs are filtered upstream in
+    okp_mcp.solr, so the case is unreachable and 0.0 is the saner result.
+    """
+    scores = BM25Plus(corpus).get_scores(query)
+    assert len(scores) == len(corpus)
+    assert all(s == 0.0 for s in scores)

--- a/uv.lock
+++ b/uv.lock
@@ -714,67 +714,6 @@ wheels = [
 ]
 
 [[package]]
-name = "numpy"
-version = "2.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
-    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
-    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
-    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
-    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
-    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
-    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
-    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
-    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
-    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
-    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
-    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
-    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
-    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
-    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
-    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
-    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
-]
-
-[[package]]
 name = "okp-mcp"
 version = "1.0.2"
 source = { editable = "." }
@@ -783,7 +722,6 @@ dependencies = [
     { name = "httpx" },
     { name = "prometheus-client" },
     { name = "pydantic-settings" },
-    { name = "rank-bm25" },
     { name = "sentry-sdk", extra = ["httpx"] },
 ]
 
@@ -807,7 +745,6 @@ requires-dist = [
     { name = "httpx" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
-    { name = "rank-bm25" },
     { name = "sentry-sdk", extras = ["httpx"], specifier = ">=2.60.0" },
 ]
 
@@ -1253,18 +1190,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/6d/98e61600febf6bd929cf04154537c39dc577ce414bafbfc24a286c4fa76d/radon-6.0.1.tar.gz", hash = "sha256:d1ac0053943a893878940fedc8b19ace70386fc9c9bf0a09229a44125ebf45b5", size = 1874992, upload-time = "2023-03-26T06:24:38.868Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/f7/d00d9b4a0313a6be3a3e0818e6375e15da6d7076f4ae47d1324e7ca986a1/radon-6.0.1-py2.py3-none-any.whl", hash = "sha256:632cc032364a6f8bb1010a2f6a12d0f14bc7e5ede76585ef29dc0cecf4cd8859", size = 52784, upload-time = "2023-03-26T06:24:33.949Z" },
-]
-
-[[package]]
-name = "rank-bm25"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- `rank-bm25` pulls in numpy, whose C-extensions need libstdc++ at runtime. That blocks moving the container to a distroless base.
- We only use a tiny slice of rank-bm25 (build from a tokenized corpus, score a query). Reimplementing it in pure Python drops both numpy and rank-bm25 with no behavior change.

## Changes

- Add `okp_mcp.bm25.BM25Plus`, a pure-Python BM25+ scorer that reproduces `rank_bm25.BM25Plus` v0.2.2 output exactly.
- Swap `okp_mcp.solr` over to the new scorer and drop the `rank-bm25` dependency (re-locked, removing numpy + rank-bm25 from `uv.lock`).
- Lock behavior with a characterization test built from golden values captured from the original library before reimplementation, plus edge-case coverage for empty/degenerate corpora.

One deliberate divergence: an all-empty corpus returns `0.0` here where rank-bm25 returns `NaN` (numpy divide-by-zero on `avgdl=0`). solr.py filters empty paragraphs before scoring, so the case is unreachable; `0.0` is the saner result. Documented in the class docstring and asserted in tests.

## Testing

- [x] Lint passes (`ruff check`, `ruff format`)
- [x] Typecheck passes (`ty check`)
- [x] Complexity gate passes (radon A/B)
- [x] Tests pass (`400 passed`, bm25 module at 100% coverage)
- [x] Container rebuilds and starts clean with no numpy / no libstdc++ in the runtime


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internalized the BM25+ search ranking algorithm with a dedicated internal implementation, replacing an external library dependency. This significantly reduces the installation footprint, eliminates external dependency management overhead, improves long-term system maintainability, and ensures complete functional equivalence and identical performance in search ranking operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->