### PR TITLE
ci(konflux): disable hermetic builds in tekton pipelines

### DIFF
--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -35,7 +35,7 @@ spec:
       value: /Containerfile
 
     - name: hermetic
-      value: "true"
+      value: "false"
 
     - name: prefetch-input
       value: |

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -40,7 +40,7 @@ spec:
       value: /Containerfile
 
     - name: hermetic
-      value: "true"
+      value: "false"
 
     - name: prefetch-input
       value: |


### PR DESCRIPTION
Flips `hermetic` to `false` in both the PR and push PipelineRuns.

The `prefetch-input` blocks stay in place. Konflux ignores them when hermetic is off, so re-enabling is a one-line revert.

## What
- `.tekton/pull_request.yaml`: `hermetic: "true"` -> `"false"`
- `.tekton/push.yaml`: `hermetic: "true"` -> `"false"`

## Why
Build now uses the network and the non-hermetic uv path (`uv sync --locked`) instead of the Cachi2 prefetch + hash-pinned manifest flow.