### PR TITLE
Pass level2 plan and CDN package source to QE gating

### DIFF
--- a/openshift/qe-gating-stage-trigger.yml
+++ b/openshift/qe-gating-stage-trigger.yml
@@ -83,10 +83,11 @@ objects:
                 - |
                   set -euo pipefail
 
-                  # Install curl and Red Hat internal CA bundle so curl trusts
-                  # gitlab.cee.redhat.com. The redhat-internal-cert-install package
-                  # adds the Red Hat IT root CAs to the system trust store.
-                  microdnf install -y curl redhat-internal-cert-install && microdnf clean all
+                  # Install Red Hat internal CA so curl trusts gitlab.cee.redhat.com.
+                  # curl-minimal is already included in ubi-minimal, no need to install curl.
+                  curl -sk -o /etc/pki/ca-trust/source/anchors/RH-IT-Root-CAs.pem \
+                    https://certs.corp.redhat.com/certs/Current-IT-Root-CAs.pem
+                  update-ca-trust
 
                   POLL_INTERVAL=60
                   MAX_WAIT=7200  # 2 hours
@@ -111,7 +112,9 @@ objects:
                       --form "variables[CLA_TESTS_RUN_COMPARE]=true" \
                       --form "variables[SERVICE_NAME]=${SERVICE_NAME}" \
                       --form "variables[DEPLOYED_SHA]=${COMMIT_SHA}" \
-                      --form "variables[TRIGGER_SOURCE]=promotion-channel"
+                      --form "variables[TRIGGER_SOURCE]=promotion-channel" \
+                      --form "variables[PLAN]=level2" \
+                      --form "variables[CLA_TESTS_PACKAGE_SOURCE_PROFILE]=cdn"
                   )
                   CURL_EXIT=$?
                   set -e


### PR DESCRIPTION
- Pass PLAN=level2 to run all eval tiers (was defaulting to level1)
- Pass CLA_TESTS_PACKAGE_SOURCE_PROFILE=cdn to test with CDN packages (what customers use) instead of copr

JIRA: RSPEED-3038