### PR TITLE
refactor: decompose monolith _solr_query into focused units

### DIFF
--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -3,7 +3,11 @@
 import re
 import time
 
+from enum import StrEnum
+
 import httpx
+
+from pydantic import ValidationError
 
 from okp_mcp.bm25 import BM25Plus
 from okp_mcp.config import logger
@@ -109,123 +113,107 @@ def _clean_query(query: str) -> str:
     return " ".join(parts) if parts else query
 
 
-async def _solr_query(params: dict, client: httpx.AsyncClient | None = None, *, solr_endpoint: str) -> SolrResponse:
+# Static edismax configuration — built once, merged per-call.
+_SOLR_BASE_PARAMS: dict[str, str] = {
+    # Response format: return results as JSON.
+    "wt": "json",
+    # Use Extended DisMax, which supports field boosting, phrase boosting, and minimum-match.
+    "defType": "edismax",
+    # Query fields with boosts: title matches matter most (^5), headings and synopses help,
+    # and body content contributes at lower weight.
+    "qf": "title^5 main_content heading_h1^3 heading_h2 portal_synopsis allTitle^3 content^2 all_content^1",
+    # Phrase boost: reward documents where all query terms appear as an exact phrase.
+    "pf": "main_content^5 title^8",
+    # Phrase slop for pf: terms may be up to 3 positions apart and still earn the phrase boost.
+    "ps": "3",
+    # Bigram phrase boost: reward docs where adjacent pairs of query terms appear nearby.
+    "pf2": "main_content^3 title^5",
+    # Bigram slop: term pairs may be up to 2 positions apart.
+    "ps2": "2",
+    # Trigram phrase boost: reward docs where consecutive triples of query terms appear nearby.
+    "pf3": "main_content^1 title^2",
+    # Trigram slop: term triples may be up to 5 positions apart.
+    "ps3": "5",
+    # --- Highlighting (returns relevant snippets from matched documents) ---
+    # Enable highlighting.
+    "hl": "on",
+    # Generate highlights from the main_content field only.
+    "hl.fl": "main_content",
+    # Return up to 6 highlighted snippets per document.
+    "hl.snippets": "6",
+    # Target snippet size in characters (extended to sentence boundaries, see fragsizeIsMinimum).
+    "hl.fragsize": "600",
+    # Use the Unified Highlighter (fastest, most accurate, supports all options below).
+    "hl.method": "unified",
+    # Analyze up to 512K characters per document for highlighting (covers long RHEL docs).
+    "hl.maxAnalyzedChars": "512000",
+    # Break fragments on sentence boundaries rather than mid-sentence.
+    "hl.bs.type": "SENTENCE",
+    # Use English rules for sentence-boundary detection.
+    "hl.bs.language": "en",
+    # Treat fragsize as a minimum: snippets grow to the next sentence boundary instead of cutting off.
+    "hl.fragsizeIsMinimum": "true",
+    # If no query terms match in a document, return a summary from the start of the field.
+    "hl.defaultSummary": "true",
+    # Use BM25 term weighting to score highlighted passages instead of simple term frequency.
+    "hl.weightMatches": "true",
+    # Fragment alignment: position each snippet so the match starts roughly 1/3 in from the left,
+    # giving context before and after.
+    "hl.fragAlignRatio": "0.33",
+    # BM25 k1 (term saturation): higher values make repeated terms contribute more to the score.
+    "hl.score.k1": "1.0",
+    # BM25 b (length normalization): 0.65 moderately penalizes very long documents.
+    "hl.score.b": "0.65",
+    # BM25 pivot: documents around 200 characters get neutral length treatment;
+    # shorter docs score slightly higher, longer ones slightly lower.
+    "hl.score.pivot": "200",
+    # Minimum match: for 1-2 terms all must match; for 5+ terms at least
+    # 75% must match; for 10+ terms relax to 50%.  Long queries (e.g.
+    # user-pasted commands with IP addresses and interface names) carry
+    # many environment-specific tokens that won't appear in any doc.
+    # Without the 10<50% clause, mm=75% on a 15-token query requires 12
+    # matches, which no bonding/LACP solution doc can satisfy.
+    "mm": "2<-1 5<75% 10<50%",
+}
+
+
+class SolrStatus(StrEnum):
+    """Prometheus label values for Solr query outcomes."""
+
+    SUCCESS = "success"
+    ERROR = "error"
+    TIMEOUT = "timeout"
+
+
+async def _solr_query(params: dict, client: httpx.AsyncClient, *, solr_endpoint: str) -> SolrResponse:
     """Execute a SOLR query and return the parsed JSON response."""
