### PR TITLE
Fix/graceful commit sha fallback

### DIFF
--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -47,7 +47,10 @@ def main() -> None:
     config = CliApp.run(ServerConfig)
     _server._server_config = config
     _configure_logging(config.log_level)
-    initialize_error_reporting(config)
+    try:
+        initialize_error_reporting(config)
+    except Exception:
+        logger.warning("Failed to initialize error reporting; continuing without it", exc_info=True)
 
     logger.info("okp-mcp %s (%s)", get_package_version(), get_commit_sha())
     logger.info("Starting MCP server with transport=%s", config.transport)

--- a/src/okp_mcp/build_info.py
+++ b/src/okp_mcp/build_info.py
@@ -60,7 +60,7 @@ def get_commit_sha() -> str:
         git_sha = _commit_sha_from_git()
         if git_sha:
             commit_sha = git_sha
-        logger.warning("No commit sha found in %s. Using commit value: %s", commit_sha_file, commit_sha)
+        logger.warning(f"No commit sha found in {commit_sha_file}. Using commit value: {commit_sha}")
 
     return commit_sha
 

--- a/src/okp_mcp/build_info.py
+++ b/src/okp_mcp/build_info.py
@@ -18,7 +18,7 @@ DEFAULT_COMMIT_SHA = os.getenv("COMMIT_SHA", "development")
 logger = logging.getLogger(__name__)
 
 
-def _commit_sha_from_git() -> str:
+def _commit_sha_from_git() -> str | None:
     """Return the short commit SHA from the local git checkout, if available.
 
     Local dev runs (``uv run okp-mcp``) execute outside the container, so the
@@ -34,8 +34,9 @@ def _commit_sha_from_git() -> str:
             text=True,
             check=True,
         )
-    except (OSError, subprocess.SubprocessError) as ex:
-        raise ValueError("Failed to retrieve git commit sha.") from ex
+    except (OSError, subprocess.SubprocessError):
+        logger.debug("git not available for commit SHA resolution")
+        return None
 
     return result.stdout.strip()
 
@@ -56,8 +57,10 @@ def get_commit_sha() -> str:
     try:
         commit_sha = commit_sha_file.read_text(encoding="utf-8").strip()
     except OSError:
-        commit_sha = _commit_sha_from_git()
-        logger.warning(f"No commit sha found in {commit_sha_file}. Using commit value: {commit_sha}")
+        git_sha = _commit_sha_from_git()
+        if git_sha:
+            commit_sha = git_sha
+        logger.warning("No commit sha found in %s. Using commit value: %s", commit_sha_file, commit_sha)
 
     return commit_sha
 

--- a/tests/test_build_info.py
+++ b/tests/test_build_info.py
@@ -2,8 +2,6 @@
 
 from unittest.mock import patch
 
-import pytest
-
 from okp_mcp.build_info import _commit_sha_from_git
 from okp_mcp.build_info import get_commit_sha
 from okp_mcp.build_info import get_package_version
@@ -26,23 +24,20 @@ def test_get_commit_sha_uses_git_when_file_missing(tmp_path):
         assert get_commit_sha() == "9abcdef"
 
 
-def test_get_commit_sha_propagates_git_failure(tmp_path):
-    """Raise when the file is absent and git is unavailable."""
+def test_get_commit_sha_falls_back_to_default_when_git_unavailable(tmp_path):
+    """Return the default sentinel when the file is absent and git is unavailable."""
     with (
         patch("okp_mcp.build_info.DEFAULT_APP_ROOT", str(tmp_path)),
-        patch("okp_mcp.build_info._commit_sha_from_git", side_effect=ValueError),
-        pytest.raises(ValueError),
+        patch("okp_mcp.build_info._commit_sha_from_git", return_value=None),
+        patch("okp_mcp.build_info.DEFAULT_COMMIT_SHA", "development"),
     ):
-        get_commit_sha()
+        assert get_commit_sha() == "development"
 
 
-def test_commit_sha_from_git_raises_when_git_missing():
-    """Raise ValueError when the git executable is unavailable."""
-    with (
-        patch("okp_mcp.build_info.subprocess.run", side_effect=FileNotFoundError),
-        pytest.raises(ValueError),
-    ):
-        _commit_sha_from_git()
+def test_commit_sha_from_git_returns_none_when_git_missing():
+    """Return None when the git executable is unavailable."""
+    with patch("okp_mcp.build_info.subprocess.run", side_effect=FileNotFoundError):
+        assert _commit_sha_from_git() is None
 
 
 def test_get_package_version():


### PR DESCRIPTION
get_commit_sha() crashed with an unhandled ValueError when both the
COMMIT_SHA file and the git binary were absent, causing okp-mcp to
crash-loop in containers. _commit_sha_from_git() now returns None
instead of raising, letting get_commit_sha() fall back to the default
sentinel. Telemetry init failures are also caught so they never abort
startup.

Resolves: RSPEED-3220