### PR TITLE
ci: disable Renovate Tekton task updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,6 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>rhel-lightspeed/renovate-config"],
   "tekton": {
-    "managerFilePatterns": ["/\\.tekton/.+\\.ya?ml$/"]
+    "enabled": false
   }
 }


### PR DESCRIPTION
## Summary

- Disable the Tekton manager in Renovate so it stops bumping `.tekton/` digest pins

## Why

- Tekton digest bumps get grouped with Python dep updates by the org-level "all non-major" rule, adding unrelated file changes to those PRs
- The combined PRs then fail the `Sanity - Manifests` gate because the Python lock changes require `.konflux/` manifest regeneration, which Renovate can't run (`postUpgradeTasks` requires Mend-hosted admin approval)
- The pipeline has known structural gaps (missing `source-build-oci-ta` task, matrix strategy migrations) that need manual rework before automated digest pin bumps add value

## Testing

- `make ci` passes (lint, typecheck, radon, manifests, tests)
- Validated JSON syntax via `check-toml`/`check-yaml` pre-commit hooks

## Reverting

Re-enable when the pipeline structural gaps are addressed by restoring:
```json
"tekton": {
  "enabled": true,
  "managerFilePatterns": ["/\\.tekton/.+\\.ya?ml$/"]
}
```