### PR TITLE
Improve dev tool settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+coverage/
 
 # Translations
 *.mo

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ radon:
 		|| echo "PASS: All functions rated A or B"
 
 test:
-	uv run pytest -v --cov=okp_mcp --cov-report=term-missing
+	uv run pytest
 
 ci: lint typecheck radon check-konflux-requirements test
 

--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,29 @@
-.PHONY: lint format typecheck radon test ci setup konflux-requirements check-konflux-requirements
+.PHONY: fix lint format typecheck radon test ci setup konflux-requirements check-konflux-requirements
+
+fix:
+	uv run --locked ruff check --fix
+	uv run --locked ruff format
 
 lint:
-	uv run ruff check src/ tests/
+	uv run --locked ruff check src/ tests/
 
 format:
-	uv run ruff format src/ tests/
+	uv run --locked ruff format src/ tests/
 
 typecheck:
-	uv run ty check src/
+	uv run --locked ty check src/
 
 radon:
-	@uv run radon cc src/ -s --min C | grep -q . \
+	@uv run --locked radon cc src/ -s --min C | grep -q . \
 		&& { echo "FAIL: Cyclomatic complexity C or higher detected"; exit 1; } \
 		|| echo "PASS: All functions rated A or B"
 
 test:
-	uv run pytest
+	uv run --locked pytest
 
 ci: lint typecheck radon check-konflux-requirements test
+	@echo ""
+	@echo "✅ All CI checks passed!"
 
 # Regenerate the hermetic build manifests from uv.lock.
 konflux-requirements:
@@ -31,5 +37,5 @@ check-konflux-requirements:
 		|| { echo "FAIL: .konflux manifests are stale. Run 'make konflux-requirements' and commit."; git status --porcelain -- .konflux/; exit 1; }
 
 setup:
-	uv sync --group dev
+	uv sync --locked --group dev
 	pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,13 @@ select = [
     "W",      # pycodestyle warnings
 ]
 
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+lines-after-imports = 2
+lines-between-types = 1
+order-by-type = false
+
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S104"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,23 @@ dev = [
     "ty>=0.0.39",
 ]
 
