### PR TITLE
refactor(tools): remove private re-exports from tools/__init__.py

### DIFF
--- a/src/okp_mcp/tools/__init__.py
+++ b/src/okp_mcp/tools/__init__.py
@@ -1,24 +1,5 @@
 """MCP tool definitions for RHEL OKP knowledge base search."""
 
-from okp_mcp.tools.document import _doc_id_filter
-from okp_mcp.tools.document import _escape_solr_phrase
-from okp_mcp.tools.document import _fetch_document_raw
-from okp_mcp.tools.document import _fetch_document_with_query
-from okp_mcp.tools.document import _format_document
-from okp_mcp.tools.document import _normalize_doc_id
-from okp_mcp.tools.document import get_document
-from okp_mcp.tools.run_code import run_code
-from okp_mcp.tools.search import search_portal
-
-
-__all__ = [
-    "_doc_id_filter",
-    "_escape_solr_phrase",
-    "_fetch_document_raw",
-    "_fetch_document_with_query",
-    "_format_document",
-    "_normalize_doc_id",
-    "get_document",
-    "run_code",
-    "search_portal",
-]
+from okp_mcp.tools.document import get_document as get_document  # triggers @mcp.tool registration
+from okp_mcp.tools.run_code import run_code as run_code  # triggers @mcp.tool registration
+from okp_mcp.tools.search import search_portal as search_portal  # triggers @mcp.tool registration

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -17,10 +17,12 @@ from okp_mcp import tools
 from okp_mcp.config import ServerConfig
 from okp_mcp.portal import _MAX_QUERIES
 from okp_mcp.server import mcp
-from okp_mcp.tools import _doc_id_filter
-from okp_mcp.tools import _escape_solr_phrase
-from okp_mcp.tools import _format_document
-from okp_mcp.tools import _normalize_doc_id
+from okp_mcp.tools.document import _doc_id_filter
+from okp_mcp.tools.document import _escape_solr_phrase
+from okp_mcp.tools.document import _fetch_document_raw
+from okp_mcp.tools.document import _fetch_document_with_query
+from okp_mcp.tools.document import _format_document
+from okp_mcp.tools.document import _normalize_doc_id
 
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
@@ -52,7 +54,7 @@ async def test_fetch_document_raw_uses_provided_client_without_constructing_or_c
     with patch(
         "okp_mcp.tools.document.httpx.AsyncClient", side_effect=AssertionError("constructor should not be called")
     ):
-        data = await tools._fetch_document_raw("/solutions/123", client=mock_client, solr_endpoint=_SOLR_ENDPOINT)
+        data = await _fetch_document_raw("/solutions/123", client=mock_client, solr_endpoint=_SOLR_ENDPOINT)
 
     mock_client.get.assert_awaited_once()
     mock_client.aclose.assert_not_awaited()
@@ -70,7 +72,7 @@ async def test_fetch_document_raw_creates_and_closes_client_when_not_provided():
     created_client.aclose = AsyncMock()
 
     with patch("okp_mcp.tools.document.httpx.AsyncClient", return_value=created_client) as client_ctor:
-        data = await tools._fetch_document_raw("/solutions/123", solr_endpoint=_SOLR_ENDPOINT)
+        data = await _fetch_document_raw("/solutions/123", solr_endpoint=_SOLR_ENDPOINT)
 
     client_ctor.assert_called_once_with(timeout=30.0)
     created_client.get.assert_awaited_once()
@@ -84,7 +86,7 @@ async def test_fetch_document_with_query_passes_client_to_solr_query():
     expected = {"response": {"numFound": 1, "docs": [{"id": "123"}]}}
 
     with patch("okp_mcp.tools.document._solr_query", AsyncMock(return_value=expected)) as solr_query_mock:
-        data = await tools._fetch_document_with_query(
+        data = await _fetch_document_with_query(
             "/solutions/123", "kernel panic", client=mock_client, solr_endpoint=_SOLR_ENDPOINT
         )
 


### PR DESCRIPTION
Remove `__all__` and 6 private helper re-exports from `tools/__init__.py`. These existed solely so tests could `from okp_mcp.tools import _helper` instead of importing from the defining module (`okp_mcp.tools.document`).

Tests now import directly from `okp_mcp.tools.document`. The three public tool registrations (`get_document`, `run_code`, `search_portal`) remain as side-effect imports for `@mcp.tool` registration.

Net: -17 lines, one fewer place to update when adding/renaming document helpers.

## Testing

`make ci` passes (lint, typecheck, radon, 396 tests).
