### PR TITLE
Initialize tools with the server instance

### DIFF
--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -6,7 +6,6 @@ import sys
 from pydantic_settings import CliApp
 
 from okp_mcp import server as _server
-from okp_mcp import tools as _tools  # noqa: F401 -- import triggers @mcp.tool registration
 from okp_mcp.build_info import get_commit_sha
 from okp_mcp.build_info import get_package_version
 from okp_mcp.config import ServerConfig

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -68,6 +68,8 @@ mcp = FastMCP(
     middleware=[RequestIDContextMiddleware()],
 )
 
+from okp_mcp.tools import *  # noqa: F403, E402 -- register tools
+
 
 @mcp.custom_route("/metrics", methods=["GET"])
 async def metrics_endpoint(request: Request) -> Response:

--- a/src/okp_mcp/tools/__init__.py
+++ b/src/okp_mcp/tools/__init__.py
@@ -1,5 +1,14 @@
 """MCP tool definitions for RHEL OKP knowledge base search."""
 
-from okp_mcp.tools.document import get_document as get_document  # triggers @mcp.tool registration
-from okp_mcp.tools.run_code import run_code as run_code  # triggers @mcp.tool registration
-from okp_mcp.tools.search import search_portal as search_portal  # triggers @mcp.tool registration
+from okp_mcp.tools.document import get_document as get_document
+from okp_mcp.tools.run_code import run_code as run_code
+from okp_mcp.tools.search import search_portal as search_portal
+
+
+# Tool functions that will be registered with the MCP server.
+# All tools need to be listed here or they will not be registered.
+__all__ = [
+    "get_document",
+    "run_code",
+    "search_portal",
+]


### PR DESCRIPTION
Move tool import to the same module as the server to ensure tools are always registered.

Add a `__all__` to the tools package to create a single place where new tools need to be added.