+[tool.coverage.run]
+branch = true
+data_file = "coverage/.data"
+source = [
+    "src",
+    "tests",
+]
+
+[tool.coverage.html]
+directory = "coverage/htmlcov"
+
+[tool.coverage.json]
+output = "coverage/coverage.json"
+
+[tool.coverage.xml]
+output = "coverage/coverage.xml"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,8 @@ build-backend = "uv_build"
 
 [dependency-groups]
 dev = [
+    "ipdb",
+    "ipython",
     "pytest>=9.0.3",
     "pytest-asyncio>=1.3.0",
     "pytest-cov>=7.1.0",
@@ -38,6 +40,20 @@ testpaths = ["tests"]
 markers = [
     "functional: document retrieval tests requiring live Solr (podman-compose up -d)",
 ]
+addopts = [
+    "-r", "a",
+    "--verbose",
+    "--strict-markers",
+    "--cov", "src",
+    "--cov", "tests",
+    "--cov-report", "html",
+    "--cov-report", "term-missing:skip-covered",
+    "--durations-min", "1",
+    "--durations", "10",
+    "--color", "yes",
+    "--showlocals",
+    "--pdbcls", "IPython.terminal.debugger:TerminalPdb",
+]
 
 
 [tool.ruff]
@@ -45,7 +61,20 @@ target-version = "py312"
 line-length = 120
 
 [tool.ruff.lint]
-select = ["E", "F", "W", "I", "UP", "S", "B", "A", "C4", "SIM", "TID252"]
+select = [
+    "A",      # flake8-builtins
+    "B",      # flake8-bugbear
+    "C4",     # flake8-comprehensions
+    "E",      # pycodestyle errors
+    "F",      # pyflakes
+    "I",      # isort
+    "RUF100", # unused noqa directives
+    "S",      # flake8-bandit (security)
+    "SIM",    # flake8-simplify
+    "TID252", # ban relative imports
+    "UP",     # pyupgrade
+    "W",      # pycodestyle warnings
+]
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**" = ["S101", "S104"]

--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -6,11 +6,13 @@ import sys
 from pydantic_settings import CliApp
 
 from okp_mcp import server as _server
-from okp_mcp.build_info import get_commit_sha, get_package_version
+from okp_mcp.build_info import get_commit_sha
+from okp_mcp.build_info import get_package_version
 from okp_mcp.config import ServerConfig
 from okp_mcp.request_id import RequestIDLogFilter
 from okp_mcp.server import mcp
 from okp_mcp.telemetry import initialize_error_reporting
+
 
 __all__ = ["mcp", "main"]
 

--- a/src/okp_mcp/bm25.py
+++ b/src/okp_mcp/bm25.py
@@ -1,6 +1,7 @@
 """Pure-Python BM25+ scorer (drop-in for rank_bm25.BM25Plus, no numpy)."""
 
 import math
+
 from collections import Counter
 from collections.abc import Sequence
 

--- a/src/okp_mcp/build_info.py
+++ b/src/okp_mcp/build_info.py
@@ -2,9 +2,11 @@
 
 import logging
 import os
-import subprocess  # noqa: S404 -- used only for a fixed, no-input `git rev-parse` in local dev
+import subprocess
+
 from importlib.metadata import version
 from pathlib import Path
+
 
 # In-container WORKDIR set by the Containerfile. This is the path *inside the
 # built image*, not a directory on a developer's machine. The Tekton pipeline
@@ -26,7 +28,7 @@ def _commit_sha_from_git() -> str:
     working directory is not a repo (e.g. an unpacked sdist).
     """
     try:
-        result = subprocess.run(  # noqa: S603 -- fixed argv, no shell, no user input
+        result = subprocess.run(
             ["git", "rev-parse", "--short", "HEAD"],  # noqa: S607 -- git resolved from PATH is fine for dev-only use
             capture_output=True,
             text=True,

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -1,14 +1,19 @@
 """Server configuration via MCP_* environment variables and CLI arguments."""
 
 import logging
+
 from enum import StrEnum
 
-from pydantic import Field, SecretStr, computed_field
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import computed_field
+from pydantic import Field
+from pydantic import SecretStr
+from pydantic_settings import BaseSettings
+from pydantic_settings import SettingsConfigDict
 from starlette.middleware import Middleware as StarletteMiddleware
 
 from okp_mcp.metrics import PrometheusMiddleware
 from okp_mcp.request_id import RequestIDHeaderMiddleware
+
 
 # Configure logging
 logging.basicConfig(

--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -2,6 +2,7 @@
 
 import re
 
+
 # Solr content uses a Unicode right single quotation mark (U+2019, a.k.a.
 # "smart apostrophe") in "Red Hat\u2019s", not the ASCII apostrophe (U+0027).
 # The character class ['\u2019] matches either variant so the pattern works

--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -2,6 +2,7 @@
 
 import re
 
+
 EOL_PRODUCT_MENTIONS = [
     ("Red Hat Virtualization", "RHV"),
     ("RHEV", "RHV"),

--- a/src/okp_mcp/intent.py
+++ b/src/okp_mcp/intent.py
@@ -12,10 +12,14 @@
 from __future__ import annotations
 
 import re
+
 from dataclasses import dataclass
 
 from okp_mcp.config import logger
-from okp_mcp.metrics import INTENT_DEPRECATION_SKIPPED, INTENT_MATCHED, INTENT_NO_MATCH
+from okp_mcp.metrics import INTENT_DEPRECATION_SKIPPED
+from okp_mcp.metrics import INTENT_MATCHED
+from okp_mcp.metrics import INTENT_NO_MATCH
+
 
 # ---------------------------------------------------------------------------
 # Intent rule dataclass

--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -2,8 +2,14 @@
 
 import time
 
-from prometheus_client import Counter, Histogram
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from prometheus_client import Counter
+from prometheus_client import Histogram
+from starlette.types import ASGIApp
+from starlette.types import Message
+from starlette.types import Receive
+from starlette.types import Scope
+from starlette.types import Send
+
 
 # Allowlist of known paths to prevent unbounded label cardinality.
 # Unknown paths are bucketed as "OTHER" so rogue or scan traffic

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -5,21 +5,27 @@ from __future__ import annotations
 import asyncio
 import html as html_mod
 import re
-from dataclasses import dataclass, field, replace
+
+from dataclasses import dataclass
+from dataclasses import field
+from dataclasses import replace
 
 import httpx
 
 from okp_mcp.config import logger
-from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate
+from okp_mcp.content import _select_within_budget
+from okp_mcp.content import doc_uri
+from okp_mcp.content import strip_boilerplate
 from okp_mcp.formatting import _annotate_result
-from okp_mcp.intent import apply_deprecation_boosts, apply_main_boosts
-from okp_mcp.metrics import (
-    SEARCH_DEPRECATION_DETECTED,
-    SEARCH_RESULT_COUNT,
-    SEARCH_SCORE_FILTER_DROPPED,
-    SEARCH_ZERO_RESULTS,
-)
-from okp_mcp.solr import _clean_query, _filter_rhv_sentences, _solr_query
+from okp_mcp.intent import apply_deprecation_boosts
+from okp_mcp.intent import apply_main_boosts
+from okp_mcp.metrics import SEARCH_DEPRECATION_DETECTED
+from okp_mcp.metrics import SEARCH_RESULT_COUNT
+from okp_mcp.metrics import SEARCH_SCORE_FILTER_DROPPED
+from okp_mcp.metrics import SEARCH_ZERO_RESULTS
+from okp_mcp.solr import _clean_query
+from okp_mcp.solr import _filter_rhv_sentences
+from okp_mcp.solr import _solr_query
 
 
 @dataclass

--- a/src/okp_mcp/request_id.py
+++ b/src/okp_mcp/request_id.py
@@ -2,14 +2,23 @@
 
 from __future__ import annotations
 
-from contextvars import ContextVar, Token
+from contextvars import ContextVar
+from contextvars import Token
 from typing import Any
 from uuid import uuid4
 
 from fastmcp.server.dependencies import get_http_request
-from fastmcp.server.middleware import CallNext, Middleware, MiddlewareContext
-from starlette.datastructures import Headers, MutableHeaders
-from starlette.types import ASGIApp, Message, Receive, Scope, Send
+from fastmcp.server.middleware import CallNext
+from fastmcp.server.middleware import Middleware
+from fastmcp.server.middleware import MiddlewareContext
+from starlette.datastructures import Headers
+from starlette.datastructures import MutableHeaders
+from starlette.types import ASGIApp
+from starlette.types import Message
+from starlette.types import Receive
+from starlette.types import Scope
+from starlette.types import Send
+
 
 REQUEST_ID_HEADER = "X-Request-ID"
 _request_id_var: ContextVar[str | None] = ContextVar("okp_request_id", default=None)

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -3,18 +3,23 @@
 # pyright: reportAttributeAccessIssue=false
 
 import logging
+
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
 import httpx
-from fastmcp import Context, FastMCP
-from prometheus_client import CONTENT_TYPE_LATEST, generate_latest
+
+from fastmcp import Context
+from fastmcp import FastMCP
+from prometheus_client import CONTENT_TYPE_LATEST
+from prometheus_client import generate_latest
 from starlette.requests import Request
 from starlette.responses import Response
 
 from okp_mcp.config import ServerConfig
 from okp_mcp.request_id import RequestIDContextMiddleware
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -6,8 +6,10 @@ import time
 import httpx
 
 from okp_mcp.bm25 import BM25Plus
-from okp_mcp.config import STOP_WORDS, logger
-from okp_mcp.metrics import SOLR_QUERIES, SOLR_QUERY_DURATION
+from okp_mcp.config import logger
+from okp_mcp.config import STOP_WORDS
+from okp_mcp.metrics import SOLR_QUERIES
+from okp_mcp.metrics import SOLR_QUERY_DURATION
 
 
 def _split_quoted_and_plain(text: str) -> list[str]:

--- a/src/okp_mcp/telemetry.py
+++ b/src/okp_mcp/telemetry.py
@@ -1,13 +1,18 @@
 """Error reporting setup for GlitchTip-compatible Sentry DSNs."""
 
 import logging
-from typing import TYPE_CHECKING, Any
+
+from typing import Any
+from typing import TYPE_CHECKING
 
 import sentry_sdk
+
 from sentry_sdk.utils import BadDsn
 
-from okp_mcp.build_info import get_commit_sha, get_package_version
+from okp_mcp.build_info import get_commit_sha
+from okp_mcp.build_info import get_package_version
 from okp_mcp.config import ServerConfig
+
 
 if TYPE_CHECKING:
     from sentry_sdk._types import Event

--- a/src/okp_mcp/tools/__init__.py
+++ b/src/okp_mcp/tools/__init__.py
@@ -1,16 +1,15 @@
 """MCP tool definitions for RHEL OKP knowledge base search."""
 
-from okp_mcp.tools.document import (
-    _doc_id_filter,
-    _escape_solr_phrase,
-    _fetch_document_raw,
-    _fetch_document_with_query,
-    _format_document,
-    _normalize_doc_id,
-    get_document,
-)
+from okp_mcp.tools.document import _doc_id_filter
+from okp_mcp.tools.document import _escape_solr_phrase
+from okp_mcp.tools.document import _fetch_document_raw
+from okp_mcp.tools.document import _fetch_document_with_query
+from okp_mcp.tools.document import _format_document
+from okp_mcp.tools.document import _normalize_doc_id
+from okp_mcp.tools.document import get_document
 from okp_mcp.tools.run_code import run_code
 from okp_mcp.tools.search import search_portal
+
 
 __all__ = [
     "_doc_id_filter",

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -2,23 +2,31 @@
 
 import logging
 import time
+
 from urllib.parse import urlsplit
 
 import httpx
+
 from fastmcp import Context
 
-from okp_mcp.content import _select_within_budget, doc_uri, strip_boilerplate, truncate_content
-from okp_mcp.metrics import (
-    DOCUMENT_HIGHLIGHT_FALLBACK,
-    DOCUMENT_HIGHLIGHT_USED,
-    DOCUMENT_NOT_FOUND,
-    DOCUMENT_NUDGE,
-    TOOL_CALLS,
-    TOOL_DURATION,
-)
-from okp_mcp.server import get_app_context, mcp
-from okp_mcp.solr import _clean_query, _extract_relevant_section, _get_highlight_snippets, _solr_query
+from okp_mcp.content import _select_within_budget
+from okp_mcp.content import doc_uri
+from okp_mcp.content import strip_boilerplate
+from okp_mcp.content import truncate_content
+from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_FALLBACK
+from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_USED
+from okp_mcp.metrics import DOCUMENT_NOT_FOUND
+from okp_mcp.metrics import DOCUMENT_NUDGE
+from okp_mcp.metrics import TOOL_CALLS
+from okp_mcp.metrics import TOOL_DURATION
+from okp_mcp.server import get_app_context
+from okp_mcp.server import mcp
+from okp_mcp.solr import _clean_query
+from okp_mcp.solr import _extract_relevant_section
+from okp_mcp.solr import _get_highlight_snippets
+from okp_mcp.solr import _solr_query
 from okp_mcp.tools.shared import DOCUMENT_FL
+
 
 logger = logging.getLogger("okp_mcp.tools.get_document")
 

--- a/src/okp_mcp/tools/run_code.py
+++ b/src/okp_mcp/tools/run_code.py
@@ -6,6 +6,7 @@ from fastmcp import Context
 
 from okp_mcp.server import mcp
 
+
 logger = logging.getLogger("okp_mcp.tools.run_code")
 
 

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -4,11 +4,18 @@ import logging
 import time
 
 import httpx
+
 from fastmcp import Context
 
-from okp_mcp.metrics import TOOL_CALLS, TOOL_DURATION
-from okp_mcp.portal import _MAX_QUERIES, _format_portal_results, _run_multi_query_search, _run_portal_search
-from okp_mcp.server import get_app_context, mcp
+from okp_mcp.metrics import TOOL_CALLS
+from okp_mcp.metrics import TOOL_DURATION
+from okp_mcp.portal import _format_portal_results
+from okp_mcp.portal import _MAX_QUERIES
+from okp_mcp.portal import _run_multi_query_search
+from okp_mcp.portal import _run_portal_search
+from okp_mcp.server import get_app_context
+from okp_mcp.server import mcp
+
 
 logger = logging.getLogger("okp_mcp.tools.search_portal")
 

--- a/tests/test_bm25.py
+++ b/tests/test_bm25.py
@@ -6,6 +6,7 @@ import pytest
 
 from okp_mcp.bm25 import BM25Plus
 
+
 # (corpus, query, expected_scores) triples captured from rank_bm25.BM25Plus.
 GOLDEN_CASES = [
     pytest.param(

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -4,7 +4,9 @@ from unittest.mock import patch
 
 import pytest
 
-from okp_mcp.build_info import _commit_sha_from_git, get_commit_sha, get_package_version
+from okp_mcp.build_info import _commit_sha_from_git
+from okp_mcp.build_info import get_commit_sha
+from okp_mcp.build_info import get_package_version
 
 
 def test_get_commit_sha_reads_file(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@
 from unittest.mock import patch
 
 import pytest
+
 from pydantic import ValidationError
 from pydantic_settings import CliApp
 

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -2,7 +2,11 @@
 
 import pytest
 
-from okp_mcp.content import _select_within_budget, clean_content, doc_uri, strip_boilerplate, truncate_content
+from okp_mcp.content import _select_within_budget
+from okp_mcp.content import clean_content
+from okp_mcp.content import doc_uri
+from okp_mcp.content import strip_boilerplate
+from okp_mcp.content import truncate_content
 
 
 @pytest.mark.parametrize(

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,22 +1,24 @@
 """Tests for document retrieval tool formatting functions."""
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import httpx
 import pytest
+
 from prometheus_client import REGISTRY
 
 from okp_mcp import tools
 from okp_mcp.config import ServerConfig
-from okp_mcp.tools.document import (
-    _DOCUMENTATION_MAX_CHARS,
-    _DOCUMENTATION_MAX_SECTIONS,
-    _DOCUMENTATION_PER_SECTION,
-    _format_document_content,
-    _format_document_passages,
-    _format_metadata,
-    _uses_document_passages,
-)
+from okp_mcp.tools.document import _DOCUMENTATION_MAX_CHARS
+from okp_mcp.tools.document import _DOCUMENTATION_MAX_SECTIONS
+from okp_mcp.tools.document import _DOCUMENTATION_PER_SECTION
+from okp_mcp.tools.document import _format_document_content
+from okp_mcp.tools.document import _format_document_passages
+from okp_mcp.tools.document import _format_metadata
+from okp_mcp.tools.document import _uses_document_passages
+
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
@@ -318,20 +320,44 @@ class TestDocumentRetrievalMetrics:
         "kind, view_uri, content, snippets, query, counter_name, expected_delta",
         [
             pytest.param(
-                "documentation", "/documentation/en-US/test", "Content", ["Snippet about kernel configuration"],
-                "kernel", "okp_document_highlight_used", 1, id="doc-with-highlights",
+                "documentation",
+                "/documentation/en-US/test",
+                "Content",
+                ["Snippet about kernel configuration"],
+                "kernel",
+                "okp_document_highlight_used",
+                1,
+                id="doc-with-highlights",
             ),
             pytest.param(
-                "solution", "/solutions/12345", "Full body.", ["Fix for the network issue"],
-                "network", "okp_document_highlight_used", 1, id="non-doc-with-highlights",
+                "solution",
+                "/solutions/12345",
+                "Full body.",
+                ["Fix for the network issue"],
+                "network",
+                "okp_document_highlight_used",
+                1,
+                id="non-doc-with-highlights",
             ),
             pytest.param(
-                "documentation", "/documentation/en-US/test", "Content about systemd units " + "w" * 300, None,
-                "systemd", "okp_document_highlight_fallback", 1, id="doc-no-highlights",
+                "documentation",
+                "/documentation/en-US/test",
+                "Content about systemd units " + "w" * 300,
+                None,
+                "systemd",
+                "okp_document_highlight_fallback",
+                1,
+                id="doc-no-highlights",
             ),
             pytest.param(
-                "solution", "/solutions/12345", "Solution about networking " + "z" * 300, None,
-                "networking", "okp_document_highlight_fallback", 1, id="non-doc-no-highlights",
+                "solution",
+                "/solutions/12345",
+                "Solution about networking " + "z" * 300,
+                None,
+                "networking",
+                "okp_document_highlight_fallback",
+                1,
+                id="non-doc-no-highlights",
             ),
         ],
     )

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,11 +1,10 @@
 """Tests for okp_mcp.formatting module."""
 
-from okp_mcp.formatting import (
-    SORT_DEPRECATION,
-    SORT_EOL_PRODUCT,
-    SORT_REPLACEMENT,
-    _annotate_result,
-)
+from okp_mcp.formatting import _annotate_result
+from okp_mcp.formatting import SORT_DEPRECATION
+from okp_mcp.formatting import SORT_EOL_PRODUCT
+from okp_mcp.formatting import SORT_REPLACEMENT
+
 
 # ---------------------------------------------------------------------------
 # EOL false-positive demotion regression tests

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -13,10 +13,14 @@ Requires: OKP Solr container running (``podman-compose up -d``)
 
 import httpx
 import pytest
-from functional_cases import FUNCTIONAL_TEST_CASES, FunctionalCase
+
+from functional_cases import FUNCTIONAL_TEST_CASES
+from functional_cases import FunctionalCase
 
 from okp_mcp.config import ServerConfig
-from okp_mcp.portal import PortalChunk, _run_portal_search
+from okp_mcp.portal import _run_portal_search
+from okp_mcp.portal import PortalChunk
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_intent_metrics.py
+++ b/tests/test_intent_metrics.py
@@ -2,7 +2,8 @@
 
 from prometheus_client import REGISTRY
 
-from okp_mcp.intent import apply_deprecation_boosts, apply_main_boosts
+from okp_mcp.intent import apply_deprecation_boosts
+from okp_mcp.intent import apply_main_boosts
 
 
 def _get_counter(name: str, labels: dict) -> float:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -5,31 +5,31 @@ from unittest.mock import MagicMock
 import httpx
 import pytest
 import respx
+
 from prometheus_client import REGISTRY
 
 from okp_mcp.config import ServerConfig
-from okp_mcp.metrics import (
-    DOCUMENT_HIGHLIGHT_FALLBACK,
-    DOCUMENT_HIGHLIGHT_USED,
-    DOCUMENT_NOT_FOUND,
-    DOCUMENT_NUDGE,
-    HTTP_REQUEST_DURATION,
-    HTTP_REQUESTS,
-    INTENT_DEPRECATION_SKIPPED,
-    INTENT_MATCHED,
-    INTENT_NO_MATCH,
-    SEARCH_DEPRECATION_DETECTED,
-    SEARCH_RESULT_COUNT,
-    SEARCH_SCORE_FILTER_DROPPED,
-    SEARCH_ZERO_RESULTS,
-    SOLR_QUERIES,
-    SOLR_QUERY_DURATION,
-    TOOL_CALLS,
-    TOOL_DURATION,
-    PrometheusMiddleware,
-)
+from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_FALLBACK
+from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_USED
+from okp_mcp.metrics import DOCUMENT_NOT_FOUND
+from okp_mcp.metrics import DOCUMENT_NUDGE
+from okp_mcp.metrics import HTTP_REQUEST_DURATION
+from okp_mcp.metrics import HTTP_REQUESTS
+from okp_mcp.metrics import INTENT_DEPRECATION_SKIPPED
+from okp_mcp.metrics import INTENT_MATCHED
+from okp_mcp.metrics import INTENT_NO_MATCH
+from okp_mcp.metrics import PrometheusMiddleware
+from okp_mcp.metrics import SEARCH_DEPRECATION_DETECTED
+from okp_mcp.metrics import SEARCH_RESULT_COUNT
+from okp_mcp.metrics import SEARCH_SCORE_FILTER_DROPPED
+from okp_mcp.metrics import SEARCH_ZERO_RESULTS
+from okp_mcp.metrics import SOLR_QUERIES
+from okp_mcp.metrics import SOLR_QUERY_DURATION
+from okp_mcp.metrics import TOOL_CALLS
+from okp_mcp.metrics import TOOL_DURATION
 from okp_mcp.server import metrics_endpoint
 from okp_mcp.solr import _solr_query
+
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -3,32 +3,35 @@
 import httpx
 import pytest
 import respx
+
 from prometheus_client import REGISTRY
 
-from okp_mcp.intent import INTENT_RULES, IntentRule, apply_deprecation_boosts, apply_main_boosts
-from okp_mcp.portal import (
-    _DEPRECATION_WARNING,
-    _EOL_PRODUCTS,
-    _FALLBACK_MAX_CHARS,
-    _KIND_LABELS,
-    _MAIN_QF,
-    _MAX_QUERIES,
-    PortalChunk,
-    _build_deprecation_query,
-    _build_eol_filter,
-    _build_main_query,
-    _deduplicate_by_parent,
-    _docs_to_chunks,
-    _fallback_cve,
-    _fallback_errata,
-    _filter_by_score,
-    _format_portal_chunk,
-    _format_portal_results,
-    _reciprocal_rank_fusion,
-    _resolve_title,
-    _run_multi_query_search,
-    _run_portal_search,
-)
+from okp_mcp.intent import apply_deprecation_boosts
+from okp_mcp.intent import apply_main_boosts
+from okp_mcp.intent import INTENT_RULES
+from okp_mcp.intent import IntentRule
+from okp_mcp.portal import _build_deprecation_query
+from okp_mcp.portal import _build_eol_filter
+from okp_mcp.portal import _build_main_query
+from okp_mcp.portal import _deduplicate_by_parent
+from okp_mcp.portal import _DEPRECATION_WARNING
+from okp_mcp.portal import _docs_to_chunks
+from okp_mcp.portal import _EOL_PRODUCTS
+from okp_mcp.portal import _fallback_cve
+from okp_mcp.portal import _fallback_errata
+from okp_mcp.portal import _FALLBACK_MAX_CHARS
+from okp_mcp.portal import _filter_by_score
+from okp_mcp.portal import _format_portal_chunk
+from okp_mcp.portal import _format_portal_results
+from okp_mcp.portal import _KIND_LABELS
+from okp_mcp.portal import _MAIN_QF
+from okp_mcp.portal import _MAX_QUERIES
+from okp_mcp.portal import _reciprocal_rank_fusion
+from okp_mcp.portal import _resolve_title
+from okp_mcp.portal import _run_multi_query_search
+from okp_mcp.portal import _run_portal_search
+from okp_mcp.portal import PortalChunk
+
 
 # ---------------------------------------------------------------------------
 # EOL products
@@ -1546,9 +1549,7 @@ class TestSearchQualityMetrics:
         with respx.mock(assert_all_called=False) as router:
             router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
             async with httpx.AsyncClient() as client:
-                _, has_dep = await _run_portal_search(
-                    "deprecated feature", client=client, solr_endpoint=_SOLR_ENDPOINT
-                )
+                _, has_dep = await _run_portal_search("deprecated feature", client=client, solr_endpoint=_SOLR_ENDPOINT)
 
         assert has_dep is True
         assert _get_counter("okp_search_deprecation_detected") == before + 1
@@ -1569,9 +1570,7 @@ class TestSearchQualityMetrics:
         with respx.mock(assert_all_called=False) as router:
             router.get(_SOLR_ENDPOINT).mock(side_effect=side_effect)
             async with httpx.AsyncClient() as client:
-                _, has_dep = await _run_portal_search(
-                    "clean query", client=client, solr_endpoint=_SOLR_ENDPOINT
-                )
+                _, has_dep = await _run_portal_search("clean query", client=client, solr_endpoint=_SOLR_ENDPOINT)
 
         assert has_dep is False
         assert _get_counter("okp_search_deprecation_detected") == before

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -3,12 +3,16 @@
 # pyright: reportMissingImports=false
 
 import logging
+
 from types import SimpleNamespace
-from typing import Any, cast
-from unittest.mock import AsyncMock, patch
+from typing import Any
+from typing import cast
+from unittest.mock import AsyncMock
+from unittest.mock import patch
 
 import httpx
 import pytest
+
 from fastmcp import Context
 from fastmcp.server.middleware import MiddlewareContext
 from starlette.applications import Starlette
@@ -16,16 +20,17 @@ from starlette.middleware import Middleware as StarletteMiddleware
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
-from okp_mcp.request_id import (
-    REQUEST_ID_HEADER,
-    RequestIDContextMiddleware,
-    RequestIDHeaderMiddleware,
-    RequestIDLogFilter,
-    get_request_id,
-    reset_request_id,
-    set_request_id,
-)
-from okp_mcp.server import AppContext, _app_lifespan, get_app_context, mcp
+from okp_mcp.request_id import get_request_id
+from okp_mcp.request_id import REQUEST_ID_HEADER
+from okp_mcp.request_id import RequestIDContextMiddleware
+from okp_mcp.request_id import RequestIDHeaderMiddleware
+from okp_mcp.request_id import RequestIDLogFilter
+from okp_mcp.request_id import reset_request_id
+from okp_mcp.request_id import set_request_id
+from okp_mcp.server import _app_lifespan
+from okp_mcp.server import AppContext
+from okp_mcp.server import get_app_context
+from okp_mcp.server import mcp
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,8 +1,10 @@
 """Tests for the MCP server entry point and transport dispatch."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 import pytest
+
 from pydantic import ValidationError
 
 from okp_mcp.metrics import PrometheusMiddleware

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -2,14 +2,19 @@
 
 # pyright: reportMissingImports=false
 
-from unittest.mock import AsyncMock, Mock, patch
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import httpx
 import pytest
 import respx
 
 from okp_mcp.config import ServerConfig
-from okp_mcp.solr import _clean_query, _get_highlight_snippets, _solr_query
+from okp_mcp.solr import _clean_query
+from okp_mcp.solr import _get_highlight_snippets
+from okp_mcp.solr import _solr_query
+
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -4,10 +4,12 @@ from unittest.mock import patch
 
 import pytest
 import sentry_sdk
+
 from pydantic import SecretStr
 
 from okp_mcp.config import ServerConfig
-from okp_mcp.telemetry import _before_send, initialize_error_reporting
+from okp_mcp.telemetry import _before_send
+from okp_mcp.telemetry import initialize_error_reporting
 
 
 @pytest.mark.parametrize(

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -3,17 +3,25 @@
 # pyright: reportMissingImports=false
 
 import inspect
-from unittest.mock import AsyncMock, Mock, patch
+
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import httpx
 import pytest
 
 import okp_mcp  # noqa: F401 -- triggers @mcp.tool registration
+
 from okp_mcp import tools
 from okp_mcp.config import ServerConfig
 from okp_mcp.portal import _MAX_QUERIES
 from okp_mcp.server import mcp
-from okp_mcp.tools import _doc_id_filter, _escape_solr_phrase, _format_document, _normalize_doc_id
+from okp_mcp.tools import _doc_id_filter
+from okp_mcp.tools import _escape_solr_phrase
+from okp_mcp.tools import _format_document
+from okp_mcp.tools import _normalize_doc_id
+
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,15 @@ wheels = [
 ]
 
 [[package]]
+name = "asttokens"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -337,6 +346,15 @@ wheels = [
 ]
 
 [[package]]
+name = "decorator"
+version = "5.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/60/8b/32f9823da46cde7df2087faa08cd98d01b908f8dcab982cdba9c84e85355/decorator-5.3.1.tar.gz", hash = "sha256:4cbcdd55a6efadb9dbea26b858f4fb3264567b52d69ca0d25b721b553f60ea82", size = 58084, upload-time = "2026-05-18T06:03:28.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/05/7f/798705f5296a58ca505d600456748d1be48078eac8a7050d8a98bc9edb89/decorator-5.3.1-py3-none-any.whl", hash = "sha256:f47fe6fdbd2edd623ecfe36875d37aba411624e2670dd395dddae1358689bb3c", size = 10365, upload-time = "2026-05-18T06:03:26.517Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -377,6 +395,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "executing"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
 ]
 
 [[package]]
@@ -516,6 +543,53 @@ wheels = [
 ]
 
 [[package]]
+name = "ipdb"
+version = "0.13.13"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "decorator" },
+    { name = "ipython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/1b/7e07e7b752017f7693a0f4d41c13e5ca29ce8cbcfdcc1fd6c4ad8c0a27a0/ipdb-0.13.13.tar.gz", hash = "sha256:e3ac6018ef05126d442af680aad863006ec19d02290561ac88b8b1c0b0cfc726", size = 17042, upload-time = "2023-03-09T15:40:57.487Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4c/b075da0092003d9a55cf2ecc1cae9384a1ca4f650d51b00fc59875fe76f6/ipdb-0.13.13-py3-none-any.whl", hash = "sha256:45529994741c4ab6d2388bfa5d7b725c2cf7fe9deffabdb8a6113aa5ed449ed4", size = 12130, upload-time = "2023-03-09T15:40:55.021Z" },
+]
+
+[[package]]
+name = "ipython"
+version = "9.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "decorator" },
+    { name = "ipython-pygments-lexers" },
+    { name = "jedi" },
+    { name = "matplotlib-inline" },
+    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit" },
+    { name = "psutil", marker = "sys_platform != 'emscripten'" },
+    { name = "pygments" },
+    { name = "stack-data" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/23/3a27530575643c8bb7bfc757a28e2e7ef80092afbf59a2bc5716320b6602/ipython-9.14.1.tar.gz", hash = "sha256:f913bf74df06d458e46ced84ca506c23797590d594b236fe60b14df213291e7b", size = 4433457, upload-time = "2026-06-05T08:12:34.921Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/22/58818a63eaf8982b67632b1bc20585c811611b15a8da19d6012323dc76a5/ipython-9.14.1-py3-none-any.whl", hash = "sha256:5d4a9ecaa3b10e6e5f269dd0948bdb58ca9cb851899cd23e07c320d3eb11613c", size = 627770, upload-time = "2026-06-05T08:12:33.045Z" },
+]
+
+[[package]]
+name = "ipython-pygments-lexers"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/33/1f075bf72b0b747cb3288d011319aaf64083cf2efef8354174e3ed4540e2/ipython_pygments_lexers-1.1.1-py3-none-any.whl", hash = "sha256:a9462224a505ade19a605f71f8fa63c2048833ce50abc86768a0d81d876dc81c", size = 8074, upload-time = "2025-01-17T11:24:33.271Z" },
+]
+
+[[package]]
 name = "jaraco-classes"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -546,6 +620,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/cf/ea4ef2920830dea3f5ab2ea4da6fb67724e6dca80ee2553788c3607243d0/jaraco_functools-4.5.0.tar.gz", hash = "sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03", size = 20272, upload-time = "2026-05-15T21:34:10.025Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/9a/982e48afcffcd727a9144506720ffd4224b6b7e355c98641866f38b7c043/jaraco_functools-4.5.0-py3-none-any.whl", hash = "sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4", size = 10594, upload-time = "2026-05-15T21:34:08.595Z" },
