### PR TITLE
Use a single `ServerConfig` instance

### DIFF
--- a/src/okp_mcp/__init__.py
+++ b/src/okp_mcp/__init__.py
@@ -3,12 +3,9 @@
 import logging
 import sys
 
-from pydantic_settings import CliApp
-
-from okp_mcp import server as _server
 from okp_mcp.build_info import get_commit_sha
 from okp_mcp.build_info import get_package_version
-from okp_mcp.config import ServerConfig
+from okp_mcp.config import CONFIG
 from okp_mcp.request_id import RequestIDLogFilter
 from okp_mcp.server import mcp
 from okp_mcp.telemetry import initialize_error_reporting
@@ -44,19 +41,17 @@ def main() -> None:
     CLI arguments take precedence over environment variables.
     Run ``okp-mcp --help`` for available options.
     """
-    config = CliApp.run(ServerConfig)
-    _server._server_config = config
-    _configure_logging(config.log_level)
+    _configure_logging(CONFIG.log_level)
     try:
-        initialize_error_reporting(config)
+        initialize_error_reporting(CONFIG)
     except Exception:
         logger.warning("Failed to initialize error reporting; continuing without it", exc_info=True)
 
     logger.info("okp-mcp %s (%s)", get_package_version(), get_commit_sha())
-    logger.info("Starting MCP server with transport=%s", config.transport)
+    logger.info("Starting MCP server with transport=%s", CONFIG.transport)
 
     try:
-        mcp.run(transport=config.transport.value, show_banner=False, **config.transport_kwargs)
+        mcp.run(transport=CONFIG.transport.value, show_banner=False, **CONFIG.transport_kwargs)
     except KeyboardInterrupt:
         logger.info("Shutting down okp-mcp")
         sys.exit()

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -1,6 +1,7 @@
 """Server configuration via MCP_* environment variables and CLI arguments."""
 
 import logging
+import sys
 
 from enum import StrEnum
 
@@ -111,6 +112,9 @@ class ServerConfig(BaseSettings):
         cli_prog_name="okp-mcp",
         cli_hide_none_type=True,
         cli_kebab_case=True,
+        # Only parse CLI args when running okp-mcp from the command line,
+        # not when importing the module.
+        cli_parse_args=sys.argv[0].endswith("okp-mcp"),
     )
 
     transport: Transport = Field(
@@ -161,3 +165,6 @@ class ServerConfig(BaseSettings):
             ]
 
         return result
+
+
+CONFIG = ServerConfig()

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -17,13 +17,11 @@ from prometheus_client import generate_latest
 from starlette.requests import Request
 from starlette.responses import Response
 
-from okp_mcp.config import ServerConfig
+from okp_mcp.config import CONFIG
 from okp_mcp.request_id import RequestIDContextMiddleware
 
 
 logger = logging.getLogger(__name__)
-
-_server_config: ServerConfig | None = None
 
 
 @dataclass
@@ -39,9 +37,8 @@ class AppContext:
 async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]:
     """Manage app lifecycle resources for tool execution."""
     del server
-    cfg = _server_config if _server_config is not None else ServerConfig()
-    solr_endpoint = cfg.solr_endpoint
-    max_response_chars = cfg.max_response_chars
+    solr_endpoint = CONFIG.solr_endpoint
+    max_response_chars = CONFIG.max_response_chars
     logger.info("SOLR endpoint: %s", solr_endpoint)
     client = httpx.AsyncClient(timeout=30.0)
     try:

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -36,7 +36,6 @@ class AppContext:
 @asynccontextmanager
 async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]:
     """Manage app lifecycle resources for tool execution."""
-    del server
     solr_endpoint = CONFIG.solr_endpoint
     max_response_chars = CONFIG.max_response_chars
     logger.info("SOLR endpoint: %s", solr_endpoint)
@@ -71,5 +70,4 @@ from okp_mcp.tools import *  # noqa: F403, E402 -- register tools
 @mcp.custom_route("/metrics", methods=["GET"])
 async def metrics_endpoint(request: Request) -> Response:
     """Expose Prometheus metrics for scraping."""
-    del request
     return Response(content=generate_latest(), media_type=CONTENT_TYPE_LATEST)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -162,20 +162,6 @@ async def test_app_context_has_solr_endpoint():
         assert app_context.solr_endpoint == "http://localhost:8983/solr/portal/select"
 
 
-def test_server_config_assignment_propagates_to_lifespan():
-    """Direct _server_config assignment is picked up by the lifespan."""
-    from okp_mcp import server as server_module
-    from okp_mcp.config import ServerConfig
-
-    original = server_module._server_config
-    try:
-        cfg = ServerConfig()
-        server_module._server_config = cfg
-        assert server_module._server_config is cfg
-    finally:
-        server_module._server_config = original
-
-
 def test_request_id_log_filter_uses_context_var():
     """Log filter injects the active request ID into records."""
     log_filter = RequestIDLogFilter()

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -5,8 +5,10 @@ from unittest.mock import patch
 
 import pytest
 
-from pydantic import ValidationError
+from pydantic import SecretStr
 
+from okp_mcp.config import ServerConfig
+from okp_mcp.config import Transport
 from okp_mcp.metrics import PrometheusMiddleware
 from okp_mcp.request_id import RequestIDHeaderMiddleware
 
@@ -57,96 +59,97 @@ def test_main_defaults_to_streamable_http(_mock_mcp_run):
     """Default transport is streamable-http when no args or env vars are set."""
     from okp_mcp import main
 
-    with patch("sys.argv", ["okp-mcp"]):
+    config = ServerConfig()
+
+    with patch("okp_mcp.CONFIG", config):
         main()
 
-    _assert_http_run(_mock_mcp_run, transport="streamable-http", host="0.0.0.0", port=8000)
+    _assert_http_run(_mock_mcp_run, transport=Transport.streamable_http, host="0.0.0.0", port=8000)
 
 
 def test_main_initializes_error_reporting(_mock_mcp_run):
     """Configured GlitchTip setup runs before the server starts."""
     from okp_mcp import main
 
+    config = ServerConfig(glitchtip_dsn=SecretStr("https://glitchtip.example.com/1"))
     call_order: list[str] = []
 
     with (
-        patch("sys.argv", ["okp-mcp"]),
-        patch.dict("os.environ", {"MCP_GLITCHTIP_DSN": "https://glitchtip.example.com/1"}),
-        patch("okp_mcp.initialize_error_reporting") as initialize_error_reporting,
+        patch("okp_mcp.CONFIG", config),
+        patch("okp_mcp.initialize_error_reporting") as mock_init,
     ):
-        initialize_error_reporting.side_effect = lambda _cfg: call_order.append("init")
+        mock_init.side_effect = lambda _cfg: call_order.append("init")
         _mock_mcp_run.run.side_effect = lambda *args, **kwargs: call_order.append("run")
         main()
 
-    initialize_error_reporting.assert_called_once()
-    glitchtip_dsn = initialize_error_reporting.call_args.args[0].glitchtip_dsn
+    mock_init.assert_called_once_with(config)
+    glitchtip_dsn = mock_init.call_args.args[0].glitchtip_dsn
     assert glitchtip_dsn is not None
     assert glitchtip_dsn.get_secret_value() == "https://glitchtip.example.com/1"
     assert call_order == ["init", "run"]
-    _assert_http_run(_mock_mcp_run, transport="streamable-http", host="0.0.0.0", port=8000)
+    _assert_http_run(_mock_mcp_run, transport=Transport.streamable_http, host="0.0.0.0", port=8000)
 
 
 def test_main_stdio_transport(_mock_mcp_run):
     """stdio transport calls mcp.run without host/port."""
     from okp_mcp import main
 
-    with patch("sys.argv", ["okp-mcp", "--transport", "stdio"]):
+    config = ServerConfig(transport=Transport.stdio)
+
+    with patch("okp_mcp.CONFIG", config):
         main()
 
-    _mock_mcp_run.run.assert_called_once_with(transport="stdio", show_banner=False)
+    _mock_mcp_run.run.assert_called_once_with(transport=Transport.stdio, show_banner=False)
 
 
-@pytest.mark.parametrize("transport", ["sse", "streamable-http"])
+@pytest.mark.parametrize("transport", [Transport.sse, Transport.streamable_http])
 def test_main_http_transports(_mock_mcp_run, transport):
     """SSE and streamable-http transports pass host and port to mcp.run."""
     from okp_mcp import main
 
-    with patch("sys.argv", ["okp-mcp", "--transport", transport]):
+    config = ServerConfig(transport=transport)
+
+    with patch("okp_mcp.CONFIG", config):
         main()
 
     _assert_http_run(_mock_mcp_run, transport=transport, host="0.0.0.0", port=8000)
 
 
 def test_main_custom_host_and_port(_mock_mcp_run):
-    """CLI host and port are forwarded to mcp.run."""
+    """Custom host and port are forwarded to mcp.run."""
     from okp_mcp import main
 
-    with patch("sys.argv", ["okp-mcp", "--transport", "sse", "--host", "127.0.0.1", "--port", "3000"]):
+    config = ServerConfig(transport=Transport.sse, host="127.0.0.1", port=3000)
+
+    with patch("okp_mcp.CONFIG", config):
         main()
 
-    _assert_http_run(_mock_mcp_run, transport="sse", host="127.0.0.1", port=3000)
+    _assert_http_run(_mock_mcp_run, transport=Transport.sse, host="127.0.0.1", port=3000)
 
 
 def test_main_env_var_transport(_mock_mcp_run):
     """MCP_TRANSPORT env var selects the transport when no CLI arg is given."""
     from okp_mcp import main
 
-    with patch("sys.argv", ["okp-mcp"]), patch.dict("os.environ", {"MCP_TRANSPORT": "sse"}):
+    with patch.dict("os.environ", {"MCP_TRANSPORT": "sse"}):
+        config = ServerConfig()
+
+    with patch("okp_mcp.CONFIG", config):
         main()
 
-    _assert_http_run(_mock_mcp_run, transport="sse", host="0.0.0.0", port=8000)
+    _assert_http_run(_mock_mcp_run, transport=Transport.sse, host="0.0.0.0", port=8000)
 
 
 def test_main_cli_overrides_env_var(_mock_mcp_run):
     """CLI arguments take precedence over environment variables."""
     from okp_mcp import main
 
-    with (
-        patch("sys.argv", ["okp-mcp", "--transport", "sse", "--port", "7777"]),
-        patch.dict("os.environ", {"MCP_TRANSPORT": "streamable-http", "MCP_PORT": "9999"}),
-    ):
+    # _cli_parse_args overrides model_config cli_parse_args per-instance,
+    # feeding explicit CLI args without mutating sys.argv.
+    with patch.dict("os.environ", {"MCP_TRANSPORT": "streamable-http", "MCP_PORT": "9999"}):
+        config = ServerConfig(_cli_parse_args=["--transport", "sse", "--port", "7777"])
+
+    with patch("okp_mcp.CONFIG", config):
         main()
 
-    _assert_http_run(_mock_mcp_run, transport="sse", host="0.0.0.0", port=7777)
-
-
-def test_main_invalid_transport_from_env():
-    """Invalid transport from env var raises ValidationError."""
-    from okp_mcp import main
-
-    with (
-        patch("sys.argv", ["okp-mcp"]),
-        patch.dict("os.environ", {"MCP_TRANSPORT": "websocket"}),
-        pytest.raises(ValidationError, match="transport"),
-    ):
-        main()
+    _assert_http_run(_mock_mcp_run, transport=Transport.sse, host="0.0.0.0", port=7777)


### PR DESCRIPTION
Instead of passing the config instance through a module global, create the instance once on import and use that everywhere.

Instead of using CliApp.run() which returns a settings instance, use the run method on the FastMCP instance passing in parameters from the config. This is functionally the same but does not return a settings instance that needs to be passed around to the lifespan function.

Enable CLI argument parsing only when the application is called using the script not when it is run as a module (which we don’t support yet) or when `okp_mcp.config` is imported.

Remove `del` statements that only exist to satisfy the type checker and are confusing to the reader. The parameters are required by the function but not used. I think we’re fine with that.