### PR TITLE
Move transport settings to config and gracefully shutdown application

### DIFF
--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -1,17 +1,14 @@
 """OKP MCP server — SOLR bridge for Red Hat knowledge base search."""
 
 import logging
+import sys
 
 from pydantic_settings import CliApp
-from starlette.middleware import Middleware as StarletteMiddleware
 
-from okp_mcp import metrics as _metrics  # noqa: F401 -- import registers @mcp.custom_route("/metrics")
 from okp_mcp import server as _server
-from okp_mcp import tools as _tools  # noqa: F401 -- import triggers @mcp.tool registration
 from okp_mcp.build_info import get_commit_sha, get_package_version
 from okp_mcp.config import ServerConfig
-from okp_mcp.metrics import PrometheusMiddleware
-from okp_mcp.request_id import RequestIDLogFilter, build_http_request_id_middleware
+from okp_mcp.request_id import RequestIDLogFilter
 from okp_mcp.server import mcp
 from okp_mcp.telemetry import initialize_error_reporting
 
@@ -53,15 +50,11 @@ def main() -> None:
     logger.info("okp-mcp %s (%s)", get_package_version(), get_commit_sha())
     logger.info("Starting MCP server with transport=%s", config.transport)
 
-    if config.transport in ("sse", "streamable-http"):
-        http_middleware = build_http_request_id_middleware()
-        http_middleware.insert(0, StarletteMiddleware(PrometheusMiddleware))
-        mcp.run(
-            transport=config.transport,
-            host=config.host,
-            port=config.port,
-            middleware=http_middleware,
-            show_banner=False,
-        )
-    else:
-        mcp.run(transport="stdio", show_banner=False)
+    try:
+        mcp.run(transport=config.transport.value, show_banner=False, **config.transport_kwargs)
+    except KeyboardInterrupt:
+        logger.info("Shutting down okp-mcp")
+        sys.exit()
+    except Exception as exc:
+        logger.critical(f"Fatal error in okp-mcp: {exc}", exc_info=True)
+        sys.exit(1)

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -1,10 +1,14 @@
 """Server configuration via MCP_* environment variables and CLI arguments."""
 
 import logging