+]
+
+[[package]]
+name = "jedi"
+version = "0.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "parso" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/b7/a3635f6a2d7cf5b5dd98064fc1d5fbbafcb25477bcea204a3a92145d158b/jedi-0.20.0.tar.gz", hash = "sha256:c3f4ccbd276696f4b19c54618d4fb18f9fc24b0aef02acf704b23f487daa1011", size = 3119416, upload-time = "2026-05-01T23:38:47.814Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/93/242e2eab5fe682ffcb8b0084bde703a41d51e17ee0f3a31ff0d9d813620a/jedi-0.20.0-py2.py3-none-any.whl", hash = "sha256:7bdd9c2634f56713299976f4cbd59cb3fa92165cc5e05ea811fb253480728b67", size = 4884812, upload-time = "2026-05-01T23:38:43.919Z" },
 ]
 
 [[package]]
@@ -662,6 +748,18 @@ wheels = [
 ]
 
 [[package]]
+name = "matplotlib-inline"
+version = "0.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/c0/9f7c9a46090390368a4d7bcb76bb87a4a36c421e4c0792cdb53486ffac7a/matplotlib_inline-0.2.2.tar.gz", hash = "sha256:72f3fe8fce36b70d4a5b612f899090cd0401deddc4ea90e1572b9f4bfb058c79", size = 8150, upload-time = "2026-05-08T17:33:33.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/09/5b161152e2d90f7b87f781c2e1267494aef9c32498df793f73ad0a0a494a/matplotlib_inline-0.2.2-py3-none-any.whl", hash = "sha256:3c821cf1c209f59fb2d2d64abbf5b23b67bcb2210d663f9918dd851c6da1fcf6", size = 9534, upload-time = "2026-05-08T17:33:32.055Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
@@ -718,6 +816,8 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "ipdb" },
+    { name = "ipython" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -739,6 +839,8 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ipdb" },
+    { name = "ipython" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
     { name = "pytest-cov", specifier = ">=7.1.0" },
@@ -783,12 +885,33 @@ wheels = [
 ]
 
 [[package]]
+name = "parso"
+version = "0.8.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
 name = "pathable"
 version = "0.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
+]
+
+[[package]]
+name = "pexpect"
+version = "4.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c3/059298687310d527a58bb01f3b1965787ee3b40dce76752eda8b44e9a2c5/pexpect-4.9.0-py2.py3-none-any.whl", hash = "sha256:7236d1e080e4936be2dc3e326cec0af72acf9212a7e1d060210e70a47e253523", size = 63772, upload-time = "2023-11-25T06:56:14.81Z" },
 ]
 
 [[package]]
