### PR TITLE
Set CLA_THROTTLING_DELAY=10 in QE gating trigger

### DIFF
--- a/openshift/qe-gating-stage-trigger.yml
+++ b/openshift/qe-gating-stage-trigger.yml
@@ -126,7 +126,8 @@ objects:
                       --form "variables[TRIGGER_SOURCE]=promotion-channel" \
                       --form "variables[PLAN]=level2" \
                       --form "variables[CLA_TESTS_PACKAGE_SOURCE_PROFILE]=cdn" \
-                      --form "variables[COMPOSE]=RHEL-9.8.0-Nightly"
+                      --form "variables[COMPOSE]=RHEL-9.8.0-Nightly" \
+                      --form "variables[CLA_THROTTLING_DELAY]=10"
                   )
                   CURL_EXIT=$?
                   set -e


### PR DESCRIPTION
Without throttling delay, concurrent API calls to the backend cause rate limiting or failures during the compare test run.

JIRA: RSPEED-3038