-from typing import Literal
+from enum import StrEnum
 
 from pydantic import Field, SecretStr, computed_field
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from starlette.middleware import Middleware as StarletteMiddleware
+
+from okp_mcp.metrics import PrometheusMiddleware
+from okp_mcp.request_id import RequestIDHeaderMiddleware
 
 # Configure logging
 logging.basicConfig(
@@ -84,6 +88,13 @@ STOP_WORDS: frozenset[str] = frozenset(
 )
 
 
+class Transport(StrEnum):
+    http = "http"
+    sse = "sse"
+    stdio = "stdio"
+    streamable_http = "streamable-http"
+
+
 class ServerConfig(BaseSettings):
     """MCP server settings from CLI arguments and MCP_* environment variables.
 
@@ -96,8 +107,8 @@ class ServerConfig(BaseSettings):
         cli_hide_none_type=True,
     )
 
-    transport: Literal["stdio", "sse", "streamable-http"] = Field(
-        default="streamable-http",
+    transport: Transport = Field(
+        default=Transport.streamable_http,
         description="Transport protocol",
     )
     host: str = Field(
@@ -131,3 +142,16 @@ class ServerConfig(BaseSettings):
     def solr_endpoint(self) -> str:
         """Solr select endpoint derived from solr_url."""
         return f"{self.solr_url}/solr/portal/select"
+
+    @property
+    def transport_kwargs(self) -> dict[str, str | int | list[StarletteMiddleware]]:
+        result = {}
+        if self.transport in {Transport.streamable_http, Transport.sse}:
+            result["host"] = self.host
+            result["port"] = self.port
+            result["middleware"] = [
+                StarletteMiddleware(PrometheusMiddleware),
+                StarletteMiddleware(RequestIDHeaderMiddleware),
+            ]
+
+        return result

--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -2,13 +2,8 @@
 
 import time
 
-from prometheus_client import CONTENT_TYPE_LATEST as _CONTENT_TYPE  # noqa: N812 -- upstream naming
-from prometheus_client import Counter, Histogram, generate_latest
-from starlette.requests import Request
-from starlette.responses import Response
+from prometheus_client import Counter, Histogram
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
-
-from okp_mcp.server import mcp
 
 # Allowlist of known paths to prevent unbounded label cardinality.
 # Unknown paths are bucketed as "OTHER" so rogue or scan traffic
@@ -207,10 +202,3 @@ class PrometheusMiddleware:
             # Fallback for cases where headers never sent (e.g. app crash before response).
             if not recorded:
                 _emit_metrics(status_code)
-
-
-@mcp.custom_route("/metrics", methods=["GET"])
-async def metrics_endpoint(request: Request) -> Response:
-    """Expose Prometheus metrics for scraping."""
-    del request
-    return Response(content=generate_latest(), media_type=_CONTENT_TYPE)

--- a/src/okp_mcp/request_id.py
+++ b/src/okp_mcp/request_id.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 from fastmcp.server.dependencies import get_http_request
 from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
 from starlette.datastructures import Headers, MutableHeaders
-from starlette.middleware import Middleware as StarletteMiddleware
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
 REQUEST_ID_HEADER = "X-Request-ID"
@@ -122,8 +121,3 @@ class RequestIDHeaderMiddleware:
             await self.app(scope, receive, send_with_request_id)
         finally:
             reset_request_id(token)
-
-
-def build_http_request_id_middleware() -> list[StarletteMiddleware]:
-    """Return the Starlette middleware objects used for HTTP transports."""
-    return [StarletteMiddleware(RequestIDHeaderMiddleware)]

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -9,6 +9,9 @@ from dataclasses import dataclass
 
 import httpx
 from fastmcp import Context, FastMCP
+from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+from starlette.requests import Request
+from starlette.responses import Response
 
 from okp_mcp.config import ServerConfig
 from okp_mcp.request_id import RequestIDContextMiddleware
@@ -59,3 +62,10 @@ mcp = FastMCP(
     lifespan=_app_lifespan,
     middleware=[RequestIDContextMiddleware()],
 )
+
+
+@mcp.custom_route("/metrics", methods=["GET"])
+async def metrics_endpoint(request: Request) -> Response:
+    """Expose Prometheus metrics for scraping."""
+    del request
+    return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -27,8 +27,8 @@ from okp_mcp.metrics import (
     TOOL_CALLS,
     TOOL_DURATION,
     PrometheusMiddleware,
-    metrics_endpoint,
 )
+from okp_mcp.server import metrics_endpoint
 from okp_mcp.solr import _solr_query
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint


### PR DESCRIPTION
- Compute the transport settings in config in order to simplify the main entrypoint.
- Move metrics route to server module to avoid circular import.
- Catch and handle `KeyboardInterrupt` so the application exits gracefully. This works both in a container and when running directly.

Instead of a stack trace:
```
Traceback (most recent call last):
  File "/usr/lib64/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
asyncio.exceptions.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/app-root/bin/okp-mcp", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/okp_mcp/__init__.py", line 59, in main
    mcp.run(
  File "/opt/app-root/lib64/python3.12/site-packages/fastmcp/server/mixins/transport.py", line 92, in run
    anyio.run(
  File "/opt/app-root/lib64/python3.12/site-packages/anyio/_core/_eventloop.py", line 77, in run
    return async_backend.run(func, args, {}, backend_options)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.12/site-packages/anyio/_backends/_asyncio.py", line 2358, in run
    return runner.run(wrapper())
           ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib64/python3.12/asyncio/runners.py", line 123, in run
    raise KeyboardInterrupt()
KeyboardInterrupt
```

We now get a clean exit:
```
INFO:     Shutting down
INFO:     Waiting for application shutdown.
2026-06-09 11:39:58,298 [INFO] [request_id=-] mcp.server.streamable_http_manager: StreamableHTTP session manager shutting down
INFO:     Application shutdown complete.
INFO:     Finished server process [68313]
2026-06-09 11:39:58,299 [INFO] [request_id=-] okp_mcp: Shutting down okp-mcp
```