### PR TITLE
refactor(types): replace bare dict hints with SolrDoc/SolrResponse BaseModels

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,6 +88,7 @@ src/okp_mcp/
   bm25.py        # Pure-Python BM25Plus scorer (drop-in for rank_bm25, no numpy)
   content.py     # Boilerplate stripping, content truncation, text cleaning
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
+  types.py       # Shared TypedDicts: SolrDoc, SolrHighlighting, SolrResponseBody, SolrResponse
 tests/
   conftest.py          # shared fixtures (solr mocks, sample responses) + functional marker deselection
   functional_cases.py  # FunctionalCase dataclass + parametrized RSPEED test data
@@ -214,21 +215,22 @@ __init__.py → build_info, config, metrics (side-effect import), request_id, se
 build_info.py → (standalone; reads COMMIT_SHA env var, APP_ROOT/COMMIT_SHA file, or local `git rev-parse`)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
 tools/search.py → config, metrics, portal, server
-tools/document.py → content, metrics, server, solr, tools/shared.py
+tools/document.py → content, metrics, server, solr, tools/shared.py, types
 tools/run_code.py → config, server
 metrics.py  → server (imports mcp for custom_route)
 request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starlette
 intent.py   → config
-portal.py   → config, content, formatting, intent, solr
+portal.py   → config, content, formatting, intent, solr, types
 formatting.py → (standalone)
-solr.py     → bm25, config, metrics
+solr.py     → bm25, config, metrics, types
 bm25.py     → (standalone)
 server.py   → config
 telemetry.py → build_info, config, sentry_sdk
