### PR TITLE
Change CLI arg format

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,7 +133,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Change Solr query logic | `src/okp_mcp/solr.py` | `_solr_query()` builds edismax params; `_clean_query()` for tokenization |
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
-| Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg via `MCP_` prefix |
+| Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |
@@ -299,7 +299,7 @@ No circular imports. `types.py`, `bm25.py`, and `formatting.py` have zero intern
 
 Config uses `pydantic_settings.BaseSettings` with `MCP_` env prefix. CLI via `CliApp.run()`. Precedence: CLI > env vars > defaults. Derived values use `@computed_field`.
 
-Optional GlitchTip/Sentry exception reporting is configured with `MCP_GLITCHTIP_DSN` / `--glitchtip_dsn`. Missing or empty DSNs are handled as a no-op for local development.
+Optional GlitchTip/Sentry exception reporting is configured with `MCP_GLITCHTIP_DSN` / `--glitchtip-dsn`. Missing or empty DSNs are handled as a no-op for local development.
 
 Module-level constant `STOP_WORDS` lives in `config.py` outside the class to avoid circular import issues. The Solr endpoint is no longer a module-level constant — it flows through `ServerConfig.solr_endpoint` → `AppContext.solr_endpoint` at runtime.
 

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Settings come from CLI arguments and `MCP_*` environment variables. CLI args tak
 | `--transport` | `MCP_TRANSPORT` | `streamable-http` | `stdio`, `sse`, or `streamable-http` |
 | `--host` | `MCP_HOST` | `0.0.0.0` | Bind address for HTTP transports |
 | `--port` | `MCP_PORT` | `8000` | Bind port for HTTP transports |
-| `--log_level` | `MCP_LOG_LEVEL` | `INFO` | Python log level |
-| `--solr_url` | `MCP_SOLR_URL` | `http://localhost:8983` | Base URL of the Solr instance |
-| `--glitchtip_dsn` | `MCP_GLITCHTIP_DSN` | unset | Optional GlitchTip/Sentry DSN for exception reporting |
+| `--log-level` | `MCP_LOG_LEVEL` | `INFO` | Python log level |
+| `--solr-url` | `MCP_SOLR_URL` | `http://localhost:8983` | Base URL of the Solr instance |
+| `--glitchtip-dsn` | `MCP_GLITCHTIP_DSN` | unset | Optional GlitchTip/Sentry DSN for exception reporting |
 
 Run `okp-mcp --help` for the full list.
 

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -110,6 +110,7 @@ class ServerConfig(BaseSettings):
         env_prefix="MCP_",
         cli_prog_name="okp-mcp",
         cli_hide_none_type=True,
+        cli_kebab_case=True,
     )
 
     transport: Transport = Field(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,7 +72,7 @@ def test_cli_args_via_cli_app():
             "127.0.0.1",
             "--port",
             "3000",
-            "--glitchtip_dsn",
+            "--glitchtip-dsn",
             "https://example.com/1",
         ],
     )


### PR DESCRIPTION
Use [kebab case](https://pydantic.dev/docs/validation/latest/concepts/pydantic_settings/#cli-kebab-case-for-arguments): `--foo-bar` instead of `--foo_bar`. This is the more traditional command line argument format.