### PR TITLE
refactor: remove unused legacy _format_result rendering path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,7 +211,7 @@ metrics.py  → server (imports mcp for custom_route)
 request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starlette
 intent.py   → config
 portal.py   → config, content, formatting, intent, solr
-formatting.py → content, solr
+formatting.py → (standalone)
 solr.py     → bm25, config, metrics
 bm25.py     → (standalone)
 server.py   → config
@@ -219,7 +219,7 @@ telemetry.py → build_info, config, sentry_sdk
 content.py  → (standalone)
 ```
 
-No circular imports. `content.py` and `bm25.py` have zero internal dependencies.
+No circular imports. `content.py`, `bm25.py`, and `formatting.py` have zero internal dependencies.
 
 ## Code Style
 

--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -1,9 +1,6 @@
-"""Result formatting, annotation, and sorting."""
+"""Result annotation and sorting."""
 
 import re
-
-from okp_mcp.content import doc_uri, strip_boilerplate
-from okp_mcp.solr import _extract_relevant_section, _get_highlights
 
 EOL_PRODUCT_MENTIONS = [
     ("Red Hat Virtualization", "RHV"),
@@ -17,13 +14,6 @@ _DEPRECATION_RE = re.compile(
     r"\b(deprecated|removed|no longer available|no longer supported|end of life|"
     r"has been removed|is not available|will be removed|not recommended|"
     r"maintenance support ended|extended life phase)\b",
-    re.IGNORECASE,
-)
-
-_VERSION_LIST_RE = re.compile(
-    r"(?:available for|planned for|is available for)[:\s]*"
-    r"(?:RHEL[:\s]*)?"
-    r"((?:\d+\.\d+\s*\([^)]+\)[,;\s]*(?:and\s*)?)+)",
     re.IGNORECASE,
 )
 
@@ -96,113 +86,3 @@ def _annotate_result(title: str, highlights: str, content: str, product: str = "
 
     sort_key = _determine_sort_key(has_replacement, is_deprecated, eol_product)
     return annotations, applicability, sort_key
-
-
-def _extract_version_lists(text: str) -> str:
-    """Pull out version lists (e.g. '9.0 (ended May 31, 2024)') as bullet points."""
-    bullets: list[str] = []
-    for match in _VERSION_LIST_RE.finditer(text):
-        raw = match.group(1).strip().rstrip(",; ")
-        entries = re.findall(r"(\d+\.\d+\s*\([^)]+\))", raw)
-        for entry in entries:
-            bullet = f"  - {entry.strip()}"
-            if bullet not in bullets:
-                bullets.append(bullet)
-    return "\n".join(bullets)
-
-
-_LARGE_DOC_THRESHOLD = 10_000
-
-# Cap content per search result to prevent a single large document from
-# consuming the entire tool response. With hl.fragsizeIsMinimum=true,
-# Solr can produce highlight fragments of several thousand characters each,
-# so even a few snippets can exceed the caller's budget and push all
-# subsequent results out of the tool response.
-_MAX_RESULT_CONTENT = 4_500
-
-
-async def _resolve_content_text(highlights: str, include_content: bool, doc: dict, query: str) -> str:
-    """Resolve the content text to display: highlights take priority, then main_content.
-
-    For large documents (>10KB), Solr highlights may miss key overview paragraphs
-    when earlier sections (e.g. tables of contents) consume highlight slots.
-    In this case, BM25-extracted content supplements the highlights.
-    """
-    if highlights:
-        if include_content and query and doc.get("main_content"):
-            content = strip_boilerplate(doc["main_content"])
-            if len(content) > _LARGE_DOC_THRESHOLD:
-                bm25_section = _extract_relevant_section(content, query, per_section=1000, max_sections=1)
-                if bm25_section:
-                    return f"{highlights}\n\n---\n\n{bm25_section}"
-        return highlights
-    if include_content and doc.get("main_content"):
-        content = strip_boilerplate(doc["main_content"])
-        return _extract_relevant_section(content, query) if query else content[:2000]
-    return ""
-
-
-def _build_metadata_lines(doc: dict, kind_label: str | None, applicability: str, url_path: str) -> list[str]:
-    """Build the metadata lines for a formatted search result.
-
-    Returns a list of metadata strings (Type, Applicability, Product, URL, date)
-    that will be joined with newlines in the result.
-    """
-    lines: list[str] = []
-    if kind_label:
-        lines.append(f"Type: {kind_label}")
-    lines.append(f"Applicability: {applicability}")
-    if doc.get("product"):
-        product_line = f"Product: {doc['product']}"
-        if doc.get("documentation_version"):
-            product_line += f" {doc['documentation_version']}"
-        lines.append(product_line)
-    lines.append(f"URL: https://access.redhat.com{url_path}")
-    if doc.get("lastModifiedDate"):
-        date_str = doc["lastModifiedDate"][:10]
-        lines.append(f"Last updated: {date_str}")
-    return lines
-
-
-async def _format_result(
-    doc: dict, data: dict, include_content: bool = False, query: str = "", max_content: int = _MAX_RESULT_CONTENT
-) -> tuple[str, int]:
-    """Format a single Solr document with applicability labels and annotations."""
-    doc_id = doc.get("id", "")
-    view_uri = doc.get("view_uri", "")
-    all_title = doc.get("allTitle")
-    heading_h1 = doc.get("heading_h1")
-    doc_title = doc.get("title", "")
-    if all_title:
-        title = all_title
-    elif heading_h1:
-        title = heading_h1[0] if isinstance(heading_h1, list) else heading_h1
-    elif doc_title:
-        title = doc_title.split("|")[0].strip()
-    else:
-        title = "Untitled"
-    url_path = doc_uri(doc)
-    highlights = _get_highlights(data, doc_id, view_uri, query=query)
-    content_text = await _resolve_content_text(highlights, include_content, doc, query)
-
-    annotations, applicability, sort_key = _annotate_result(
-        title, highlights, content_text, product=doc.get("product", "")
-    )
-    doc_kind = doc.get("documentKind", "")
-    kind_label = {"solution": "Solution", "article": "Article", "documentation": "Documentation"}.get(
-        doc_kind, doc_kind.replace("access-drupal10-node-type-page", "Documentation")
-    )
-
-    result = ""
-    if annotations:
-        result += " | ".join(annotations) + "\n"
-    result += f"**{title}**"
-    result += "\n" + "\n".join(_build_metadata_lines(doc, kind_label, applicability, url_path))
-    version_bullets = _extract_version_lists(content_text) if content_text else ""
-    if version_bullets:
-        result += f"\nReleases mentioned:\n{version_bullets}"
-    if content_text:
-        if len(content_text) > max_content:
-            content_text = content_text[:max_content] + " [...]"
-        result += f"\nContent: {content_text}"
-    return result, sort_key

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -278,11 +278,6 @@ def _get_highlight_snippets(data: dict, *keys: str, query: str = "") -> list[str
     return cleaned_snippets
 
 
-def _get_highlights(data: dict, *keys: str, query: str = "") -> str:
-    """Extract highlight snippets for a document, trying multiple ID keys."""
-    return " ... ".join(_get_highlight_snippets(data, *keys, query=query))
-
-
 _EXTRACTION_BOOST_KEYWORDS = frozenset(
     [
         "deprecated",

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,44 +1,11 @@
 """Tests for okp_mcp.formatting module."""
 
-import pytest
-
 from okp_mcp.formatting import (
     SORT_DEPRECATION,
     SORT_EOL_PRODUCT,
     SORT_REPLACEMENT,
     _annotate_result,
-    _format_result,
 )
-
-
-@pytest.mark.parametrize(
-    "main_content,max_content,expect_truncated",
-    [
-        ("x" * 10_000, 200, True),
-        ("Brief content about kernels.", 5000, False),
-    ],
-    ids=["large-content-truncated", "short-content-preserved"],
-)
-async def test_format_result_content_cap(main_content: str, max_content: int, expect_truncated: bool):
-    """_format_result caps content at max_content, appending [...] when truncated."""
-    doc = {
-        "id": "doc-1",
-        "allTitle": "Test Doc",
-        "documentKind": "solution",
-        "view_uri": "/test-doc",
-        "main_content": main_content,
-    }
-    data: dict = {"highlighting": {}}
-    result, _ = await _format_result(doc, data, include_content=True, query="test", max_content=max_content)
-
-    if expect_truncated:
-        assert "[...]" in result
-        content_start = result.index("Content: ") + len("Content: ")
-        assert len(result[content_start:]) < max_content + 100
-    else:
-        assert "[...]" not in result
-        assert main_content in result
-
 
 # ---------------------------------------------------------------------------
 # EOL false-positive demotion regression tests
@@ -127,35 +94,3 @@ class TestEolProductFieldGuard:
         )
         assert sort_key == SORT_REPLACEMENT
         assert any("replacement" in a.lower() for a in annotations)
-
-
-class TestFormatResultProductPassthrough:
-    """Verify that _format_result passes the doc product field through to _annotate_result."""
-
-    async def test_format_result_non_eol_product_not_demoted(self):
-        """_format_result does not demote docs with a non-EOL product that mention EOL products."""
-        doc = {
-            "id": "doc-odf",
-            "allTitle": "Troubleshooting OpenShift Data Foundation",
-            "documentKind": "documentation",
-            "view_uri": "/docs/odf",
-            "product": "Red Hat OpenShift Data Foundation",
-            "main_content": "Deploy on Red Hat Virtualization or VMware for storage.",
-        }
-        data: dict = {"highlighting": {}}
-        _, sort_key = await _format_result(doc, data, include_content=True, query="odf troubleshoot")
-        assert sort_key != SORT_EOL_PRODUCT
-
-    async def test_format_result_eol_product_still_demoted(self):
-        """_format_result still demotes docs whose product IS an EOL product."""
-        doc = {
-            "id": "doc-rhv",
-            "allTitle": "Red Hat Virtualization Installation Guide",
-            "documentKind": "documentation",
-            "view_uri": "/docs/rhv",
-            "product": "Red Hat Virtualization",
-            "main_content": "Red Hat Virtualization Manager installation steps.",
-        }
-        data: dict = {"highlighting": {}}
-        _, sort_key = await _format_result(doc, data, include_content=True, query="install rhv")
-        assert sort_key == SORT_EOL_PRODUCT


### PR DESCRIPTION
## Summary

- The `_format_result` rendering path was superseded by the portal chunk formatter (`_format_portal_chunk`) but never removed when we shipped.
- It had zero production reachability: the only references were tests calling it directly. Keeping it around added dead surface area and a phantom `formatting.py -> solr` dependency.

## Changes

- Remove `_format_result` and its exclusive helpers (`_resolve_content_text`, `_build_metadata_lines`, `_extract_version_lists`), the orphaned `_VERSION_LIST_RE` regex, and the content-cap constants from `formatting.py`. The module is now dependency-free (only `re`).
- Remove the `_get_highlights` string wrapper from `solr.py` (its sole caller was `_format_result`). The list variant `_get_highlight_snippets`, used by `get_document`, stays.
- Drop the dead `_format_result` tests. The `_annotate_result` product-guard behavior they exercised is still covered by `TestEolProductFieldGuard`, which calls `_annotate_result` directly.
- Update the `AGENTS.md` module dependency graph to reflect `formatting.py` as standalone.

Net: -193 lines, no behavior change. The live search and document paths are untouched.

## Verification

Reachability was confirmed against `origin/main` before deleting: no production imports of the removed symbols, no star imports, no dynamic dispatch (`getattr`/`importlib`/`__all__`) reaching them, and the three registered MCP tools (`search_portal`, `get_document`, `run_code`) all route around them.

- [x] Lint passes (`ruff check`)
- [x] Typecheck passes (`ty`)
- [x] Complexity gate passes (radon)
- [x] Tests pass (396 passed, 31 functional deselected)
- [x] CodeRabbit local review: 0 findings


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored search result annotation and sorting logic for improved maintainability.
  * Enhanced extraction and presentation of search result highlight snippets with de-duplication and improved cleaning of formatting artifacts.
  * Updated module documentation to reflect revised dependency boundaries.

* **Tests**
  * Updated test coverage to align with refactored result annotation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->