-    _start = time.monotonic()
-    close_client = client is None
-    if client is None:
-        client = httpx.AsyncClient(timeout=30.0)
-    base_params = {
-        # Response format: return results as JSON.
-        "wt": "json",
-        # Use Extended DisMax, which supports field boosting, phrase boosting, and minimum-match.
-        "defType": "edismax",
-        # Query fields with boosts: title matches matter most (^5), headings and synopses help,
-        # and body content contributes at lower weight.
-        "qf": "title^5 main_content heading_h1^3 heading_h2 portal_synopsis allTitle^3 content^2 all_content^1",
-        # Phrase boost: reward documents where all query terms appear as an exact phrase.
-        "pf": "main_content^5 title^8",
-        # Phrase slop for pf: terms may be up to 3 positions apart and still earn the phrase boost.
-        "ps": "3",
-        # Bigram phrase boost: reward docs where adjacent pairs of query terms appear nearby.
-        "pf2": "main_content^3 title^5",
-        # Bigram slop: term pairs may be up to 2 positions apart.
-        "ps2": "2",
-        # Trigram phrase boost: reward docs where consecutive triples of query terms appear nearby.
-        "pf3": "main_content^1 title^2",
-        # Trigram slop: term triples may be up to 5 positions apart.
-        "ps3": "5",
-        # --- Highlighting (returns relevant snippets from matched documents) ---
-        # Enable highlighting.
-        "hl": "on",
-        # Generate highlights from the main_content field only.
-        "hl.fl": "main_content",
-        # Return up to 6 highlighted snippets per document.
-        "hl.snippets": "6",
-        # Target snippet size in characters (extended to sentence boundaries, see fragsizeIsMinimum).
-        "hl.fragsize": "600",
-        # Use the Unified Highlighter (fastest, most accurate, supports all options below).
-        "hl.method": "unified",
-        # Analyze up to 512K characters per document for highlighting (covers long RHEL docs).
-        "hl.maxAnalyzedChars": "512000",
-        # Break fragments on sentence boundaries rather than mid-sentence.
-        "hl.bs.type": "SENTENCE",
-        # Use English rules for sentence-boundary detection.
-        "hl.bs.language": "en",
-        # Treat fragsize as a minimum: snippets grow to the next sentence boundary instead of cutting off.
-        "hl.fragsizeIsMinimum": "true",
-        # If no query terms match in a document, return a summary from the start of the field.
-        "hl.defaultSummary": "true",
-        # Use BM25 term weighting to score highlighted passages instead of simple term frequency.
-        "hl.weightMatches": "true",
-        # Fragment alignment: position each snippet so the match starts roughly 1/3 in from the left,
-        # giving context before and after.
-        "hl.fragAlignRatio": "0.33",
-        # BM25 k1 (term saturation): higher values make repeated terms contribute more to the score.
-        "hl.score.k1": "1.0",
-        # BM25 b (length normalization): 0.65 moderately penalizes very long documents.
-        "hl.score.b": "0.65",
-        # BM25 pivot: documents around 200 characters get neutral length treatment;
-        # shorter docs score slightly higher, longer ones slightly lower.
-        "hl.score.pivot": "200",
-        # Minimum match: for 1-2 terms all must match; for 5+ terms at least
-        # 75% must match; for 10+ terms relax to 50%.  Long queries (e.g.
-        # user-pasted commands with IP addresses and interface names) carry
-        # many environment-specific tokens that won't appear in any doc.
-        # Without the 10<50% clause, mm=75% on a 15-token query requires 12
-        # matches, which no bonding/LACP solution doc can satisfy.
-        "mm": "2<-1 5<75% 10<50%",
-    }
-    base_params.update(params)
+    merged = _SOLR_BASE_PARAMS | params
     logger.info("SOLR query: q=%r, fq=%r", params.get("q"), params.get("fq"))
