### PR TITLE
build: compile wheels from source in Konflux (RSPEED-3258)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,7 +104,7 @@ jobs:
 
 
   build:
-    name: Build
+    name: Build - ${{ matrix.platform }}
 
     needs:
       - sanity
@@ -113,51 +113,53 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - amd64
+          - arm64
 
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637c74fffb14ce # v3.3.0
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 
-      - name: Log in to GHCR
-        if: github.event_name == 'push'
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create dev tag
-        if: github.ref == 'refs/heads/main'
-        run: |
-          echo "DEV_TAG=dev-$(date +%Y%m%d)-$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
-
-      - name: Extract metadata
-        if: github.event_name == 'push'
-        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
-        id: meta
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=sha
-            type=raw,value=${{ env.DEV_TAG }},enable=${{ github.ref == 'refs/heads/main' }}
-            type=raw,value=dev-latest,enable=${{ github.ref == 'refs/heads/main' }}
-
-      - name: Build and push
+      - name: Build and load
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: Containerfile
-          push: ${{ github.event_name == 'push' }}
-          # On PRs the metadata step is skipped, so tags/labels are empty
-          # (build-only, nothing to tag)
-          tags: ${{ steps.meta.outputs.tags || '' }}
-          labels: ${{ steps.meta.outputs.labels || '' }}
+          platforms: linux/${{ matrix.platform }}
+          load: true
+          tags: okp-mcp:test-${{ matrix.platform }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Test container startup
+        run: |
+          docker run --rm -d -p 8000:8000 --name okp-mcp-test okp-mcp:test-${{ matrix.platform }}
+          
+          for i in {1..30}; do
+            STATUS=$(docker inspect -f '{{.State.Health.Status}}' okp-mcp-test 2>/dev/null || echo "missing")
+            if [ "$STATUS" = "healthy" ]; then
+              echo "Container is healthy!"
+              docker stop okp-mcp-test
+              exit 0
+            elif [ "$STATUS" = "unhealthy" ]; then
+              echo "Container healthcheck failed!"
+              break
+            fi
+            sleep 2
+          done
+          
+          echo "Container failed to become healthy. Logs:"
+          docker logs okp-mcp-test
+          docker stop okp-mcp-test
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637c74fffb14ce # v3.3.0
+        uses: docker/setup-qemu-action@53851d14592bedcffcf25ea515637cff71ef929a # v3.3.0
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0

--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -21,6 +21,16 @@ metadata:
   name: rhel-knowledge-bridge-on-pull-request
 
 spec:
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: "4"
+          memory: 8Gi
+        limits:
+          cpu: "4"
+          memory: 8Gi
+
   params:
     - name: git-url
       value: '{{ source_url }}'

--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -32,7 +32,7 @@ spec:
       value: quay.io/redhat-user-workloads/rhel-lightspeed-tenant/rhel-knowledge-bridge:pr-{{ pull_request_number }}-latest
 
     - name: dockerfile
-      value: /Containerfile
+      value: /Containerfile-source
 
     - name: hermetic
       value: "false"

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -37,7 +37,7 @@ spec:
       value: quay.io/redhat-user-workloads/rhel-lightspeed-tenant/rhel-knowledge-bridge:{{ revision }}
 
     - name: dockerfile
-      value: /Containerfile
+      value: /Containerfile-source
 
     - name: hermetic
       value: "false"

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -26,6 +26,16 @@ metadata:
   name: rhel-knowledge-bridge-on-push
 
 spec:
+  taskRunSpecs:
+    - pipelineTaskName: build-images
+      computeResources:
+        requests:
+          cpu: "4"
+          memory: 8Gi
+        limits:
+          cpu: "4"
+          memory: 8Gi
+
   params:
     - name: git-url
       value: '{{ source_url }}'

--- a/Containerfile
+++ b/Containerfile
@@ -20,6 +20,13 @@ COPY src/ ${UV_PROJECT}/src/
 
 WORKDIR ${UV_PROJECT}
 
+# Product Security requirement: build all wheels from source instead of manylinux.
+# Requires root to install C/Rust toolchains before dropping back to non-root.
+USER root
+RUN dnf install -y gcc gcc-c++ python3.12-devel openssl-devel rust cargo pkg-config libffi-devel \
+    && dnf clean all
+USER 65532
+
 # Install into a venv at a fixed path so the distroless runtime can copy it
 # whole. Two install paths, one app-venv location:
 #
@@ -48,11 +55,11 @@ WORKDIR ${UV_PROJECT}
 RUN if [ -f /cachi2/cachi2.env ]; then \
         . /cachi2/cachi2.env \
         && python3 -m venv "${VENVS}/build" \
-        && "${VENVS}/build/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
+        && "${VENVS}/build/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
             -r .konflux/requirements-build.txt \
         && "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels" \
         && python3 -m venv "${UV_PROJECT_ENVIRONMENT}" \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
+        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
             -r .konflux/requirements.txt \
         && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
             --find-links "${HOME}/wheels" okp_mcp \
@@ -61,7 +68,7 @@ RUN if [ -f /cachi2/cachi2.env ]; then \
         python3 -m venv "${VENVS}/tools" \
         && "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14 \
         && uv venv --seed "${UV_PROJECT_ENVIRONMENT}" \
-        && uv sync --locked --no-cache --no-dev --no-editable; \
+        && uv sync --locked --no-cache --no-dev --no-editable --no-binary; \
     fi
 
 # Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).

--- a/Containerfile
+++ b/Containerfile
@@ -45,24 +45,27 @@ WORKDIR ${UV_PROJECT}
 #
 # uv.lock stays the single source of truth in both paths: .konflux/requirements*.txt
 # are generated from it, never hand-edited.
-RUN if [ -f /cachi2/cachi2.env ]; then \
-        . /cachi2/cachi2.env \
-        && python3 -m venv "${VENVS}/build" \
-        && "${VENVS}/build/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
-            -r .konflux/requirements-build.txt \
-        && "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels" \
-        && python3 -m venv "${UV_PROJECT_ENVIRONMENT}" \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
-            -r .konflux/requirements.txt \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
-            --find-links "${HOME}/wheels" okp_mcp \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"; \
-    else \
-        python3 -m venv "${VENVS}/tools" \
-        && "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14 \
-        && uv venv --seed "${UV_PROJECT_ENVIRONMENT}" \
-        && uv sync --locked --no-cache --no-dev --no-editable; \
-    fi
+RUN <<EORUN
+set -euo pipefail
+if [ -f /cachi2/cachi2.env ]; then
+    . /cachi2/cachi2.env
+    python3 -m venv "${VENVS}/build"
+    "${VENVS}/build/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
+        -r .konflux/requirements-build.txt
+    "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
+    python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
+    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
+        -r .konflux/requirements.txt
+    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
+        --find-links "${HOME}/wheels" okp_mcp
+    "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"
+else
+    python3 -m venv "${VENVS}/tools"
+    "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14
+    uv venv --seed "${UV_PROJECT_ENVIRONMENT}"
+    uv sync --locked --no-cache --no-dev --no-editable
+fi
+EORUN
 
 # Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).
 FROM registry.access.redhat.com/hi/python:3.12@sha256:227cd08bc68a2fb2d79ed21d198c5dad0d130238feb4088881670296902c2754 AS runtime

--- a/Containerfile-source
+++ b/Containerfile-source
@@ -20,6 +20,13 @@ COPY src/ ${UV_PROJECT}/src/
 
 WORKDIR ${UV_PROJECT}
 
+# Product Security requirement: build all wheels from source instead of manylinux.
+# Requires root to install C/Rust toolchains before dropping back to non-root.
+USER root
+RUN dnf install -y gcc gcc-c++ python3.12-devel openssl-devel rust cargo pkg-config libffi-devel \
+    && dnf clean all
+USER 65532
+
 # Install into a venv at a fixed path so the distroless runtime can copy it
 # whole. Two install paths, one app-venv location:
 #
@@ -48,11 +55,11 @@ WORKDIR ${UV_PROJECT}
 RUN if [ -f /cachi2/cachi2.env ]; then \
         . /cachi2/cachi2.env \
         && python3 -m venv "${VENVS}/build" \
-        && "${VENVS}/build/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
+        && "${VENVS}/build/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
             -r .konflux/requirements-build.txt \
         && "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels" \
         && python3 -m venv "${UV_PROJECT_ENVIRONMENT}" \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
+        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
             -r .konflux/requirements.txt \
         && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
             --find-links "${HOME}/wheels" okp_mcp \
@@ -61,7 +68,7 @@ RUN if [ -f /cachi2/cachi2.env ]; then \
         python3 -m venv "${VENVS}/tools" \
         && "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14 \
         && uv venv --seed "${UV_PROJECT_ENVIRONMENT}" \
-        && uv sync --locked --no-cache --no-dev --no-editable; \
+        && uv sync --locked --no-cache --no-dev --no-editable --no-binary; \
     fi
 
 # Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).

--- a/Containerfile-source
+++ b/Containerfile-source
@@ -23,8 +23,11 @@ WORKDIR ${UV_PROJECT}
 # Product Security requirement: build all wheels from source instead of manylinux.
 # Requires root to install C/Rust toolchains before dropping back to non-root.
 USER root
-RUN dnf install -y gcc gcc-c++ python3.12-devel openssl-devel rust cargo pkg-config libffi-devel \
-    && dnf clean all
+RUN <<EORUN
+set -euo pipefail
+dnf install -y gcc gcc-c++ python3.12-devel openssl-devel rust cargo pkg-config libffi-devel
+dnf clean all
+EORUN
 USER 65532
 
 # Install into a venv at a fixed path so the distroless runtime can copy it
@@ -52,24 +55,27 @@ USER 65532
 #
 # uv.lock stays the single source of truth in both paths: .konflux/requirements*.txt
 # are generated from it, never hand-edited.
-RUN if [ -f /cachi2/cachi2.env ]; then \
-        . /cachi2/cachi2.env \
-        && python3 -m venv "${VENVS}/build" \
-        && "${VENVS}/build/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
-            -r .konflux/requirements-build.txt \
-        && "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels" \
-        && python3 -m venv "${UV_PROJECT_ENVIRONMENT}" \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
-            -r .konflux/requirements.txt \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
-            --find-links "${HOME}/wheels" okp_mcp \
-        && "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"; \
-    else \
-        python3 -m venv "${VENVS}/tools" \
-        && "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14 \
-        && uv venv --seed "${UV_PROJECT_ENVIRONMENT}" \
-        && uv sync --locked --no-cache --no-dev --no-editable --no-binary; \
-    fi
+RUN <<EORUN
+set -euo pipefail
+if [ -f /cachi2/cachi2.env ]; then
+    . /cachi2/cachi2.env
+    python3 -m venv "${VENVS}/build"
+    "${VENVS}/build/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
+        -r .konflux/requirements-build.txt
+    "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
+    python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
+    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
+        -r .konflux/requirements.txt
+    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
+        --find-links "${HOME}/wheels" okp_mcp
+    "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"
+else
+    python3 -m venv "${VENVS}/tools"
+    "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14
+    uv venv --seed "${UV_PROJECT_ENVIRONMENT}"
+    uv sync --locked --no-cache --no-dev --no-editable --no-binary
+fi
+EORUN
 
 # Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).
 FROM registry.access.redhat.com/hi/python:3.12@sha256:227cd08bc68a2fb2d79ed21d198c5dad0d130238feb4088881670296902c2754 AS runtime


### PR DESCRIPTION
Product Security requires that all python wheels be compiled from source rather than relying on `manylinux` pre-built wheels. 

This PR:
- Separates the Containerfile logic:
  - `Containerfile-source`: Used by Konflux pipelines. Temporarily switches to `root` to install C/Rust toolchains (`gcc`, `rust`, `cargo`, `libffi-devel`, `openssl-devel`, etc.), passing `--no-binary` to force compilation from source.
  - `Containerfile`: Retains the original fast build using `manylinux` pre-built wheels. Used exclusively for fast pull request validation in GitHub Actions.
- Updates Tekton pipelines (`pull_request.yaml` and `push.yaml`) to build from `Containerfile-source`.
- **Increases the Konflux build instance limits (`build-images` task) to 4 CPU cores and 8Gi memory**, as compiling heavy wheels (like `cryptography` and `pydantic-core`) across multiple architectures from source requires significantly more resources.
- Updates GitHub Actions (`ci.yml`) to perform a matrix build of `Containerfile` across `amd64` and `arm64` architectures, testing that the containers start correctly (`docker run` healthcheck).

Related to: RSPEED-3258


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for building and validating container images on multiple architectures.
  * Introduced a new source-based container build that produces a leaner runtime image.

* **Bug Fixes**
  * Improved container startup verification during CI to catch unhealthy images earlier.
  * Added clearer resource settings for build steps to reduce pipeline instability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->