-content.py  → (standalone)
+content.py  → types
+types.py    → (standalone)
 ```
 
-No circular imports. `content.py`, `bm25.py`, and `formatting.py` have zero internal dependencies.
+No circular imports. `types.py`, `bm25.py`, and `formatting.py` have zero internal dependencies.
 
 ## Code Style
 

--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -2,6 +2,8 @@
 
 import re
 
+from okp_mcp.types import SolrDoc
+
 
 # Solr content uses a Unicode right single quotation mark (U+2019, a.k.a.
 # "smart apostrophe") in "Red Hat\u2019s", not the ASCII apostrophe (U+0027).
@@ -104,13 +106,13 @@ def strip_boilerplate(text: str) -> str:
     return text
 
 
-def doc_uri(doc: dict) -> str:
+def doc_uri(doc: SolrDoc) -> str:
     """Return the canonical URL path for a Solr document.
 
     Prefers view_uri, falls back to id. Strips trailing /index.html
     because Solr document IDs carry it but access.redhat.com 404s on those paths.
     """
-    uri = doc.get("view_uri") or doc.get("id", "")
+    uri = doc.view_uri or doc.id
     return uri.removesuffix("/index.html")
 
 

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -27,6 +27,8 @@ from okp_mcp.metrics import SEARCH_ZERO_RESULTS
 from okp_mcp.solr import _clean_query
 from okp_mcp.solr import _filter_rhv_sentences
 from okp_mcp.solr import _solr_query
+from okp_mcp.types import SolrDoc
+from okp_mcp.types import SolrResponse
 
 
 @dataclass
@@ -179,24 +181,23 @@ _FALLBACK_MAX_CHARS = 400
 _ACCESS_BASE_URL = "https://access.redhat.com"
 
 
-def _resolve_title(doc: dict) -> str:
+def _resolve_title(doc: SolrDoc) -> str:
     """Pick the best available title for a Solr document.
 
     Prefers ``allTitle`` (populated for most doc types), then ``title``,
     then ``heading_h1`` (list field, takes first element), then falls back
     to the document ID.
     """
-    if doc.get("allTitle"):
-        return doc["allTitle"]
-    if doc.get("title"):
-        return doc["title"]
-    h1 = doc.get("heading_h1")
-    if isinstance(h1, list) and h1:
-        return h1[0]
-    return doc.get("id", "Untitled")
+    if doc.allTitle:
+        return doc.allTitle
+    if doc.title:
+        return doc.title
+    if doc.heading_h1:
+        return doc.heading_h1[0]
+    return doc.id or "Untitled"
 
 
-def _build_doc_url(doc: dict) -> str:
+def _build_doc_url(doc: SolrDoc) -> str:
     """Build a full access.redhat.com URL for a Solr document."""
     uri = doc_uri(doc)
     if not uri:
@@ -207,54 +208,48 @@ def _build_doc_url(doc: dict) -> str:
     return f"{_ACCESS_BASE_URL}{uri}"
 
 
-def _fallback_cve(doc: dict) -> str:
+def _fallback_cve(doc: SolrDoc) -> str:
     """Build fallback chunk text for a CVE without highlight snippets.
 
     Uses ``cve_details`` (the vulnerability description), prefixed with
     severity when available.
     """
     parts: list[str] = []
-    severity = doc.get("cve_threatSeverity")
-    if severity:
-        parts.append(f"Severity: {severity}")
-    details = doc.get("cve_details")
+    if doc.cve_threatSeverity:
+        parts.append(f"Severity: {doc.cve_threatSeverity}")
+    details = doc.cve_details
     if details:
         parts.append(details[:_FALLBACK_MAX_CHARS])
     return "\n".join(parts) if parts else ""
 
 
-def _fallback_errata(doc: dict) -> str:
+def _fallback_errata(doc: SolrDoc) -> str:
     """Build fallback chunk text for an erratum without highlight snippets.
 
     Uses ``portal_synopsis`` + ``portal_summary``, prefixed with advisory
     type and severity when available.
     """
     parts: list[str] = []
-    advisory_type = doc.get("portal_advisory_type")
-    severity = doc.get("portal_severity")
-    if advisory_type or severity:
-        meta = " | ".join(filter(None, [advisory_type, severity]))
+    if doc.portal_advisory_type or doc.portal_severity:
+        meta = " | ".join(filter(None, [doc.portal_advisory_type, doc.portal_severity]))
         parts.append(meta)
-    synopsis = doc.get("portal_synopsis")
-    if synopsis:
-        parts.append(synopsis)
-    summary = doc.get("portal_summary")
-    if summary:
+    if doc.portal_synopsis:
+        parts.append(doc.portal_synopsis)
+    if doc.portal_summary:
         remaining = _FALLBACK_MAX_CHARS - sum(len(p) for p in parts)
         if remaining > 0:
-            parts.append(summary[:remaining])
+            parts.append(doc.portal_summary[:remaining])
     return "\n".join(parts) if parts else ""
 
 
-def _fallback_generic(doc: dict) -> str:
+def _fallback_generic(doc: SolrDoc) -> str:
     """Build fallback chunk text for a doc/solution/article without highlights."""
-    mc = doc.get("main_content", "")
-    if mc:
-        return strip_boilerplate(mc)[:_FALLBACK_MAX_CHARS]
+    if doc.main_content:
+        return strip_boilerplate(doc.main_content)[:_FALLBACK_MAX_CHARS]
     return ""
 
 
-def _make_chunk(doc: dict, suffix: str, chunk_text: str, chunk_index: int) -> PortalChunk:
+def _make_chunk(doc: SolrDoc, suffix: str, chunk_text: str, chunk_index: int) -> PortalChunk:
     """Build a PortalChunk from a Solr doc and a single passage.
 
     Centralizes the shared field extraction (title, URL, kind, score) so the
@@ -272,22 +267,21 @@ def _make_chunk(doc: dict, suffix: str, chunk_text: str, chunk_index: int) -> Po
     Returns:
         A populated PortalChunk.
     """
-    doc_id = doc.get("id", "")
     return PortalChunk(
-        doc_id=f"{doc_id}_{suffix}",
-        parent_id=doc_id,
+        doc_id=f"{doc.id}_{suffix}",
+        parent_id=doc.id,
         title=_resolve_title(doc),
         chunk=chunk_text,
         chunk_index=chunk_index,
         num_tokens=len(chunk_text.split()),
         online_source_url=_build_doc_url(doc),
-        documentKind=doc.get("documentKind", ""),
-        score=doc.get("score"),
+        documentKind=doc.documentKind,
+        score=doc.score,
     )
 
 
 def _docs_to_chunks(
-    solr_response: dict,
+    solr_response: SolrResponse,
     query: str,
 ) -> list[PortalChunk]:
     """Convert a Solr response with highlighting into a flat list of PortalChunk chunks.
@@ -309,13 +303,13 @@ def _docs_to_chunks(
         List of PortalChunk chunks ordered by Solr rank, with multiple
         chunks per source document when highlighting produces multiple snippets.
     """
-    docs = solr_response.get("response", {}).get("docs", [])
-    highlighting = solr_response.get("highlighting", {})
+    docs = solr_response.response.docs
+    highlighting = solr_response.highlighting
     chunks: list[PortalChunk] = []
 
     for doc in docs:
-        doc_id = doc.get("id", "")
-        kind = doc.get("documentKind", "")
+        doc_id = doc.id
+        kind = doc.documentKind
 
         if kind in ("Cve", "Erratum"):
             chunk_text = _fallback_cve(doc) if kind == "Cve" else _fallback_errata(doc)
@@ -323,7 +317,7 @@ def _docs_to_chunks(
                 chunks.append(_make_chunk(doc, "fb_0", chunk_text, 0))
             continue
 
-        hl_snippets = highlighting.get(doc_id, {}).get("main_content", [])
+        hl_snippets = highlighting.get(doc_id, {}).get("main_content", [])  # highlighting is a plain dict
 
         if hl_snippets:
             for i, snippet in enumerate(hl_snippets):

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -10,6 +10,7 @@ from okp_mcp.config import logger
 from okp_mcp.config import STOP_WORDS
 from okp_mcp.metrics import SOLR_QUERIES
 from okp_mcp.metrics import SOLR_QUERY_DURATION
+from okp_mcp.types import SolrResponse
 
 
 def _split_quoted_and_plain(text: str) -> list[str]:
@@ -108,7 +109,7 @@ def _clean_query(query: str) -> str:
     return " ".join(parts) if parts else query
 
 
-async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, solr_endpoint: str) -> dict:
+async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, solr_endpoint: str) -> SolrResponse:
     """Execute a SOLR query and return the parsed JSON response."""
     _start = time.monotonic()
     close_client = client is None
@@ -207,11 +208,13 @@ async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, 
         if close_client:
             await client.aclose()
 
-    _empty_response = {"response": {"numFound": 0, "docs": []}, "highlighting": {}}
+    _empty_response = SolrResponse()
 
-    if "error" in data:
+    parsed = SolrResponse.model_validate(data)
+
+    if parsed.error is not None:
         SOLR_QUERIES.labels(status="error").inc()
-        logger.error("SOLR returned error: %s", data["error"])
+        logger.error("SOLR returned error: %s", parsed.error)
         return _empty_response
     if "response" not in data or not isinstance(data.get("response", {}).get("docs"), list):
         SOLR_QUERIES.labels(status="error").inc()
@@ -219,10 +222,10 @@ async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, 
         return _empty_response
 
     SOLR_QUERIES.labels(status="success").inc()
-    num_found = data["response"]["numFound"]
-    num_docs = len(data["response"]["docs"])
+    num_found = parsed.response.numFound
+    num_docs = len(parsed.response.docs)
     logger.info("SOLR query matched %d total, returning %d docs", num_found, num_docs)
-    return data
+    return parsed
 
 
 _CONTAMINATION_PHRASES = frozenset(
@@ -259,9 +262,9 @@ def _filter_rhv_sentences(text: str, query: str) -> str:
     return " ".join(filtered)
 
 
-def _get_highlight_snippets(data: dict, *keys: str, query: str = "") -> list[str]:
+def _get_highlight_snippets(data: SolrResponse, *keys: str, query: str = "") -> list[str]:
     """Extract cleaned highlight snippets for a document."""
-    hl = data.get("highlighting", {})
+    hl = data.highlighting
     seen: set[str] = set()
     cleaned_snippets: list[str] = []
 

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -26,6 +26,8 @@ from okp_mcp.solr import _extract_relevant_section
 from okp_mcp.solr import _get_highlight_snippets
 from okp_mcp.solr import _solr_query
 from okp_mcp.tools.shared import DOCUMENT_FL
+from okp_mcp.types import SolrDoc
+from okp_mcp.types import SolrResponse
 
 
 logger = logging.getLogger("okp_mcp.tools.get_document")
@@ -71,29 +73,29 @@ def _doc_id_filter(doc_id: str) -> str:
     return f'id:"{safe}" OR view_uri:"{safe}"'
 
 
-def _uses_document_passages(doc: dict) -> bool:
+def _uses_document_passages(doc: SolrDoc) -> bool:
     """Return whether a document should render Solr highlights as passages."""
-    if doc.get("documentKind") == "documentation":
+    if doc.documentKind == "documentation":
         return True
     return doc_uri(doc).startswith("/documentation/")
 
 
-def _format_metadata(doc: dict) -> str:
+def _format_metadata(doc: SolrDoc) -> str:
     """Build the metadata header for a fetched document."""
-    result = f"**{doc.get('allTitle', 'Untitled')}**"
-    result += f"\nType: {doc.get('documentKind', 'Unknown')}"
-    if doc.get("product"):
-        result += f"\nProduct: {doc['product']}"
-    if doc.get("documentation_version"):
-        result += f" {doc['documentation_version']}"
+    result = f"**{doc.allTitle or 'Untitled'}**"
+    result += f"\nType: {doc.documentKind or 'Unknown'}"
+    if doc.product:
+        result += f"\nProduct: {doc.product}"
+    if doc.documentation_version:
+        result += f" {doc.documentation_version}"
     result += f"\nURL: https://access.redhat.com{doc_uri(doc)}"
 
-    if doc.get("portal_synopsis"):
-        result += f"\n\nSynopsis: {doc['portal_synopsis']}"
-    if doc.get("portal_summary"):
-        result += f"\n\nSummary: {doc['portal_summary']}"
-    if doc.get("cve_details"):
-        result += f"\n\nCVE Details: {doc['cve_details']}"
+    if doc.portal_synopsis:
+        result += f"\n\nSynopsis: {doc.portal_synopsis}"
+    if doc.portal_summary:
+        result += f"\n\nSummary: {doc.portal_summary}"
+    if doc.cve_details:
+        result += f"\n\nCVE Details: {doc.cve_details}"
     return result
 
 
@@ -109,7 +111,7 @@ def _format_document_passages(highlight_snippets: list[str], query: str, max_cha
 
 
 def _format_document_content(
-    doc: dict, data: dict, doc_id: str, query: str, max_chars: int, current_result: str
+    doc: SolrDoc, data: SolrResponse, doc_id: str, query: str, max_chars: int, current_result: str
 ) -> str:
     """Build the content section for a fetched document.
 
@@ -144,7 +146,7 @@ def _format_document_content(
             "Pass a query to get_document to extract the most relevant passages."
         )
 
-    main_content = doc.get("main_content")
+    main_content = doc.main_content
     if not main_content:
         return ""
 
@@ -152,7 +154,7 @@ def _format_document_content(
     if not query:
         return f"\n\nContent:\n{_extract_relevant_section(content, '', max_sections=8)}"
 
-    highlight_snippets = _get_highlight_snippets(data, doc.get("view_uri", ""), doc.get("id", ""), doc_id, query=query)
+    highlight_snippets = _get_highlight_snippets(data, doc.view_uri, doc.id, doc_id, query=query)
 
     if is_documentation:
         if highlight_snippets:
@@ -178,7 +180,7 @@ async def _fetch_document_with_query(
     client: httpx.AsyncClient | None = None,
     *,
     solr_endpoint: str,
-) -> dict:
+) -> SolrResponse:
     """Fetch a document by ID using edismax query mode with highlighting.
 
     Uses _solr_query so edismax and highlight parameters are applied.
@@ -198,7 +200,9 @@ async def _fetch_document_with_query(
     )
 
 
-async def _fetch_document_raw(doc_id: str, client: httpx.AsyncClient | None = None, *, solr_endpoint: str) -> dict:
+async def _fetch_document_raw(
+    doc_id: str, client: httpx.AsyncClient | None = None, *, solr_endpoint: str
+) -> SolrResponse:
     """Fetch a document by ID using a plain HTTP request, bypassing edismax defaults.
 
     Uses httpx directly rather than _solr_query to avoid injecting edismax
@@ -219,13 +223,13 @@ async def _fetch_document_raw(doc_id: str, client: httpx.AsyncClient | None = No
             },
         )
         response.raise_for_status()
-        return response.json()
+        return SolrResponse.model_validate(response.json())
     finally:
         if close_client:
             await client.aclose()
 
 
-async def _format_document(doc: dict, data: dict, doc_id: str, query: str, max_chars: int) -> str:
+async def _format_document(doc: SolrDoc, data: SolrResponse, doc_id: str, query: str, max_chars: int) -> str:
     """Format a fetched document into a readable string.
 
     Renders title, type, product/version, URL, synopsis/summary/CVE details,
@@ -258,7 +262,7 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
         else:
             data = await _fetch_document_raw(doc_id, client=app.http_client, solr_endpoint=app.solr_endpoint)
 
-        docs = data["response"]["docs"]
+        docs = data.response.docs
         if not docs:
             DOCUMENT_NOT_FOUND.inc()
             return f"Document not found: {doc_id}"

--- a/src/okp_mcp/types.py
+++ b/src/okp_mcp/types.py
@@ -1,0 +1,46 @@
+"""Shared type definitions for Solr documents and responses."""
+
+from pydantic import BaseModel
+from pydantic import Field
+
+
+class SolrDoc(BaseModel):
+    """A Solr document (all fields optional per query fl)."""
+
+    id: str = ""
+    allTitle: str = ""
+    title: str = ""
+    heading_h1: list[str] = Field(default_factory=list)
+    view_uri: str = ""
+    url_slug: str = ""
+    documentKind: str = ""
+    product: str = ""
+    documentation_version: str = ""
+    lastModifiedDate: str = ""
+    score: float | None = None
+    main_content: str = ""
+    cve_details: str = ""
+    cve_threatSeverity: str = ""
+    portal_synopsis: str = ""
+    portal_summary: str = ""
+    portal_severity: str = ""
+    portal_advisory_type: str = ""
+
+    model_config = {"extra": "ignore"}
+
+
+class SolrResponseBody(BaseModel):
+    """The nested ``response`` object inside a Solr JSON response."""
+
+    numFound: int = 0
+    docs: list[SolrDoc] = Field(default_factory=list)
+
+
+class SolrResponse(BaseModel):
+    """Top-level Solr JSON response structure."""
+
+    response: SolrResponseBody = Field(default_factory=SolrResponseBody)
+    highlighting: dict[str, dict[str, list[str]]] = Field(default_factory=dict)
+    error: dict | None = None
+
+    model_config = {"extra": "ignore"}

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -7,6 +7,7 @@ from okp_mcp.content import clean_content
 from okp_mcp.content import doc_uri
 from okp_mcp.content import strip_boilerplate
 from okp_mcp.content import truncate_content
+from okp_mcp.types import SolrDoc
 
 
 @pytest.mark.parametrize(
@@ -75,17 +76,17 @@ def test_clean_content_edge_cases(text, max_chars, expected):
 @pytest.mark.parametrize(
     "doc,expected",
     [
-        ({"id": "/solutions/3257611/index.html"}, "/solutions/3257611"),
-        ({"id": "/articles/2585/index.html"}, "/articles/2585"),
+        (SolrDoc(id="/solutions/3257611/index.html"), "/solutions/3257611"),
+        (SolrDoc(id="/articles/2585/index.html"), "/articles/2585"),
         (
-            {"id": "/documentation/en-us/rhel/9/html-single/guide/index.html"},
+            SolrDoc(id="/documentation/en-us/rhel/9/html-single/guide/index.html"),
             "/documentation/en-us/rhel/9/html-single/guide",
         ),
-        ({"view_uri": "/security/cve/CVE-2024-9823/"}, "/security/cve/CVE-2024-9823/"),
-        ({"view_uri": "/errata/RHSA-2022:4915/"}, "/errata/RHSA-2022:4915/"),
-        ({}, ""),
-        ({"id": "/solutions/123"}, "/solutions/123"),
-        ({"view_uri": "/solutions/7134031", "id": "/solutions/7134031/index.html"}, "/solutions/7134031"),
+        (SolrDoc(view_uri="/security/cve/CVE-2024-9823/"), "/security/cve/CVE-2024-9823/"),
+        (SolrDoc(view_uri="/errata/RHSA-2022:4915/"), "/errata/RHSA-2022:4915/"),
+        (SolrDoc(), ""),
+        (SolrDoc(id="/solutions/123"), "/solutions/123"),
+        (SolrDoc(view_uri="/solutions/7134031", id="/solutions/7134031/index.html"), "/solutions/7134031"),
     ],
     ids=[
         "solution-id-strips-suffix",

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -18,6 +18,9 @@ from okp_mcp.tools.document import _format_document_content
 from okp_mcp.tools.document import _format_document_passages
 from okp_mcp.tools.document import _format_metadata
 from okp_mcp.tools.document import _uses_document_passages
+from okp_mcp.types import SolrDoc
+from okp_mcp.types import SolrResponse
+from okp_mcp.types import SolrResponseBody
 
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
@@ -28,23 +31,26 @@ def _make_doc(
     kind: str = "documentation",
     content: str = "Some content about RHEL",
     view_uri: str = "/documentation/en-US/test",
-) -> dict:
-    """Build a minimal Solr doc dict for testing."""
-    return {
-        "allTitle": "Test Doc",
-        "documentKind": kind,
-        "view_uri": view_uri,
-        "id": view_uri,
-        "main_content": content,
-    }
+) -> SolrDoc:
+    """Build a minimal Solr doc for testing."""
+    return SolrDoc(
+        allTitle="Test Doc",
+        documentKind=kind,
+        view_uri=view_uri,
+        id=view_uri,
+        main_content=content,
+    )
 
 
-def _make_data(*, highlight_key: str = "", snippets: list[str] | None = None) -> dict:
-    """Build a minimal Solr response dict with optional highlighting."""
+def _make_data(*, highlight_key: str = "", snippets: list[str] | None = None) -> SolrResponse:
+    """Build a minimal Solr response with optional highlighting."""
     highlighting: dict = {}
     if highlight_key and snippets:
         highlighting[highlight_key] = {"main_content": snippets}
-    return {"response": {"docs": []}, "highlighting": highlighting}
+    return SolrResponse(
+        response=SolrResponseBody(numFound=0, docs=[]),
+        highlighting=highlighting,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -55,10 +61,10 @@ def _make_data(*, highlight_key: str = "", snippets: list[str] | None = None) ->
 @pytest.mark.parametrize(
     "doc,expected",
     [
-        ({"documentKind": "documentation"}, True),
-        ({"documentKind": "solution", "view_uri": "/solutions/12345"}, False),
-        ({"documentKind": "solution", "view_uri": "/documentation/en-US/rhel/9"}, True),
-        ({"documentKind": "errata", "view_uri": "/errata/RHSA-2024:1234", "id": "/errata/RHSA-2024:1234"}, False),
+        (SolrDoc(documentKind="documentation"), True),
+        (SolrDoc(documentKind="solution", view_uri="/solutions/12345"), False),
+        (SolrDoc(documentKind="solution", view_uri="/documentation/en-US/rhel/9"), True),
+        (SolrDoc(documentKind="errata", view_uri="/errata/RHSA-2024:1234", id="/errata/RHSA-2024:1234"), False),
     ],
     ids=["kind-documentation", "kind-solution", "uri-documentation", "kind-errata"],
 )
@@ -75,7 +81,7 @@ def test_uses_document_passages(doc, expected):
 def test_format_metadata_basic():
     """Metadata includes title, type, product, and URL."""
     doc = _make_doc(kind="documentation")
-    doc["product"] = "Red Hat Enterprise Linux"
+    doc.product = "Red Hat Enterprise Linux"
     result = _format_metadata(doc)
     assert "**Test Doc**" in result
     assert "Type: documentation" in result
@@ -86,7 +92,7 @@ def test_format_metadata_basic():
 def test_format_metadata_with_synopsis():
     """Synopsis is included when present."""
     doc = _make_doc()
-    doc["portal_synopsis"] = "A brief synopsis."
+    doc.portal_synopsis = "A brief synopsis."
     result = _format_metadata(doc)
     assert "Synopsis: A brief synopsis." in result
 
@@ -100,7 +106,7 @@ def test_documentation_no_query_returns_nudge():
     """Documentation without a query returns a nudge instead of content."""
     doc = _make_doc(kind="documentation", content="x" * 100_000)
     data = _make_data()
-    result = _format_document_content(doc, data, doc["view_uri"], query="", max_chars=30_000, current_result="")
+    result = _format_document_content(doc, data, doc.view_uri, query="", max_chars=30_000, current_result="")
     assert "Pass a query" in result
     assert "large documentation page" in result
     # Must NOT contain the actual content
@@ -111,7 +117,7 @@ def test_documentation_no_query_nudge_via_uri():
     """URI-based documentation detection also triggers the nudge."""
     doc = _make_doc(kind="other", view_uri="/documentation/en-US/rhel/9/guide")
     data = _make_data()
-    result = _format_document_content(doc, data, doc["view_uri"], query="", max_chars=30_000, current_result="")
+    result = _format_document_content(doc, data, doc.view_uri, query="", max_chars=30_000, current_result="")
     assert "Pass a query" in result
 
 
@@ -164,7 +170,7 @@ def test_documentation_query_no_highlights_uses_reduced_extraction():
     data = _make_data()  # no highlights
 
     result = _format_document_content(
-        doc, data, doc["view_uri"], query="kernel configuration", max_chars=30_000, current_result=""
+        doc, data, doc.view_uri, query="kernel configuration", max_chars=30_000, current_result=""
     )
 
     assert "\n\nContent:\n" in result
@@ -184,7 +190,7 @@ def test_non_documentation_no_query_extracts_content():
     doc = _make_doc(kind="solution", view_uri="/solutions/12345", content="Solution body text here.")
     data = _make_data()
 
-    result = _format_document_content(doc, data, doc["view_uri"], query="", max_chars=30_000, current_result="")
+    result = _format_document_content(doc, data, doc.view_uri, query="", max_chars=30_000, current_result="")
 
     assert "\n\nContent:\n" in result
     assert "Pass a query" not in result
@@ -214,7 +220,7 @@ def test_non_documentation_query_no_highlights_uses_full_extraction():
     data = _make_data()  # no highlights
 
     result = _format_document_content(
-        doc, data, doc["view_uri"], query="network configuration", max_chars=30_000, current_result=""
+        doc, data, doc.view_uri, query="network configuration", max_chars=30_000, current_result=""
     )
 
     assert "\n\nContent:\n" in result
@@ -233,30 +239,30 @@ def test_non_documentation_query_no_highlights_uses_full_extraction():
 def test_no_main_content_returns_empty():
     """Missing main_content returns empty string for non-documentation."""
     doc = _make_doc(kind="solution", view_uri="/solutions/12345")
-    doc["main_content"] = None
+    doc.main_content = ""
     data = _make_data()
 
-    result = _format_document_content(doc, data, doc["view_uri"], query="test", max_chars=30_000, current_result="")
+    result = _format_document_content(doc, data, doc.view_uri, query="test", max_chars=30_000, current_result="")
     assert result == ""
 
 
 def test_documentation_no_main_content_still_nudges_without_query():
     """Documentation nudge fires even when main_content is missing (check order matters)."""
     doc = _make_doc(kind="documentation")
-    doc["main_content"] = None
+    doc.main_content = ""
     data = _make_data()
 
-    result = _format_document_content(doc, data, doc["view_uri"], query="", max_chars=30_000, current_result="")
+    result = _format_document_content(doc, data, doc.view_uri, query="", max_chars=30_000, current_result="")
     assert "Pass a query" in result
 
 
 def test_documentation_no_main_content_with_query_returns_empty():
     """Documentation with a query but no main_content returns empty (no content to extract)."""
     doc = _make_doc(kind="documentation")
-    doc["main_content"] = None
+    doc.main_content = ""
     data = _make_data()
 
-    result = _format_document_content(doc, data, doc["view_uri"], query="kernel", max_chars=30_000, current_result="")
+    result = _format_document_content(doc, data, doc.view_uri, query="kernel", max_chars=30_000, current_result="")
     assert result == ""
 
 
@@ -312,7 +318,7 @@ class TestDocumentRetrievalMetrics:
         data = _make_data()
         before = _get_counter("okp_document_nudge")
 
-        _format_document_content(doc, data, doc["view_uri"], query=query, max_chars=30_000, current_result="")
+        _format_document_content(doc, data, doc.view_uri, query=query, max_chars=30_000, current_result="")
 
         assert _get_counter("okp_document_nudge") == before + expected_delta
 
@@ -378,7 +384,7 @@ class TestDocumentRetrievalMetrics:
         before_used = _get_counter("okp_document_highlight_used")
         before_fallback = _get_counter("okp_document_highlight_fallback")
 
-        _format_document_content(doc, data, doc["view_uri"], query="", max_chars=30_000, current_result="")
+        _format_document_content(doc, data, doc.view_uri, query="", max_chars=30_000, current_result="")
 
         assert _get_counter("okp_document_highlight_used") == before_used
         assert _get_counter("okp_document_highlight_fallback") == before_fallback
@@ -386,12 +392,12 @@ class TestDocumentRetrievalMetrics:
     def test_no_highlight_metrics_without_main_content(self):
         """Missing main_content fires neither highlight counter."""
         doc = _make_doc(kind="documentation", content="x")
-        doc["main_content"] = None
+        doc.main_content = ""
         data = _make_data()
         before_used = _get_counter("okp_document_highlight_used")
         before_fallback = _get_counter("okp_document_highlight_fallback")
 
-        _format_document_content(doc, data, doc["view_uri"], query="kernel", max_chars=30_000, current_result="")
+        _format_document_content(doc, data, doc.view_uri, query="kernel", max_chars=30_000, current_result="")
 
         assert _get_counter("okp_document_highlight_used") == before_used
         assert _get_counter("okp_document_highlight_fallback") == before_fallback
@@ -416,7 +422,7 @@ async def test_not_found_counter_incremented():
         patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),
         patch("okp_mcp.tools.document._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
     ):
-        mock_fetch.return_value = {"response": {"docs": []}}
+        mock_fetch.return_value = SolrResponse()
         result = await tools.get_document(mock_ctx, "/solutions/nonexistent")
 
     assert _get_counter("okp_document_not_found") == before + 1
@@ -437,20 +443,20 @@ async def test_not_found_counter_not_incremented_when_doc_exists():
         patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),
         patch("okp_mcp.tools.document._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
     ):
-        mock_fetch.return_value = {
-            "response": {
-                "docs": [
-                    {
-                        "allTitle": "Test Solution",
-                        "documentKind": "solution",
-                        "view_uri": "/solutions/12345",
-                        "id": "/solutions/12345",
-                        "main_content": "Solution content here.",
-                    }
-                ]
-            },
-            "highlighting": {},
-        }
+        mock_fetch.return_value = SolrResponse(
+            response=SolrResponseBody(
+                numFound=1,
+                docs=[
+                    SolrDoc(
+                        allTitle="Test Solution",
+                        documentKind="solution",
+                        view_uri="/solutions/12345",
+                        id="/solutions/12345",
+                        main_content="Solution content here.",
+                    )
+                ],
+            ),
+        )
         await tools.get_document(mock_ctx, "/solutions/12345")
 
     assert _get_counter("okp_document_not_found") == before

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -329,7 +329,7 @@ async def test_solr_query_records_error_metrics_on_solr_error_response():
         result = await _solr_query({"q": "bad"}, solr_endpoint=_SOLR_ENDPOINT)
 
     assert _get_counter("okp_solr_queries", {"status": "error"}) == before + 1
-    assert result["response"]["numFound"] == 0
+    assert result.response.numFound == 0
 
 
 async def test_solr_query_always_records_duration():

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -31,6 +31,9 @@ from okp_mcp.portal import _resolve_title
 from okp_mcp.portal import _run_multi_query_search
 from okp_mcp.portal import _run_portal_search
 from okp_mcp.portal import PortalChunk
+from okp_mcp.types import SolrDoc
+from okp_mcp.types import SolrResponse
+from okp_mcp.types import SolrResponseBody
 
 
 # ---------------------------------------------------------------------------
@@ -583,16 +586,16 @@ class TestIntentBoostLogging:
 
 
 def _make_solr_response(docs, highlighting=None):
-    """Build a minimal Solr response dict for testing."""
-    return {
-        "response": {"numFound": len(docs), "docs": docs},
-        "highlighting": highlighting or {},
-    }
+    """Build a minimal Solr response for testing."""
+    return SolrResponse(
+        response=SolrResponseBody(numFound=len(docs), docs=docs),
+        highlighting=highlighting or {},
+    )
 
 
 def _make_doc(doc_id="doc1", kind="documentation", **overrides):
-    """Build a minimal Solr document dict."""
-    base = {
+    """Build a minimal Solr document."""
+    defaults = {
         "id": doc_id,
         "allTitle": f"Title for {doc_id}",
         "view_uri": f"/documentation/en-US/{doc_id}",
@@ -600,8 +603,8 @@ def _make_doc(doc_id="doc1", kind="documentation", **overrides):
         "product": "Red Hat Enterprise Linux",
         "score": 10.0,
     }
-    base.update(overrides)
-    return base
+    defaults.update(overrides)
+    return SolrDoc(**defaults)
 
 
 # ---------------------------------------------------------------------------
@@ -614,23 +617,23 @@ class TestResolveTitle:
 
     def test_prefers_all_title(self):
         """allTitle is used when available."""
-        assert _resolve_title({"allTitle": "Best Title", "title": "Alt"}) == "Best Title"
+        assert _resolve_title(SolrDoc(allTitle="Best Title", title="Alt")) == "Best Title"
 
     def test_falls_back_to_title(self):
         """title is used when allTitle is missing."""
-        assert _resolve_title({"title": "Fallback Title"}) == "Fallback Title"
+        assert _resolve_title(SolrDoc(title="Fallback Title")) == "Fallback Title"
 
     def test_falls_back_to_heading_h1(self):
         """First heading_h1 entry is used when allTitle and title are missing."""
-        assert _resolve_title({"heading_h1": ["H1 Title", "Other"]}) == "H1 Title"
+        assert _resolve_title(SolrDoc(heading_h1=["H1 Title", "Other"])) == "H1 Title"
 
     def test_falls_back_to_id(self):
         """Document id is used as last resort."""
-        assert _resolve_title({"id": "doc-123"}) == "doc-123"
+        assert _resolve_title(SolrDoc(id="doc-123")) == "doc-123"
 
     def test_empty_doc_returns_untitled(self):
         """Empty dict returns 'Untitled'."""
-        assert _resolve_title({}) == "Untitled"
+        assert _resolve_title(SolrDoc()) == "Untitled"
 
 
 # ---------------------------------------------------------------------------
@@ -644,7 +647,7 @@ class TestDocsToChunksHighlights:
     def test_each_snippet_becomes_a_chunk(self):
         """Each highlight snippet produces a separate PortalChunk."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["Snippet one.", "Snippet two.", "Snippet three."]}}
+        hl = {doc.id: {"main_content": ["Snippet one.", "Snippet two.", "Snippet three."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test query")
         assert len(chunks) == 3
         assert chunks[0].chunk == "Snippet one."
@@ -654,7 +657,7 @@ class TestDocsToChunksHighlights:
     def test_chunk_ids_are_unique(self):
         """Each chunk gets a unique doc_id based on parent + snippet index."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["A.", "B."]}}
+        hl = {doc.id: {"main_content": ["A.", "B."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert chunks[0].doc_id == "doc1_hl_0"
         assert chunks[1].doc_id == "doc1_hl_1"
@@ -662,42 +665,42 @@ class TestDocsToChunksHighlights:
     def test_parent_id_links_to_source(self):
         """All chunks from the same doc share the parent_id."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["A.", "B."]}}
+        hl = {doc.id: {"main_content": ["A.", "B."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert all(c.parent_id == "doc1" for c in chunks)
 
     def test_strips_html_tags(self):
         """HTML markup from Solr highlighting is removed."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["Use <em>cockpit</em> for <b>VM</b> management."]}}
+        hl = {doc.id: {"main_content": ["Use <em>cockpit</em> for <b>VM</b> management."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert chunks[0].chunk == "Use cockpit for VM management."
 
     def test_num_tokens_counted(self):
         """num_tokens reflects whitespace-split word count of cleaned text."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["one two three four"]}}
+        hl = {doc.id: {"main_content": ["one two three four"]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert chunks[0].num_tokens == 4
 
     def test_url_constructed_from_view_uri(self):
         """online_source_url uses doc_uri() to build the access.redhat.com URL."""
         doc = _make_doc(view_uri="/documentation/en-US/some/page")
-        hl = {doc["id"]: {"main_content": ["Content."]}}
+        hl = {doc.id: {"main_content": ["Content."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert chunks[0].online_source_url == "https://access.redhat.com/documentation/en-US/some/page"
 
     def test_document_kind_preserved(self):
         """documentKind from the Solr doc is carried to each chunk."""
         doc = _make_doc(kind="solution")
-        hl = {doc["id"]: {"main_content": ["Fix the issue."]}}
+        hl = {doc.id: {"main_content": ["Fix the issue."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert chunks[0].documentKind == "solution"
 
     def test_score_preserved(self):
         """Solr relevance score is carried to each chunk."""
         doc = _make_doc(score=42.5)
-        hl = {doc["id"]: {"main_content": ["Content."]}}
+        hl = {doc.id: {"main_content": ["Content."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert chunks[0].score == 42.5
 
@@ -706,7 +709,7 @@ class TestDocsToChunksHighlights:
         doc = _make_doc()
         # "fully supported" + "rhv" triggers RHV contamination filter
         hl = {
-            doc["id"]: {
+            doc.id: {
                 "main_content": ["SPICE is still fully supported in RHV deployments. Use cockpit for management."]
             }
         }
@@ -718,14 +721,14 @@ class TestDocsToChunksHighlights:
     def test_rhv_filtering_skipped_for_rhv_query(self):
         """RHV filtering is disabled when the query itself mentions RHV."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["SPICE is still fully supported in RHV deployments."]}}
+        hl = {doc.id: {"main_content": ["SPICE is still fully supported in RHV deployments."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "rhv spice support")
         assert "RHV" in chunks[0].chunk
 
     def test_empty_snippet_after_stripping_is_skipped(self):
         """Snippets that become empty after HTML stripping are excluded."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["<em></em>", "Real content here."]}}
+        hl = {doc.id: {"main_content": ["<em></em>", "Real content here."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "test")
         assert len(chunks) == 1
         assert chunks[0].chunk == "Real content here."
@@ -821,7 +824,7 @@ class TestDocsToChunksEdgeCases:
     def test_missing_highlighting_key(self):
         """Response without highlighting key uses fallback for all docs."""
         doc = _make_doc(main_content="Some content here.")
-        response = {"response": {"numFound": 1, "docs": [doc]}}
+        response = _make_solr_response([doc])
         chunks = _docs_to_chunks(response, "test")
         assert len(chunks) == 1
         assert chunks[0].doc_id.endswith("_fb_0")
@@ -842,7 +845,7 @@ class TestDocsToChunksEdgeCases:
     def test_empty_query_skips_rhv_filter(self):
         """Empty query string skips RHV filtering entirely."""
         doc = _make_doc()
-        hl = {doc["id"]: {"main_content": ["SPICE is fully supported in RHV deployments."]}}
+        hl = {doc.id: {"main_content": ["SPICE is fully supported in RHV deployments."]}}
         chunks = _docs_to_chunks(_make_solr_response([doc], hl), "")
         # No RHV filtering with empty query
         assert "RHV" in chunks[0].chunk
@@ -858,19 +861,19 @@ class TestFallbackCve:
 
     def test_severity_and_details(self):
         """Both severity and details are included."""
-        text = _fallback_cve({"cve_threatSeverity": "Critical", "cve_details": "RCE via buffer overflow."})
+        text = _fallback_cve(SolrDoc(cve_threatSeverity="Critical", cve_details="RCE via buffer overflow."))
         assert "Critical" in text
         assert "RCE via buffer overflow" in text
 
     def test_details_truncated_at_budget(self):
         """Long cve_details are truncated to _FALLBACK_MAX_CHARS."""
         long_details = "x" * 1000
-        text = _fallback_cve({"cve_details": long_details})
+        text = _fallback_cve(SolrDoc(cve_details=long_details))
         assert len(text) <= _FALLBACK_MAX_CHARS
 
     def test_empty_fields_returns_empty(self):
         """CVE with no severity or details returns empty string."""
-        assert _fallback_cve({}) == ""
+        assert _fallback_cve(SolrDoc()) == ""
 
 
 class TestFallbackErrata:
@@ -879,12 +882,12 @@ class TestFallbackErrata:
     def test_full_metadata(self):
         """Advisory type, severity, synopsis, and summary all appear."""
         text = _fallback_errata(
-            {
-                "portal_advisory_type": "Security Advisory",
-                "portal_severity": "Important",
-                "portal_synopsis": "kernel security update",
-                "portal_summary": "Fixes multiple CVEs.",
-            }
+            SolrDoc(
+                portal_advisory_type="Security Advisory",
+                portal_severity="Important",
+                portal_synopsis="kernel security update",
+                portal_summary="Fixes multiple CVEs.",
+            )
         )
         assert "Security Advisory" in text
         assert "Important" in text
@@ -893,12 +896,12 @@ class TestFallbackErrata:
 
     def test_synopsis_only(self):
         """Works with just portal_synopsis."""
-        text = _fallback_errata({"portal_synopsis": "Bug fix update"})
+        text = _fallback_errata(SolrDoc(portal_synopsis="Bug fix update"))
         assert "Bug fix update" in text
 
     def test_empty_returns_empty(self):
         """No errata fields returns empty string."""
-        assert _fallback_errata({}) == ""
+        assert _fallback_errata(SolrDoc()) == ""
 
 
 # ---------------------------------------------------------------------------
@@ -1181,7 +1184,7 @@ def _make_solr_json(docs, highlighting=None):
     """Build a Solr JSON response for respx mocking."""
     return {
         "responseHeader": {"status": 0, "QTime": 5},
-        "response": {"numFound": len(docs), "docs": docs},
+        "response": {"numFound": len(docs), "docs": [d.model_dump() if hasattr(d, "model_dump") else d for d in docs]},
         "highlighting": highlighting or {},
     }
 

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -14,6 +14,7 @@ from okp_mcp.config import ServerConfig
 from okp_mcp.solr import _clean_query
 from okp_mcp.solr import _get_highlight_snippets
 from okp_mcp.solr import _solr_query
+from okp_mcp.types import SolrResponse
 
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
@@ -33,7 +34,8 @@ async def test_solr_query_uses_provided_shared_client(sample_solr_response):
             await shared_client.aclose()
 
     assert route.called
-    assert data == sample_solr_response
+    assert isinstance(data, SolrResponse)
+    assert data.response.numFound == sample_solr_response["response"]["numFound"]
 
 
 async def test_solr_query_does_not_close_shared_client():
@@ -75,7 +77,8 @@ async def test_solr_query_creates_and_closes_client_when_not_provided(sample_sol
     client_ctor.assert_called_once_with(timeout=30.0)
     assert route.called
     assert closed
-    assert data == sample_solr_response
+    assert isinstance(data, SolrResponse)
+    assert data.response.numFound == sample_solr_response["response"]["numFound"]
 
 
 @pytest.mark.parametrize("use_shared_client", [True, False])
@@ -133,7 +136,7 @@ async def test_solr_query_respx_regression_guard(solr_mock, sample_solr_response
     data = await _solr_query({"q": "selinux"}, solr_endpoint=_SOLR_ENDPOINT)
 
     assert solr_mock.called
-    assert data["response"]["numFound"] == sample_solr_response["response"]["numFound"]
+    assert data.response.numFound == sample_solr_response["response"]["numFound"]
 
 
 @pytest.mark.parametrize(
@@ -174,8 +177,8 @@ def test_clean_query(input_query, expected):
 
 def test_get_highlight_snippets_preserves_individual_fragments():
     """_get_highlight_snippets returns cleaned highlight fragments without flattening them."""
-    data = {
-        "highlighting": {
+    data = SolrResponse(
+        highlighting={
             "doc-1": {
                 "main_content": [
                     "First <em>kernel</em> snippet.",
@@ -183,7 +186,7 @@ def test_get_highlight_snippets_preserves_individual_fragments():
                 ]
             }
         }
-    }
+    )
 
     snippets = _get_highlight_snippets(data, "doc-1", query="kernel panic")
 
@@ -192,12 +195,12 @@ def test_get_highlight_snippets_preserves_individual_fragments():
 
 def test_get_highlight_snippets_deduplicates_across_alias_keys():
     """_get_highlight_snippets deduplicates repeated fragments returned under multiple keys."""
-    data = {
-        "highlighting": {
+    data = SolrResponse(
+        highlighting={
             "doc-1": {"main_content": ["Repeated <em>snippet</em>."]},
             "/docs/doc-1": {"main_content": ["Repeated <em>snippet</em>.", "Unique snippet."]},
         }
-    }
+    )
 
     snippets = _get_highlight_snippets(data, "doc-1", "/docs/doc-1", query="snippet")
 

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -23,6 +23,9 @@ from okp_mcp.tools.document import _fetch_document_raw
 from okp_mcp.tools.document import _fetch_document_with_query
 from okp_mcp.tools.document import _format_document
 from okp_mcp.tools.document import _normalize_doc_id
+from okp_mcp.types import SolrDoc
+from okp_mcp.types import SolrResponse
+from okp_mcp.types import SolrResponseBody
 
 
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
@@ -58,7 +61,7 @@ async def test_fetch_document_raw_uses_provided_client_without_constructing_or_c
 
     mock_client.get.assert_awaited_once()
     mock_client.aclose.assert_not_awaited()
-    assert data["response"]["numFound"] == 1
+    assert data.response.numFound == 1
 
 
 async def test_fetch_document_raw_creates_and_closes_client_when_not_provided():
@@ -77,13 +80,15 @@ async def test_fetch_document_raw_creates_and_closes_client_when_not_provided():
     client_ctor.assert_called_once_with(timeout=30.0)
     created_client.get.assert_awaited_once()
     created_client.aclose.assert_awaited_once()
-    assert data["response"]["numFound"] == 1
+    assert data.response.numFound == 1
 
 
 async def test_fetch_document_with_query_passes_client_to_solr_query():
     """_fetch_document_with_query forwards explicit client through to _solr_query."""
     mock_client = AsyncMock(spec=httpx.AsyncClient)
-    expected = {"response": {"numFound": 1, "docs": [{"id": "123"}]}}
+    expected = SolrResponse(
+        response=SolrResponseBody(numFound=1, docs=[SolrDoc(id="123")]),
+    )
 
     with patch("okp_mcp.tools.document._solr_query", AsyncMock(return_value=expected)) as solr_query_mock:
         data = await _fetch_document_with_query(
@@ -123,13 +128,13 @@ async def test_format_document_budget_truncates_large_content():
     """_format_document truncates output to max_chars when content exceeds budget."""
     paragraph = "kernel panic error trace dump occurs during boot sequence\n\n"
     huge_content = paragraph * 2000
-    doc = {
-        "allTitle": "Test Doc",
-        "documentKind": "documentation",
-        "main_content": huge_content,
-        "view_uri": "/test-doc",
-    }
-    data = {"highlighting": {}}
+    doc = SolrDoc(
+        allTitle="Test Doc",
+        documentKind="documentation",
+        main_content=huge_content,
+        view_uri="/test-doc",
+    )
+    data = SolrResponse()
     result = await _format_document(doc, data, "/test-doc", "kernel panic", max_chars=200)
     assert len(result) <= 400  # slack for truncation message
     assert "Content truncated" in result
@@ -137,25 +142,25 @@ async def test_format_document_budget_truncates_large_content():
 
 async def test_format_document_uses_chunked_highlight_passages_for_documentation():
     """_format_document keeps highlight snippets as separate passages for large docs."""
-    doc = {
-        "id": "/documentation/en-us/rhel/9/html/configuring_networking/index.html",
-        "allTitle": "Configuring networking",
-        "documentKind": "documentation",
-        "view_uri": "/documentation/en-us/rhel/9/html/configuring_networking/index",
-        "main_content": "Long body text that should not be used when highlights are available.",
-    }
-    data = {
-        "highlighting": {
-            doc["id"]: {
+    doc = SolrDoc(
+        id="/documentation/en-us/rhel/9/html/configuring_networking/index.html",
+        allTitle="Configuring networking",
+        documentKind="documentation",
+        view_uri="/documentation/en-us/rhel/9/html/configuring_networking/index",
+        main_content="Long body text that should not be used when highlights are available.",
+    )
+    data = SolrResponse(
+        highlighting= {
+            doc.id: {
                 "main_content": [
                     "First <em>network</em> configuration snippet.",
                     "Second snippet about <em>routing</em>.",
                 ]
             }
         }
-    }
+    )
 
-    result = await _format_document(doc, data, doc["view_uri"], "network routing", max_chars=5000)
+    result = await _format_document(doc, data, doc.view_uri, "network routing", max_chars=5000)
 
     assert "Relevant passages:" in result
     assert "Passage 1:" in result
@@ -166,19 +171,19 @@ async def test_format_document_uses_chunked_highlight_passages_for_documentation
 
 async def test_format_document_falls_back_to_relevant_section_when_no_highlights():
     """_format_document falls back to extracted sections when highlighting is unavailable."""
-    doc = {
-        "id": "/documentation/en-us/rhel/9/html/using_systemd/index.html",
-        "allTitle": "Using systemd",
-        "documentKind": "documentation",
-        "view_uri": "/documentation/en-us/rhel/9/html/using_systemd/index",
-        "main_content": (
+    doc = SolrDoc(
+        id="/documentation/en-us/rhel/9/html/using_systemd/index.html",
+        allTitle="Using systemd",
+        documentKind="documentation",
+        view_uri="/documentation/en-us/rhel/9/html/using_systemd/index",
+        main_content=(
             "intro\n\n"
             "systemd units manage services and targets across the operating system.\n\n"
             "debugging boot delays with systemd-analyze can identify slow units."
         ),
-    }
+    )
 
-    result = await _format_document(doc, {"highlighting": {}}, doc["view_uri"], "systemd analyze units", max_chars=5000)
+    result = await _format_document(doc, SolrResponse(), doc.view_uri, "systemd analyze units", max_chars=5000)
 
     assert "Relevant passages:" not in result
     assert "Content:" in result
@@ -187,25 +192,25 @@ async def test_format_document_falls_back_to_relevant_section_when_no_highlights
 
 async def test_format_document_non_documentation_keeps_flat_highlights():
     """_format_document keeps non-documentation highlights in the legacy flat format."""
-    doc = {
-        "id": "/solutions/123/index.html",
-        "allTitle": "Kernel panic solution",
-        "documentKind": "solution",
-        "view_uri": "/solutions/123",
-        "main_content": "Long solution body.",
-    }
-    data = {
-        "highlighting": {
-            doc["id"]: {
+    doc = SolrDoc(
+        id="/solutions/123/index.html",
+        allTitle="Kernel panic solution",
+        documentKind="solution",
+        view_uri="/solutions/123",
+        main_content="Long solution body.",
+    )
+    data = SolrResponse(
+        highlighting= {
+            doc.id: {
                 "main_content": [
                     "First <em>kernel</em> snippet.",
                     "Second snippet about <em>panic</em>.",
                 ]
             }
         }
-    }
+    )
 
-    result = await _format_document(doc, data, doc["view_uri"], "kernel panic", max_chars=5000)
+    result = await _format_document(doc, data, doc.view_uri, "kernel panic", max_chars=5000)
 
     assert "Relevant passages:" not in result
     assert "Content:" in result
@@ -214,25 +219,25 @@ async def test_format_document_non_documentation_keeps_flat_highlights():
 
 async def test_format_document_documentation_budget_uses_remaining_space():
     """_format_document limits passage output to the true remaining response budget."""
-    doc = {
-        "id": "/documentation/en-us/rhel/9/html/networking/index.html",
-        "allTitle": "X" * 180,
-        "documentKind": "documentation",
-        "view_uri": "/documentation/en-us/rhel/9/html/networking/index",
-        "main_content": "Long body text.",
-    }
-    data = {
-        "highlighting": {
-            doc["id"]: {
+    doc = SolrDoc(
+        id="/documentation/en-us/rhel/9/html/networking/index.html",
+        allTitle="X" * 180,
+        documentKind="documentation",
+        view_uri="/documentation/en-us/rhel/9/html/networking/index",
+        main_content="Long body text.",
+    )
+    data = SolrResponse(
+        highlighting= {
+            doc.id: {
                 "main_content": [
                     "First <em>network</em> snippet with enough detail to consume budget.",
                     "Second snippet that should be excluded when the remaining budget is small.",
                 ]
             }
         }
-    }
+    )
 
-    result = await _format_document(doc, data, doc["view_uri"], "network", max_chars=320)
+    result = await _format_document(doc, data, doc.view_uri, "network", max_chars=320)
 
     assert "Relevant passages:" in result
     assert "Passage 1:" in result
@@ -241,26 +246,27 @@ async def test_format_document_documentation_budget_uses_remaining_space():
 
 async def test_format_document_falls_back_when_highlights_clean_to_empty():
     """_format_document falls back when highlight cleanup leaves no usable snippets."""
-    doc = {
-        "id": "/documentation/en-us/rhel/9/html/virtualization/index.html",
-        "allTitle": "Virtualization guide",
-        "documentKind": "documentation",
-        "view_uri": "/documentation/en-us/rhel/9/html/virtualization/index",
-        "main_content": (
-            "intro\n\nConfiguring KVM virtualization on RHEL systems.\n\nUse virsh to inspect virtual machines."
+    doc = SolrDoc(
+        id="/documentation/en-us/rhel/9/html/virtualization/index.html",
+        allTitle="Virtualization guide",
+        documentKind="documentation",
+        view_uri="/documentation/en-us/rhel/9/html/virtualization/index",
+        main_content=(
+            "intro\n\nConfiguring KVM virtualization on RHEL systems."
+            "\n\nUse virsh to inspect virtual machines."
         ),
-    }
-    data = {
-        "highlighting": {
-            doc["id"]: {
+    )
+    data = SolrResponse(
+        highlighting= {
+            doc.id: {
                 "main_content": [
                     "RHV is <em>commonly used</em> and fully supported.",
                 ]
             }
         }
-    }
+    )
 
-    result = await _format_document(doc, data, doc["view_uri"], "kvm virtualization", max_chars=5000)
+    result = await _format_document(doc, data, doc.view_uri, "kvm virtualization", max_chars=5000)
 
     assert "Relevant passages:" not in result
     assert "Content:" in result
@@ -387,7 +393,12 @@ async def test_get_document_normalizes_full_url():
         patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),
         patch("okp_mcp.tools.document._fetch_document_raw", new_callable=AsyncMock) as mock_fetch,
     ):
-        mock_fetch.return_value = {"response": {"docs": [{"allTitle": "Test", "documentKind": "documentation"}]}}
+        mock_fetch.return_value = SolrResponse(
+            response=SolrResponseBody(
+                numFound=1,
+                docs=[SolrDoc(allTitle="Test", documentKind="documentation")],
+            ),
+        )
         await tools.get_document(mock_ctx, full_url)
 
         # The normalized path (not the full URL) should reach the fetch function.


### PR DESCRIPTION
Replace bare `dict` type hints on Solr document/response parameters with pydantic `BaseModel` definitions so the type checker and IDEs know the actual field names, and Solr responses are validated at the boundary.

**What changed:**

- New `src/okp_mcp/types.py` with `SolrDoc`, `SolrResponseBody`, and `SolrResponse` as pydantic `BaseModel` classes (all `SolrDoc` fields have defaults since the returned set depends on each query's `fl`)
- `SolrResponse.model_validate()` at Solr response entry points (`_solr_query` and `_fetch_document_raw`)
- All dict bracket access (`doc["key"]`, `doc.get("key", ...)`) converted to attribute access (`doc.key`) across `solr.py`, `content.py`, `portal.py`, and `tools/document.py`
- Removed unnecessary `from __future__ import annotations` from `content.py`
- Updated `AGENTS.md` module dependency and layout tables
- All tests updated to construct `SolrDoc()` / `SolrResponse()` instances instead of raw dicts