@@ -816,6 +939,64 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "ptyprocess"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/e5/16ff212c1e452235a90aeb09066144d0c5a6a8c0834397e03f5224495c4e/ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220", size = 70762, upload-time = "2020-12-28T15:15:30.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/22/a6/858897256d0deac81a172289110f31629fc4cee19b6f01283303e18c8db3/ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35", size = 13993, upload-time = "2020-12-28T15:15:28.35Z" },
+]
+
+[[package]]
+name = "pure-eval"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
 ]
 
 [[package]]
@@ -1394,6 +1575,20 @@ wheels = [
 ]
 
 [[package]]
+name = "stack-data"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "executing" },
+    { name = "pure-eval" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/e3/55dcc2cfbc3ca9c29519eb6884dd1415ecb53b0e934862d3559ddcb7e20b/stack_data-0.6.3.tar.gz", hash = "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9", size = 44707, upload-time = "2023-09-30T13:58:05.479Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/7b/ce1eafaf1a76852e2ec9b22edecf1daa58175c090266e9f6c64afcd81d91/stack_data-0.6.3-py3-none-any.whl", hash = "sha256:d5558e0c25a4cb0853cddad3d77da9891a08cb85dd9f9f91b9f8cd66e511e695", size = 24521, upload-time = "2023-09-30T13:58:03.53Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1404,6 +1599,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/25/44/ec35f1b6e83094b997da438a02c8c9b0ade2b1e84cfc48bd4656780760a6/starlette-1.2.1.tar.gz", hash = "sha256:9b9b5ebb992e67d6093741e63c2f59e4f6fff986f81163c087867bd7b924b3f6", size = 2701854, upload-time = "2026-05-31T01:07:51.847Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/54/196d0c1db10af76baa4f64894448505d60d3cdf70ef92cbb35f46a4e4c71/starlette-1.2.1-py3-none-any.whl", hash = "sha256:4de0082d08c8f6764a85a54cf1120d6939507a19905c7768acad2a9f875d2b89", size = 73350, upload-time = "2026-05-31T01:07:50.09Z" },
+]
+
+[[package]]
+name = "traitlets"
+version = "5.15.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/a9/a2584b8313b89f94869ddb3c4074617a691de1812a614d2d50e32ca5a7a6/traitlets-5.15.1.tar.gz", hash = "sha256:7b1c07854fe25acb39e009bae49f11b79ff6cbb2f27999104e9110e7a6b53722", size = 163344, upload-time = "2026-06-03T12:26:06.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/8d/1080ee4c231f361b6ce4470d556c8c435b67c7e0753aaa641497ee92f88b/traitlets-5.15.1-py3-none-any.whl", hash = "sha256:770a53705f84b81ac107e83a1b3328ff2dae16094d8fc3cfc004e4b22dfd8e92", size = 85858, upload-time = "2026-06-03T12:26:04.395Z" },
 ]
 
 [[package]]