-    _solr_status = "success"
+    _start = time.monotonic()
+    _status = SolrStatus.SUCCESS
+    result = SolrResponse()
     try:
-        response = await client.get(solr_endpoint, params=base_params)
+        response = await client.get(solr_endpoint, params=merged)
         response.raise_for_status()
         data = response.json()
+        result = SolrResponse.model_validate(data)
+        num_found = result.response.numFound
+        logger.info("SOLR query matched %d total, returning %d docs", num_found, len(result.response.docs))
     except httpx.TimeoutException:
-        _solr_status = "timeout"
-        SOLR_QUERIES.labels(status="timeout").inc()
-        logger.warning("SOLR query timed out after 30s", exc_info=True)
+        _status = SolrStatus.TIMEOUT
+        logger.warning("SOLR query timed out", exc_info=True)
         raise
-    except httpx.HTTPStatusError as e:
-        _solr_status = "error"
-        SOLR_QUERIES.labels(status="error").inc()
-        logger.exception("SOLR returned HTTP %d: %s", e.response.status_code, e.response.text[:200])
-        raise
-    except httpx.RequestError as e:
-        _solr_status = "error"
-        SOLR_QUERIES.labels(status="error").inc()
-        logger.exception("SOLR connection error: %s", e)
-        raise
-    except ValueError as e:
-        _solr_status = "error"
-        SOLR_QUERIES.labels(status="error").inc()
-        logger.exception("SOLR returned non-JSON response: %s", e)
+    except ValidationError as e:
+        _status = SolrStatus.ERROR
+        logger.error("SOLR response validation failed: %s", e)
+    except (httpx.HTTPStatusError, httpx.RequestError, ValueError) as e:
+        _status = SolrStatus.ERROR
+        logger.exception("SOLR query failed: %s", e)
         raise
     finally:
-        SOLR_QUERY_DURATION.labels(status=_solr_status).observe(time.monotonic() - _start)
-        if close_client:
-            await client.aclose()
-
-    _empty_response = SolrResponse()
-
-    parsed = SolrResponse.model_validate(data)
-
-    if parsed.error is not None:
-        SOLR_QUERIES.labels(status="error").inc()
-        logger.error("SOLR returned error: %s", parsed.error)
-        return _empty_response
-    if "response" not in data or not isinstance(data.get("response", {}).get("docs"), list):
-        SOLR_QUERIES.labels(status="error").inc()
-        logger.error("SOLR returned unexpected structure: %s", list(data.keys()))
-        return _empty_response
-
-    SOLR_QUERIES.labels(status="success").inc()
-    num_found = parsed.response.numFound
-    num_docs = len(parsed.response.docs)
-    logger.info("SOLR query matched %d total, returning %d docs", num_found, num_docs)
-    return parsed
+        SOLR_QUERIES.labels(status=_status).inc()
+        SOLR_QUERY_DURATION.labels(status=_status).observe(time.monotonic() - _start)
+    return result
 
 
 _CONTAMINATION_PHRASES = frozenset(

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -177,7 +177,7 @@ def _format_document_content(
 async def _fetch_document_with_query(
     doc_id: str,
     query: str,
-    client: httpx.AsyncClient | None = None,
+    client: httpx.AsyncClient,
     *,
     solr_endpoint: str,
 ) -> SolrResponse:

--- a/src/okp_mcp/types.py
+++ b/src/okp_mcp/types.py
@@ -2,6 +2,7 @@
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import model_validator
 
 
 class SolrDoc(BaseModel):
@@ -44,3 +45,11 @@ class SolrResponse(BaseModel):
     error: dict | None = None
 
     model_config = {"extra": "ignore"}
+
+    @model_validator(mode="after")
+    def reject_error_response(self) -> "SolrResponse":
+        """Reject Solr responses that carry a domain-level error."""
+        if self.error is not None:
+            msg = f"Solr returned error: {self.error}"
+            raise ValueError(msg)
+        return self

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -284,7 +284,8 @@ async def test_solr_query_records_success_metrics(sample_solr_response):
 
     with respx.mock(assert_all_called=True) as router:
         router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=sample_solr_response))
