### PR TITLE
refactor: consolidate EOL product lists into single registry

### DIFF
--- a/src/okp_mcp/formatting.py
+++ b/src/okp_mcp/formatting.py
@@ -3,13 +3,50 @@
 import re
 
 
-EOL_PRODUCT_MENTIONS = [
+# ---------------------------------------------------------------------------
+# Single-source EOL product registry
+# ---------------------------------------------------------------------------
+# (name, abbreviation) — one place to edit when a product reaches EOL.
+#
+# * Every name feeds the Solr fq exclusion filter (via EOL_PRODUCT_NAMES).
+# * Entries with a non-empty abbreviation are also scanned in document text
+#   for EOL annotations (via EOL_PRODUCT_MENTIONS).
+# * Alias entries ("RHEV", shortened names) are legitimate text-scan patterns
+#   that don't correspond to a real Solr product field value; including them
+#   in the fq is harmless (no doc matches) and keeps the data in one tuple.
+EOL_PRODUCTS: tuple[tuple[str, str], ...] = (
     ("Red Hat Virtualization", "RHV"),
     ("RHEV", "RHV"),
+    ("Red Hat Hyperconverged Infrastructure for Virtualization", "RHHI"),
     ("Red Hat Hyperconverged Infrastructure", "RHHI"),
+    ("Red Hat JBoss Operations Network", ""),
     ("Red Hat Fuse", "Fuse"),
+    ("Red Hat Single Sign-On", ""),
+    ("Red Hat Single Sign-On Continuous Delivery", ""),
+    ("Red Hat CodeReady Workspaces", ""),
+    ("Red Hat CodeReady Studio", ""),
+    ("Red Hat JBoss Data Virtualization", ""),
+    ("Red Hat Container Development Kit", ""),
     ("Red Hat Gluster Storage", "Gluster"),
-]
+    ("Red Hat JBoss Developer Studio", ""),
+    ("Red Hat JBoss Developer Studio Integration Stack", ""),
+    ("Red Hat Application Migration Toolkit", ""),
+    ("Red Hat Software Collections", ""),
+    ("JBoss Enterprise SOA Platform", ""),
+    ("JBoss Enterprise Application Platform Continuous Delivery", ""),
+    ("Red Hat Development Suite", ""),
+    ("Red Hat Developer Toolset", ""),
+    ("OpenShift Online", ""),
+    ("Red Hat JBoss Fuse Service Works", ""),
+    ("Red Hat Certificate System", ""),
+    ("Red Hat Process Automation Manager", ""),
+    ("Red Hat Decision Manager", ""),
+    ("Red Hat OpenShift Container Storage", ""),
+)
+
+# Derived views — no separate maintenance needed.
+EOL_PRODUCT_NAMES: frozenset[str] = frozenset(name for name, _ in EOL_PRODUCTS)
+EOL_PRODUCT_MENTIONS: list[tuple[str, str]] = [(name, abbr) for name, abbr in EOL_PRODUCTS if abbr]
 
 _DEPRECATION_RE = re.compile(
     r"\b(deprecated|removed|no longer available|no longer supported|end of life|"

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -17,6 +17,7 @@ from okp_mcp.content import _select_within_budget
 from okp_mcp.content import doc_uri
 from okp_mcp.content import strip_boilerplate
 from okp_mcp.formatting import annotate_result
+from okp_mcp.formatting import EOL_PRODUCT_NAMES
 from okp_mcp.intent import apply_deprecation_boosts
 from okp_mcp.intent import apply_main_boosts
 from okp_mcp.metrics import SEARCH_DEPRECATION_DETECTED
@@ -49,37 +50,6 @@ class PortalChunk:
     rrf_score: float | None = field(default=None, repr=False)
 
 
-_EOL_PRODUCTS: frozenset[str] = frozenset(
-    [
-        "Red Hat Virtualization",
-        "Red Hat Hyperconverged Infrastructure for Virtualization",
-        "Red Hat JBoss Operations Network",
-        "Red Hat Fuse",
-        "Red Hat Single Sign-On",
-        "Red Hat Single Sign-On Continuous Delivery",
-        "Red Hat CodeReady Workspaces",
-        "Red Hat CodeReady Studio",
-        "Red Hat JBoss Data Virtualization",
-        "Red Hat Container Development Kit",
-        "Red Hat Gluster Storage",
-        "Red Hat JBoss Developer Studio",
-        "Red Hat JBoss Developer Studio Integration Stack",
-        "Red Hat Application Migration Toolkit",
-        "Red Hat Software Collections",
-        "JBoss Enterprise SOA Platform",
-        "JBoss Enterprise Application Platform Continuous Delivery",
-        "Red Hat Development Suite",
-        "Red Hat Developer Toolset",
-        "OpenShift Online",
-        "Red Hat JBoss Fuse Service Works",
-        "Red Hat Certificate System",
-        "Red Hat Process Automation Manager",
-        "Red Hat Decision Manager",
-        "Red Hat OpenShift Container Storage",
-    ]
-)
-
-
 # ---------------------------------------------------------------------------
 # Query builders
 # ---------------------------------------------------------------------------
@@ -110,7 +80,7 @@ _MAIN_QF = "title^5 main_content heading_h1^3 heading_h2 portal_synopsis^3 allTi
 
 def _build_eol_filter() -> str:
     """Build a Solr fq clause that excludes all EOL products."""
-    return " AND ".join(f'-product:"{p}"' for p in _EOL_PRODUCTS)
+    return " AND ".join(f'-product:"{p}"' for p in EOL_PRODUCT_NAMES)
 
 
 def _build_main_query(cleaned_query: str) -> dict:

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -6,6 +6,7 @@ import respx
 
 from prometheus_client import REGISTRY
 
+from okp_mcp.formatting import EOL_PRODUCT_NAMES
 from okp_mcp.intent import apply_deprecation_boosts
 from okp_mcp.intent import apply_main_boosts
 from okp_mcp.intent import INTENT_RULES
@@ -16,7 +17,6 @@ from okp_mcp.portal import _build_main_query
 from okp_mcp.portal import _deduplicate_by_parent
 from okp_mcp.portal import _DEPRECATION_WARNING
 from okp_mcp.portal import _docs_to_chunks
-from okp_mcp.portal import _EOL_PRODUCTS
 from okp_mcp.portal import _fallback_cve
 from okp_mcp.portal import _fallback_errata
 from okp_mcp.portal import _FALLBACK_MAX_CHARS
@@ -42,31 +42,31 @@ class TestEolProducts:
     """Verify the EOL product set and filter builder."""
 
     def test_eol_products_is_frozenset(self):
-        """_EOL_PRODUCTS is an immutable frozenset."""
-        assert isinstance(_EOL_PRODUCTS, frozenset)
+        """EOL_PRODUCT_NAMES is an immutable frozenset."""
+        assert isinstance(EOL_PRODUCT_NAMES, frozenset)
 
     def test_eol_products_contains_known_entries(self):
         """Spot-check that well-known EOL products are present."""
-        assert "Red Hat Virtualization" in _EOL_PRODUCTS
-        assert "Red Hat Software Collections" in _EOL_PRODUCTS
-        assert "Red Hat Decision Manager" in _EOL_PRODUCTS
+        assert "Red Hat Virtualization" in EOL_PRODUCT_NAMES
+        assert "Red Hat Software Collections" in EOL_PRODUCT_NAMES
+        assert "Red Hat Decision Manager" in EOL_PRODUCT_NAMES
 
     def test_eol_products_excludes_active(self):
         """Active products should not appear in the EOL set."""
-        assert "Red Hat Enterprise Linux" not in _EOL_PRODUCTS
-        assert "Red Hat OpenShift Container Platform" not in _EOL_PRODUCTS
+        assert "Red Hat Enterprise Linux" not in EOL_PRODUCT_NAMES
+        assert "Red Hat OpenShift Container Platform" not in EOL_PRODUCT_NAMES
 
     def test_build_eol_filter_excludes_all_products(self):
         """_build_eol_filter produces an AND-joined fq excluding every EOL product."""
         fq = _build_eol_filter()
-        for product in _EOL_PRODUCTS:
+        for product in EOL_PRODUCT_NAMES:
             assert f'-product:"{product}"' in fq
 
     def test_build_eol_filter_uses_and_conjunction(self):
         """Filter clauses are joined with AND so Solr applies all exclusions."""
         fq = _build_eol_filter()
-        # With 25 products there should be 24 AND separators
-        assert fq.count(" AND ") == len(_EOL_PRODUCTS) - 1
+        # N products → N-1 AND separators
+        assert fq.count(" AND ") == len(EOL_PRODUCT_NAMES) - 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`_EOL_PRODUCTS` in `portal.py` and `EOL_PRODUCT_MENTIONS` in `formatting.py` tracked overlapping sets of EOL products independently. Adding a new product required editing two files in two different formats, and nothing enforced they stayed in sync.

This consolidates both into a single `EOL_PRODUCTS` tuple in `formatting.py` with two derived constants:
- `EOL_PRODUCT_NAMES` (frozenset): feeds the Solr `fq` exclusion filter
- `EOL_PRODUCT_MENTIONS` (list): feeds the text-level EOL annotation scanner

Adding a new EOL product now means appending one `(name, abbreviation)` tuple.

## Testing

All existing tests pass. The `test_eol_filter_excludes_all_products` test now imports `EOL_PRODUCT_NAMES` from `formatting` instead of `_EOL_PRODUCTS` from `portal`. No behavioral changes, just data consolidation.