@@ -1567,6 +1771,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
     { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
     { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
+]
+
+[[package]]
+name = "wcwidth"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/b4/51fe890511f0f242d07cb1ebe6a5b6db417262b9d2568b460347c57d95cc/wcwidth-0.8.1.tar.gz", hash = "sha256:faf5b4a5366a72dc49cad48cdf21f52bdf63bdda995178e483ba247ff79089b9", size = 1466072, upload-time = "2026-06-08T05:57:23.146Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/6e/95b0e537de1f4d4301f76f944642c6da50d1511cc7b3d64dc418a66c7509/wcwidth-0.8.1-py3-none-any.whl", hash = "sha256:f453740b1e4a4f3291faa37944c555d71056c4da08d59809b307ef4feba695c8", size = 323092, upload-time = "2026-06-08T05:57:21.413Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add `ipdb` to the dev dependency group for better debugging.

**Pytest**
- enable coverage
- enforce strict markers
- show variables on failure
- set default debugger it `ipdb`

**Coverage**
- change default directory to `coverage/`
- enable branch coverage
- enable coverage on tests

**Ruff**
- enable rule RUF100 to find unnecessary `noqa` statements
- set import sorting rules
- reformat imports based on sorting rule changes

**Uv**
- run `uv` asserting that no changes will be made to the lock file