### PR TITLE
fix: restore tool registration side-effect import

### DIFF
--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -6,6 +6,7 @@ import sys
 from pydantic_settings import CliApp
 
 from okp_mcp import server as _server
+from okp_mcp import tools as _tools  # noqa: F401 -- import triggers @mcp.tool registration
 from okp_mcp.build_info import get_commit_sha
 from okp_mcp.build_info import get_package_version
 from okp_mcp.config import ServerConfig

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -48,18 +48,39 @@ def test_mcp_properties(attr, expected):
     assert getattr(mcp, attr) == expected
 
 
-@pytest.mark.asyncio
-async def test_production_tools_registered():
-    """Production tools are registered on the MCP server."""
-    import okp_mcp  # noqa: F401 — triggers tool registration via __init__
+def test_production_tools_registered():
+    """Importing only ``okp_mcp`` registers the production tools.
 
-    tools = await mcp._list_tools()
-    tool_names = {tool.name for tool in tools}
+    Run in a clean subprocess so the assertion exercises the real
+    ``okp_mcp/__init__.py`` import chain in isolation. In-process this would
+    pass for the wrong reason: sibling tests import the tool modules directly,
+    firing the ``@mcp.tool`` decorators as a side effect, which masks a missing
+    side-effect import in ``__init__`` (see the #280 regression where tools
+    silently stopped registering in production).
+    """
+    import subprocess
+    import sys
+
+    probe = (
+        "import asyncio, okp_mcp\n"
+        "tools = asyncio.run(okp_mcp.mcp._list_tools())\n"
+        "print(','.join(sorted(t.name for t in tools)))\n"
+    )
+    result = subprocess.run(  # noqa: S603 -- fixed literal probe, no untrusted input
+        [sys.executable, "-c", probe],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    tool_names = set(result.stdout.strip().split(",")) if result.stdout.strip() else set()
     expected_tools = {
         "search_portal",
         "get_document",
     }
-    assert expected_tools.issubset(tool_names)
+    assert expected_tools.issubset(tool_names), (
+        f"Importing okp_mcp alone did not register tools {expected_tools - tool_names}. "
+        f"Got: {sorted(tool_names)}. Is the tools side-effect import missing from __init__?"
+    )
     removed_tools = {
         "search_documentation",
         "search_solutions",


### PR DESCRIPTION
Commit 2283bd15ba (#280) removed the `from okp_mcp import tools` line from __init__.py during the architecture refactor. Tools register via @mcp.tool decorators that only fire when their modules are imported, so importing the top-level okp_mcp package alone (as production entrypoints do) left the MCP server advertising zero tools. tools/list returned an empty set in any deployment that imports okp_mcp without separately importing the tool modules.

The existing test_production_tools_registered passed in CI because sibling test modules import the tool packages directly, firing the decorators as a side effect and masking the missing import. Rewrite the guard to probe in a clean subprocess that imports only okp_mcp, so it exercises the real __init__ import chain in isolation and fails if the side-effect import regresses again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated tool registration verification to use subprocess-based testing approach for improved reliability.

* **Chores**
  * Ensured MCP tool registration occurs reliably during package import.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->