### PR TITLE
refactor: idiomatic cleanups in bm25, solr, and portal

### DIFF
--- a/src/okp_mcp/bm25.py
+++ b/src/okp_mcp/bm25.py
@@ -68,11 +68,11 @@ class BM25Plus:
         """Return one BM25+ score per document, indexed by corpus position."""
         scores = [0.0] * self.corpus_size
         for q in query:
-            idf = self.idf.get(q) or 0
+            idf = self.idf.get(q, 0)
             if not idf:
                 continue
             for idx in range(self.corpus_size):
-                q_freq = self.doc_freqs[idx].get(q) or 0
+                q_freq = self.doc_freqs[idx].get(q, 0)
                 denom = self.k1 * (1 - self.b + self.b * self.doc_len[idx] / self.avgdl) + q_freq
                 scores[idx] += idf * (self.delta + (q_freq * (self.k1 + 1)) / denom)
         return scores

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -567,8 +567,7 @@ async def _run_portal_search(
 
     Args:
         query: Raw user query string.
-        client: Shared httpx.AsyncClient (typed as object to avoid httpx import
-            at module level; the actual type is enforced by ``_solr_query``).
+        client: Shared httpx.AsyncClient used for the Solr requests.
         solr_endpoint: Full Solr endpoint URL for the portal core.
         max_results: Maximum chunks to return after deduplication.
         emit_quality_metrics: Whether to record search quality Prometheus

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -247,15 +247,15 @@ def _filter_rhv_sentences(text: str, query: str) -> str:
     sentences = re.split(r"(?<=[.!?])\s+|\n", text)
     filtered: list[str] = []
     for sentence in sentences:
-        sentence = sentence.strip()
-        if not sentence:
+        stripped = sentence.strip()
+        if not stripped:
             continue
-        sentence_lower = sentence.lower()
+        sentence_lower = stripped.lower()
         has_rhv = any(rhv in sentence_lower for rhv in _EXTRACTION_DEMOTE_RHV)
         has_contamination = any(phrase in sentence_lower for phrase in _CONTAMINATION_PHRASES)
         if has_rhv and has_contamination:
             continue
-        filtered.append(sentence)
+        filtered.append(stripped)
     return " ".join(filtered)
 
 


### PR DESCRIPTION
Three small non-behavioral cleanups, each independent:

- **bm25**: `self.idf.get(q, 0)` instead of `self.idf.get(q) or 0` (and same for `q_freq`). The default-arg form is the idiomatic fallback and does not mask a legitimate `0`. Counter-backed freqs are always >=1, so behavior is identical.
- **solr**: rebind the stripped sentence to a new variable (`stripped`) instead of reassigning the loop variable, avoiding `PLW2901`-style shadowing.
- **portal**: drop a stale docstring parenthetical claiming the `client` param is "typed as object to avoid httpx import at module level". The signature is `httpx.AsyncClient` and httpx is imported at module level.

No behavior change. `make ci` green (396 passed); CodeRabbit local review: 0 findings.