### PR TITLE
Use RHEL-9.8.0-Nightly compose for QE gating

### DIFF
--- a/openshift/qe-gating-stage-trigger.yml
+++ b/openshift/qe-gating-stage-trigger.yml
@@ -125,7 +125,8 @@ objects:
                       --form "variables[DEPLOYED_SHA]=${COMMIT_SHA}" \
                       --form "variables[TRIGGER_SOURCE]=promotion-channel" \
                       --form "variables[PLAN]=level2" \
-                      --form "variables[CLA_TESTS_PACKAGE_SOURCE_PROFILE]=cdn"
+                      --form "variables[CLA_TESTS_PACKAGE_SOURCE_PROFILE]=cdn" \
+                      --form "variables[COMPOSE]=RHEL-9.8.0-Nightly"
                   )
                   CURL_EXIT=$?
                   set -e


### PR DESCRIPTION
RHEL 9.9 is not yet available on CDN, causing subscription-manager release --set 9.9 to fail. Pin to RHEL-9.8.0-Nightly until 9.9 is released.

JIRA: RSPEED-3038