### PR TITLE
fix: read build commit from environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,7 +189,7 @@ uv run okp-mcp [--transport ...] [--port ...]
        ├─ CliApp.run(ServerConfig)     # parse CLI + MCP_* env vars
        ├─ _configure_logging()
        ├─ telemetry.initialize_error_reporting()  # no-op unless MCP_GLITCHTIP_DSN is set
-       ├─ log version + commit SHA     # build_info.py reads /opt/app-root/COMMIT_SHA
+       ├─ log version + commit SHA     # build_info.py: COMMIT_SHA env var, then APP_ROOT/COMMIT_SHA file, then local `git rev-parse`
        └─ mcp.run(transport=...)       # start FastMCP server
             → server.py: _app_lifespan()
                 ├─ creates shared httpx.AsyncClient
@@ -202,7 +202,7 @@ uv run okp-mcp [--transport ...] [--port ...]
 
 ```text
 __init__.py → build_info, config, metrics (side-effect import), request_id, server, telemetry, tools (side-effect import)
-build_info.py → (standalone, reads ./COMMIT_SHA file)
+build_info.py → (standalone; reads COMMIT_SHA env var, APP_ROOT/COMMIT_SHA file, or local `git rev-parse`)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
 tools/search.py → config, metrics, portal, server
 tools/document.py → content, metrics, server, solr, tools/shared.py

--- a/src/okp_mcp/build_info.py
+++ b/src/okp_mcp/build_info.py
@@ -1,25 +1,63 @@
 """Build-time metadata baked into the container image."""
 
+import logging
 import os
+import subprocess  # noqa: S404 -- used only for a fixed, no-input `git rev-parse` in local dev
 from importlib.metadata import version
+from pathlib import Path
 
-# Absolute path matching the Containerfile WORKDIR (/app).
-# Using an absolute path avoids breakage if Kubernetes overrides workingDir.
-_COMMIT_SHA_PATH = f"{os.getenv('APP_ROOT', '/opt/app-root')}/COMMIT_SHA"
+# In-container WORKDIR set by the Containerfile. This is the path *inside the
+# built image*, not a directory on a developer's machine. The Tekton pipeline
+# writes the build commit to ``$APP_ROOT/COMMIT_SHA`` during the image build, so
+# this default only resolves when running inside the container.
+DEFAULT_APP_ROOT = os.getenv("APP_ROOT", "/opt/app-root/src")
+DEFAULT_COMMIT_SHA = os.getenv("COMMIT_SHA", "development")
+
+logger = logging.getLogger(__name__)
+
+
+def _commit_sha_from_git() -> str:
+    """Return the short commit SHA from the local git checkout, if available.
+
+    Local dev runs (``uv run okp-mcp``) execute outside the container, so the
+    baked ``$APP_ROOT/COMMIT_SHA`` file does not exist. Rather than reporting a
+    useless ``"development"`` sentinel, ask git directly so startup logs and
+    Sentry get the real commit. Returns ``None`` when git is unavailable or the
+    working directory is not a repo (e.g. an unpacked sdist).
+    """
+    try:
+        result = subprocess.run(  # noqa: S603 -- fixed argv, no shell, no user input
+            ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607 -- git resolved from PATH is fine for dev-only use
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (OSError, subprocess.SubprocessError) as ex:
+        raise ValueError("Failed to retrieve git commit sha.") from ex
+
+    return result.stdout.strip()
 
 
 def get_commit_sha() -> str:
-    """Read the git commit SHA written during the container build.
+    """Return the git commit SHA for this build.
 
-    The Containerfile writes the SHA to ``/opt/app-root/COMMIT_SHA`` via a build arg
-    supplied by the Tekton pipeline.  Falls back to ``"development"`` for
-    local runs where the file does not exist or is unreadable.
+    Resolution order:
+
+    1. ``COMMIT_SHA`` environment variable (explicit runtime override).
+    2. ``$APP_ROOT/COMMIT_SHA`` file baked into the container image by Tekton.
+    3. ``git rev-parse`` against the local checkout, for dev runs outside a
+       container where neither of the above is present.
+    4. ``"development"`` when none of the above yield a SHA.
     """
+    commit_sha_file = Path(DEFAULT_APP_ROOT, "COMMIT_SHA")
+    commit_sha = DEFAULT_COMMIT_SHA
     try:
-        content = open(_COMMIT_SHA_PATH).read().strip()  # noqa: SIM115 -- one-shot read, no resource leak
-        return content or "development"
+        commit_sha = commit_sha_file.read_text(encoding="utf-8").strip()
     except OSError:
-        return "development"
+        commit_sha = _commit_sha_from_git()
+        logger.warning(f"No commit sha found in {commit_sha_file}. Using commit value: {commit_sha}")
+
+    return commit_sha
 
 
 def get_package_version() -> str:

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -1,32 +1,46 @@
 """Tests for build_info module."""
 
-from unittest.mock import mock_open, patch
+from unittest.mock import patch
 
-from okp_mcp.build_info import get_commit_sha, get_package_version
+import pytest
 
-
-def test_get_commit_sha_reads_file():
-    """Return the trimmed contents of the COMMIT_SHA file."""
-    with patch("builtins.open", mock_open(read_data="abc1234\n")):
-        assert get_commit_sha() == "abc1234"
+from okp_mcp.build_info import _commit_sha_from_git, get_commit_sha, get_package_version
 
 
-def test_get_commit_sha_fallback_when_missing():
-    """Fall back to 'development' when COMMIT_SHA file does not exist."""
-    with patch("builtins.open", side_effect=FileNotFoundError):
-        assert get_commit_sha() == "development"
+def test_get_commit_sha_reads_file(tmp_path):
+    """Return the trimmed value from the baked COMMIT_SHA file."""
+    (tmp_path / "COMMIT_SHA").write_text("def5678\n", encoding="utf-8")
+
+    with patch("okp_mcp.build_info.DEFAULT_APP_ROOT", str(tmp_path)):
+        assert get_commit_sha() == "def5678"
 
 
-def test_get_commit_sha_fallback_on_permission_error():
-    """Fall back to 'development' on PermissionError or other OSError."""
-    with patch("builtins.open", side_effect=PermissionError):
-        assert get_commit_sha() == "development"
+def test_get_commit_sha_uses_git_when_file_missing(tmp_path):
+    """Fall back to local git when the baked file is absent."""
+    with (
+        patch("okp_mcp.build_info.DEFAULT_APP_ROOT", str(tmp_path)),
+        patch("okp_mcp.build_info._commit_sha_from_git", return_value="9abcdef"),
+    ):
+        assert get_commit_sha() == "9abcdef"
 
 
-def test_get_commit_sha_fallback_on_empty_file():
-    """Fall back to 'development' when the file exists but is empty."""
-    with patch("builtins.open", mock_open(read_data="  \n")):
-        assert get_commit_sha() == "development"
+def test_get_commit_sha_propagates_git_failure(tmp_path):
+    """Raise when the file is absent and git is unavailable."""
+    with (
+        patch("okp_mcp.build_info.DEFAULT_APP_ROOT", str(tmp_path)),
+        patch("okp_mcp.build_info._commit_sha_from_git", side_effect=ValueError),
+        pytest.raises(ValueError),
+    ):
+        get_commit_sha()
+
+
+def test_commit_sha_from_git_raises_when_git_missing():
+    """Raise ValueError when the git executable is unavailable."""
+    with (
+        patch("okp_mcp.build_info.subprocess.run", side_effect=FileNotFoundError),
+        pytest.raises(ValueError),
+    ):
+        _commit_sha_from_git()
 
 
 def test_get_package_version():


### PR DESCRIPTION
Read the baked build commit from the COMMIT_SHA environment variable instead of a file in the image filesystem.

This is split out from #267 so the container hardening change can focus on the image migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build process to obtain commit SHA from environment variable instead of file path. Falls back to "development" when the variable is unset or empty.

* **Documentation**
  * Updated documentation to reflect the new environment variable-based build configuration method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->