### PR TITLE
refactor: make annotate_result public in formatting.py

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Add/modify intent detection | `src/okp_mcp/intent.py` | Append `IntentRule` to `INTENT_RULES` at the correct priority position |
 | Change portal search logic | `src/okp_mcp/portal.py` | Query builders, chunk conversion, RRF fusion, single/multi-query orchestrators, formatting |
 | Change Solr query logic | `src/okp_mcp/solr.py` | `_solr_query()` builds edismax params; `_clean_query()` for tokenization |
-| Modify result formatting | `src/okp_mcp/formatting.py` | `_annotate_result()` for deprecation/EOL (used by portal.py) |
+| Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg via `MCP_` prefix |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |

--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -60,7 +60,7 @@ def _scan_eol_product(text_lower: str, product: str) -> str:
     return ""
 
 
-def _annotate_result(title: str, highlights: str, content: str, product: str = "") -> tuple[list[str], str, int]:
+def annotate_result(title: str, highlights: str, content: str, product: str = "") -> tuple[list[str], str, int]:
     """Scan title and content for deprecation, replacement, and EOL-product signals.
 
     Returns (annotations, applicability, sort_key) where sort_key controls

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -16,7 +16,7 @@ from okp_mcp.config import logger
 from okp_mcp.content import _select_within_budget
 from okp_mcp.content import doc_uri
 from okp_mcp.content import strip_boilerplate
-from okp_mcp.formatting import _annotate_result
+from okp_mcp.formatting import annotate_result
 from okp_mcp.intent import apply_deprecation_boosts
 from okp_mcp.intent import apply_main_boosts
 from okp_mcp.metrics import SEARCH_DEPRECATION_DETECTED
@@ -744,11 +744,11 @@ _KIND_LABELS: dict[str, str] = {
 def _format_portal_chunk(chunk: PortalChunk) -> tuple[str, int]:
     """Render a single PortalChunk as a markdown result block.
 
-    Uses ``_annotate_result()`` from ``formatting.py`` to detect deprecation,
+    Uses ``annotate_result()`` from ``formatting.py`` to detect deprecation,
     replacement, and EOL signals. Returns ``(formatted_text, sort_key)``
     where sort_key controls ordering (replacement first, EOL last).
     """
-    annotations, applicability, sort_key = _annotate_result(
+    annotations, applicability, sort_key = annotate_result(
         title=chunk.title,
         highlights=chunk.chunk,
         content=chunk.chunk,

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,6 +1,6 @@
 """Tests for okp_mcp.formatting module."""
 
-from okp_mcp.formatting import _annotate_result
+from okp_mcp.formatting import annotate_result
 from okp_mcp.formatting import SORT_DEPRECATION
 from okp_mcp.formatting import SORT_EOL_PRODUCT
 from okp_mcp.formatting import SORT_REPLACEMENT
@@ -16,7 +16,7 @@ class TestEolProductFieldGuard:
 
     def test_non_eol_product_mentioning_rhv_not_demoted(self):
         """Doc with product='Red Hat OpenShift Data Foundation' mentioning RHV is NOT demoted."""
-        _, _, sort_key = _annotate_result(
+        _, _, sort_key = annotate_result(
             title="Troubleshooting OpenShift Data Foundation",
             highlights="Deploy on Red Hat Virtualization or VMware",
             content="Configure storage on Red Hat Virtualization hosts",
@@ -26,7 +26,7 @@ class TestEolProductFieldGuard:
 
     def test_non_eol_product_mentioning_fuse_not_demoted(self):
         """Doc with product='Red Hat build of Apache Camel' mentioning Fuse is NOT demoted."""
-        _, _, sort_key = _annotate_result(
+        _, _, sort_key = annotate_result(
             title="Support of Red Hat Middleware on OpenShift",
             highlights="Red Hat Fuse is available as a container image",
             content="Middleware products including Red Hat Fuse",
@@ -36,7 +36,7 @@ class TestEolProductFieldGuard:
 
     def test_empty_product_mentioning_rhv_still_demoted(self):
         """Doc with no product field (solutions/articles) mentioning RHV IS still demoted."""
-        _, _, sort_key = _annotate_result(
+        _, _, sort_key = annotate_result(
             title="How to configure virtual machines",
             highlights="Use Red Hat Virtualization Manager to create VMs",
             content="Red Hat Virtualization provides centralized management",
@@ -45,7 +45,7 @@ class TestEolProductFieldGuard:
 
     def test_eol_product_field_still_demoted(self):
         """Doc whose own product IS an EOL product is correctly demoted."""
-        _, _, sort_key = _annotate_result(
+        _, _, sort_key = annotate_result(
             title="Installing Red Hat Virtualization Manager",
             highlights="Red Hat Virtualization Manager installation guide",
             content="Red Hat Virtualization 4.4 installation",
@@ -55,7 +55,7 @@ class TestEolProductFieldGuard:
 
     def test_eol_product_gluster_in_product_field_demoted(self):
         """Doc with product='Red Hat Gluster Storage' is correctly demoted."""
-        _, _, sort_key = _annotate_result(
+        _, _, sort_key = annotate_result(
             title="Red Hat Gluster Storage Administration",
             highlights="Gluster volume configuration",
             content="Red Hat Gluster Storage cluster setup",
@@ -65,7 +65,7 @@ class TestEolProductFieldGuard:
 
     def test_no_product_param_defaults_to_empty(self):
         """Calling without product param preserves existing behavior (backward compat)."""
-        _, _, sort_key = _annotate_result(
+        _, _, sort_key = annotate_result(
             title="Some doc",
             highlights="Mentions Red Hat Fuse in passing",
             content="",
@@ -74,7 +74,7 @@ class TestEolProductFieldGuard:
 
     def test_deprecation_annotation_preserved_with_product_guard(self):
         """Deprecation annotations still work when product guard skips EOL scan."""
-        annotations, _, sort_key = _annotate_result(
+        annotations, _, sort_key = annotate_result(
             title="Feature deprecated in RHEL 9",
             highlights="This feature has been deprecated and Red Hat Virtualization mentioned",
             content="deprecated in favor of new approach",
@@ -85,7 +85,7 @@ class TestEolProductFieldGuard:
 
     def test_replacement_annotation_preserved_with_product_guard(self):
         """Replacement annotations still work when product guard skips EOL scan."""
-        annotations, _, sort_key = _annotate_result(
+        annotations, _, sort_key = annotate_result(
             title="Cockpit replaces old admin tool",
             highlights="replaced by cockpit, Red Hat Virtualization is mentioned",
             content="the recommended replacement is cockpit",


### PR DESCRIPTION
The function was incorrectly set to private while being used by external modules