-        await _solr_query({"q": "test"}, solr_endpoint=_SOLR_ENDPOINT)
+        async with httpx.AsyncClient() as client:
+            await _solr_query({"q": "test"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
     assert _get_counter("okp_solr_queries", {"status": "success"}) == before_success + 1
     assert _get_histogram_count("okp_solr_query_duration_seconds", {"status": "success"}) == before_duration + 1
@@ -313,8 +314,9 @@ async def test_solr_query_records_failure_metrics(status_label, mock_kwargs, exp
 
     with respx.mock(assert_all_called=True) as router:
         router.get(_SOLR_ENDPOINT).mock(**mock_kwargs)
-        with pytest.raises(expected_exc):
-            await _solr_query({"q": "test"}, solr_endpoint=_SOLR_ENDPOINT)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(expected_exc):
+                await _solr_query({"q": "test"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
     assert _get_counter("okp_solr_queries", {"status": status_label}) == before + 1
 
@@ -326,7 +328,8 @@ async def test_solr_query_records_error_metrics_on_solr_error_response():
 
     with respx.mock(assert_all_called=True) as router:
         router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=error_response))
-        result = await _solr_query({"q": "bad"}, solr_endpoint=_SOLR_ENDPOINT)
+        async with httpx.AsyncClient() as client:
+            result = await _solr_query({"q": "bad"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
     assert _get_counter("okp_solr_queries", {"status": "error"}) == before + 1
     assert result.response.numFound == 0
@@ -338,7 +341,8 @@ async def test_solr_query_always_records_duration():
 
     with respx.mock:
         respx.get(_SOLR_ENDPOINT).mock(side_effect=httpx.TimeoutException("slow"))
-        with pytest.raises(httpx.TimeoutException):
-            await _solr_query({"q": "test"}, solr_endpoint=_SOLR_ENDPOINT)
+        async with httpx.AsyncClient() as client:
+            with pytest.raises(httpx.TimeoutException):
+                await _solr_query({"q": "test"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
     assert _get_histogram_count("okp_solr_query_duration_seconds", {"status": "timeout"}) == before + 1

--- a/tests/test_solr.py
+++ b/tests/test_solr.py
@@ -1,14 +1,14 @@
-"""Tests for SOLR query client lifecycle and query cleaning behavior."""
+"""Tests for SOLR query and query cleaning behavior."""
 
 # pyright: reportMissingImports=false
 
 from unittest.mock import AsyncMock
-from unittest.mock import Mock
-from unittest.mock import patch
 
 import httpx
 import pytest
 import respx
+
+from pydantic import ValidationError
 
 from okp_mcp.config import ServerConfig
 from okp_mcp.solr import _clean_query
@@ -20,120 +20,44 @@ from okp_mcp.types import SolrResponse
 _SOLR_ENDPOINT = ServerConfig().solr_endpoint
 
 
-async def test_solr_query_uses_provided_shared_client(sample_solr_response):
-    """Provided client is used directly instead of constructing a new one."""
+async def test_solr_query_uses_provided_client(sample_solr_response):
+    """Provided client is used directly for the HTTP call."""
     with respx.mock(assert_all_called=True) as router:
         route = router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=sample_solr_response))
-        shared_client = httpx.AsyncClient(timeout=30.0)
-        try:
-            with patch(
-                "okp_mcp.solr.httpx.AsyncClient", side_effect=AssertionError("constructor should not be called")
-            ):
-                data = await _solr_query({"q": "kernel panic"}, client=shared_client, solr_endpoint=_SOLR_ENDPOINT)
-        finally:
-            await shared_client.aclose()
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            data = await _solr_query({"q": "kernel panic"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
     assert route.called
     assert isinstance(data, SolrResponse)
     assert data.response.numFound == sample_solr_response["response"]["numFound"]
 
 
-async def test_solr_query_does_not_close_shared_client():
-    """Provided shared client is not closed by _solr_query."""
-    response = Mock(spec=httpx.Response)
-    response.raise_for_status.return_value = None
-    response.json.return_value = {"response": {"numFound": 0, "docs": []}, "highlighting": {}}
+async def test_solr_query_timeout_exception_propagates():
+    """TimeoutException is re-raised to the caller."""
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=httpx.TimeoutException("slow SOLR"))
 
-    shared_client = AsyncMock(spec=httpx.AsyncClient)
-    shared_client.get = AsyncMock(return_value=response)
-    shared_client.aclose = AsyncMock()
-
-    await _solr_query({"q": "rpm-ostree"}, client=shared_client, solr_endpoint=_SOLR_ENDPOINT)
-
-    shared_client.get.assert_awaited_once()
-    shared_client.aclose.assert_not_awaited()
+    with pytest.raises(httpx.TimeoutException):
+        await _solr_query({"q": "timeout"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
 
-async def test_solr_query_creates_and_closes_client_when_not_provided(sample_solr_response):
-    """When no client is provided, _solr_query creates and closes one."""
-    created_client = httpx.AsyncClient(timeout=30.0)
-    original_aclose = created_client.aclose
-    closed = False
-
-    async def _tracking_aclose() -> None:
-        nonlocal closed
-        closed = True
-        await original_aclose()
-
-    created_client.aclose = _tracking_aclose
-
-    with (
-        patch("okp_mcp.solr.httpx.AsyncClient", return_value=created_client) as client_ctor,
-        respx.mock(assert_all_called=True) as router,
-    ):
-        route = router.get(_SOLR_ENDPOINT).mock(return_value=httpx.Response(200, json=sample_solr_response))
-        data = await _solr_query({"q": "openshift"}, solr_endpoint=_SOLR_ENDPOINT)
-
-    client_ctor.assert_called_once_with(timeout=30.0)
-    assert route.called
-    assert closed
-    assert isinstance(data, SolrResponse)
-    assert data.response.numFound == sample_solr_response["response"]["numFound"]
-
-
-@pytest.mark.parametrize("use_shared_client", [True, False])
-async def test_solr_query_timeout_exception_propagates(use_shared_client):
-    """TimeoutException is re-raised for shared and owned client paths."""
-    timeout_error = httpx.TimeoutException("slow SOLR")
-
-    if use_shared_client:
-        shared_client = AsyncMock(spec=httpx.AsyncClient)
-        shared_client.get = AsyncMock(side_effect=timeout_error)
-        with pytest.raises(httpx.TimeoutException):
-            await _solr_query({"q": "timeout"}, client=shared_client, solr_endpoint=_SOLR_ENDPOINT)
-        shared_client.aclose.assert_not_awaited()
-        return
-
-    created_client = AsyncMock(spec=httpx.AsyncClient)
-    created_client.get = AsyncMock(side_effect=timeout_error)
-    created_client.aclose = AsyncMock()
-    with (
-        patch("okp_mcp.solr.httpx.AsyncClient", return_value=created_client),
-        pytest.raises(httpx.TimeoutException),
-    ):
-        await _solr_query({"q": "timeout"}, solr_endpoint=_SOLR_ENDPOINT)
-    created_client.aclose.assert_awaited_once()
-
-
-@pytest.mark.parametrize("use_shared_client", [True, False])
-async def test_solr_query_http_status_error_propagates(use_shared_client):
-    """HTTPStatusError is re-raised for shared and owned client paths."""
+async def test_solr_query_http_status_error_propagates():
+    """HTTPStatusError is re-raised to the caller."""
     request = httpx.Request("GET", _SOLR_ENDPOINT)
     response = httpx.Response(503, request=request, text="service unavailable")
     status_error = httpx.HTTPStatusError("bad status", request=request, response=response)
 
-    if use_shared_client:
-        shared_client = AsyncMock(spec=httpx.AsyncClient)
-        shared_client.get = AsyncMock(side_effect=status_error)
-        with pytest.raises(httpx.HTTPStatusError):
-            await _solr_query({"q": "status"}, client=shared_client, solr_endpoint=_SOLR_ENDPOINT)
-        shared_client.aclose.assert_not_awaited()
-        return
+    client = AsyncMock(spec=httpx.AsyncClient)
+    client.get = AsyncMock(side_effect=status_error)
 
-    created_client = AsyncMock(spec=httpx.AsyncClient)
-    created_client.get = AsyncMock(side_effect=status_error)
-    created_client.aclose = AsyncMock()
-    with (
-        patch("okp_mcp.solr.httpx.AsyncClient", return_value=created_client),
-        pytest.raises(httpx.HTTPStatusError),
-    ):
-        await _solr_query({"q": "status"}, solr_endpoint=_SOLR_ENDPOINT)
-    created_client.aclose.assert_awaited_once()
+    with pytest.raises(httpx.HTTPStatusError):
+        await _solr_query({"q": "status"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
 
 async def test_solr_query_respx_regression_guard(solr_mock, sample_solr_response):
     """Existing respx endpoint mocking keeps working after client refactor."""
-    data = await _solr_query({"q": "selinux"}, solr_endpoint=_SOLR_ENDPOINT)
+    async with httpx.AsyncClient() as client:
+        data = await _solr_query({"q": "selinux"}, client=client, solr_endpoint=_SOLR_ENDPOINT)
 
     assert solr_mock.called
     assert data.response.numFound == sample_solr_response["response"]["numFound"]
@@ -205,3 +129,21 @@ def test_get_highlight_snippets_deduplicates_across_alias_keys():
     snippets = _get_highlight_snippets(data, "doc-1", "/docs/doc-1", query="snippet")
 
     assert snippets == ["Repeated snippet.", "Unique snippet."]
+
+
+# ---------------------------------------------------------------------------
+# SolrResponse model validation
+# ---------------------------------------------------------------------------
+
+
+def test_solr_response_rejects_error_payload():
+    """SolrResponse model validator raises on Solr error payloads."""
+    with pytest.raises(ValidationError, match="Solr returned error"):
+        SolrResponse.model_validate({"error": {"msg": "bad", "code": 400}})
+
+
+def test_solr_response_defaults_on_missing_response():
+    """Missing 'response' key produces an empty SolrResponse via defaults."""
+    parsed = SolrResponse.model_validate({"unexpected": True})
+    assert parsed.response.numFound == 0
+    assert parsed.response.docs == []


### PR DESCRIPTION
Break `_solr_query` (115 lines) into three focused units:

- `_SOLR_BASE_PARAMS`: module-level constant for the edismax config that was rebuilt every call
- `_validate_solr_response()`: pure function handling Solr error/structure validation
- `_solr_query()`: now 24 lines, just HTTP call + error handling

Other changes:

- `client` parameter is required (removed the conditional create/close lifecycle; callers always have one from `AppContext`)
- Three copy-pasted `except` blocks collapsed into one `(HTTPStatusError, RequestError, ValueError)` handler
- Counter + duration metrics consolidated into a single `finally` block
- `_fetch_document_with_query` in `document.py` also made client-required for consistency

Tests updated to supply explicit clients and removed the lifecycle test (tested behavior that no longer exists).
