### PR TITLE
build: extract Containerfile install logic into shared script

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,55 +17,14 @@ ENV UV_PYTHON=/usr/bin/python3
 COPY pyproject.toml uv.lock README.md ${UV_PROJECT}/
 COPY .konflux/ ${UV_PROJECT}/.konflux/
 COPY src/ ${UV_PROJECT}/src/
+COPY --chmod=0755 scripts/container-install.sh ${UV_PROJECT}/scripts/
 
 WORKDIR ${UV_PROJECT}
 
-# Install into a venv at a fixed path so the distroless runtime can copy it
-# whole. Two install paths, one app-venv location:
-#
-#   * Hermetic Konflux build (Cachi2 present): the network is disabled, so uv
-#     cannot be fetched from PyPI. Cachi2 has prefetched every wheel into an
-#     offline mirror and written /cachi2/cachi2.env (PIP_FIND_LINKS +
-#     PIP_NO_INDEX). Two stdlib venvs keep the build backend off the runtime:
-#       1. A throwaway tools venv gets the hash-pinned hatchling backend and
-#          builds the okp_mcp wheel with --no-build-isolation.
-#       2. The app venv gets only the hash-pinned runtime deps, then the
-#          locally built okp_mcp wheel (--no-deps --no-index). hatchling and
-#          its build deps never touch the app venv, so nothing needs
-#          uninstalling and the runtime SBOM carries no build tooling. This
-#          also dodges a version clash: packaging is both a runtime dep and a
-#          hatchling build dep, and mixing both manifests in one venv would
-#          conflict.
-#   * Local / non-hermetic build: install pinned uv, then `uv sync --locked`
-#     straight from uv.lock (fails if the lock is stale, preserving the
-#     locked-build guarantee). `uv venv --seed` seeds pip into the app venv
-#     (just pip on 3.12+); uv sync does not need it, but it keeps the local
-#     venv at parity with the hermetic path's `python -m venv` (which also
-#     ships pip).
-#
-# uv.lock stays the single source of truth in both paths: .konflux/requirements*.txt
-# are generated from it, never hand-edited.
-RUN <<EORUN
-set -euo pipefail
-if [ -f /cachi2/cachi2.env ]; then
-    . /cachi2/cachi2.env
-    python3 -m venv "${VENVS}/build"
-    "${VENVS}/build/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
-        -r .konflux/requirements-build.txt
-    "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
-    python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
-    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --only-binary=:all: --require-hashes \
-        -r .konflux/requirements.txt
-    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
-        --find-links "${HOME}/wheels" okp_mcp
-    "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"
-else
-    python3 -m venv "${VENVS}/tools"
-    "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14
-    uv venv --seed "${UV_PROJECT_ENVIRONMENT}"
-    uv sync --locked --no-cache --no-dev --no-editable
-fi
-EORUN
+# Install dependencies via the shared build script.
+# See scripts/container-install.sh for detailed comments on each step.
+# BUILD_FROM_SOURCE is unset here → uses prebuilt manylinux wheels (fast).
+RUN scripts/container-install.sh
 
 # Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).
 FROM registry.access.redhat.com/hi/python:3.12@sha256:227cd08bc68a2fb2d79ed21d198c5dad0d130238feb4088881670296902c2754 AS runtime

--- a/Containerfile-source
+++ b/Containerfile-source
@@ -17,6 +17,7 @@ ENV UV_PYTHON=/usr/bin/python3
 COPY pyproject.toml uv.lock README.md ${UV_PROJECT}/
 COPY .konflux/ ${UV_PROJECT}/.konflux/
 COPY src/ ${UV_PROJECT}/src/
+COPY --chmod=0755 scripts/container-install.sh ${UV_PROJECT}/scripts/
 
 WORKDIR ${UV_PROJECT}
 
@@ -30,52 +31,11 @@ dnf clean all
 EORUN
 USER 65532
 
-# Install into a venv at a fixed path so the distroless runtime can copy it
-# whole. Two install paths, one app-venv location:
-#
-#   * Hermetic Konflux build (Cachi2 present): the network is disabled, so uv
-#     cannot be fetched from PyPI. Cachi2 has prefetched every wheel into an
-#     offline mirror and written /cachi2/cachi2.env (PIP_FIND_LINKS +
-#     PIP_NO_INDEX). Two stdlib venvs keep the build backend off the runtime:
-#       1. A throwaway tools venv gets the hash-pinned hatchling backend and
-#          builds the okp_mcp wheel with --no-build-isolation.
-#       2. The app venv gets only the hash-pinned runtime deps, then the
-#          locally built okp_mcp wheel (--no-deps --no-index). hatchling and
-#          its build deps never touch the app venv, so nothing needs
-#          uninstalling and the runtime SBOM carries no build tooling. This
-#          also dodges a version clash: packaging is both a runtime dep and a
-#          hatchling build dep, and mixing both manifests in one venv would
-#          conflict.
-#   * Local / non-hermetic build: install pinned uv, then `uv sync --locked`
-#     straight from uv.lock (fails if the lock is stale, preserving the
-#     locked-build guarantee). `uv venv --seed` seeds pip into the app venv
-#     (just pip on 3.12+); uv sync does not need it, but it keeps the local
-#     venv at parity with the hermetic path's `python -m venv` (which also
-#     ships pip).
-#
-# uv.lock stays the single source of truth in both paths: .konflux/requirements*.txt
-# are generated from it, never hand-edited.
-RUN <<EORUN
-set -euo pipefail
-if [ -f /cachi2/cachi2.env ]; then
-    . /cachi2/cachi2.env
-    python3 -m venv "${VENVS}/build"
-    "${VENVS}/build/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
-        -r .konflux/requirements-build.txt
-    "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
-    python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
-    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-binary=:all: --require-hashes \
-        -r .konflux/requirements.txt
-    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
-        --find-links "${HOME}/wheels" okp_mcp
-    "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"
-else
-    python3 -m venv "${VENVS}/tools"
-    "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14
-    uv venv --seed "${UV_PROJECT_ENVIRONMENT}"
-    uv sync --locked --no-cache --no-dev --no-editable --no-binary
-fi
-EORUN
+# Install dependencies via the shared build script.
+# See scripts/container-install.sh for detailed comments on each step.
+# BUILD_FROM_SOURCE=1 → compiles all wheels from source (--no-binary).
+ENV BUILD_FROM_SOURCE=1
+RUN scripts/container-install.sh
 
 # Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).
 FROM registry.access.redhat.com/hi/python:3.12@sha256:227cd08bc68a2fb2d79ed21d198c5dad0d130238feb4088881670296902c2754 AS runtime

--- a/scripts/container-install.sh
+++ b/scripts/container-install.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+# scripts/container-install.sh — Install Python dependencies inside a container build.
+#
+# Shared by Containerfile (prebuilt wheels) and Containerfile-source (from-source).
+# The only behavioral difference is controlled by BUILD_FROM_SOURCE (see below).
+#
+# Required environment variables (set via Containerfile ENV):
+#   VENVS                    — base directory for virtual environments
+#   UV_PROJECT_ENVIRONMENT   — path to the application venv
+#   HOME                     — home directory (wheel output lands here)
+#
+# Optional:
+#   BUILD_FROM_SOURCE        — set to "1" to compile all wheels from source
+#                              (passes --no-binary to pip/uv instead of --only-binary)
+set -euo pipefail
+
+# --- Determine pip binary-handling flags ---
+# Prebuilt-wheel builds use --only-binary=:all: (fast, uses manylinux wheels).
+# From-source builds use --no-binary=:all: (compiles every C/Rust extension).
+if [ "${BUILD_FROM_SOURCE:-0}" = "1" ]; then
+    PIP_BINARY_FLAG="--no-binary=:all:"
+    UV_BINARY_FLAG="--no-binary"
+else
+    PIP_BINARY_FLAG="--only-binary=:all:"
+    UV_BINARY_FLAG=""
+fi
+
+if [ -f /cachi2/cachi2.env ]; then
+    # --- Hermetic Konflux build (Cachi2 present) ---
+    # Network is disabled. Cachi2 has prefetched every dependency into an offline
+    # mirror and written PIP_FIND_LINKS + PIP_NO_INDEX into cachi2.env.
+
+    # Source the Cachi2 environment so pip resolves packages from the offline mirror.
+    # shellcheck source=/dev/null
+    . /cachi2/cachi2.env
+
+    # 1. Throwaway build venv: install the hatchling build backend so we can
+    #    build the okp_mcp wheel without network access. This venv is never
+    #    copied to the runtime stage.
+    python3 -m venv "${VENVS}/build"
+    "${VENVS}/build/bin/pip" install --no-cache-dir "${PIP_BINARY_FLAG}" --require-hashes \
+        -r .konflux/requirements-build.txt
+
+    # 2. Build the okp_mcp wheel from the local source tree.
+    #    --no-build-isolation: use the hatchling we just installed (no PyPI fetch).
+    #    --no-deps: the wheel has no bundled dependencies.
+    "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
+
+    # 3. Application venv: install only the hash-pinned runtime dependencies.
+    python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
+    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir "${PIP_BINARY_FLAG}" --require-hashes \
+        -r .konflux/requirements.txt
+
+    # 4. Install the locally-built okp_mcp wheel into the app venv.
+    #    --no-deps --no-index: no PyPI, no transitive resolution — just the wheel.
+    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
+        --find-links "${HOME}/wheels" okp_mcp
+
+    # 5. Smoke-test: verify the package is importable before finishing the layer.
+    "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"
+else
+    # --- Local / non-hermetic build ---
+    # Network available. Use uv for fast, locked dependency resolution.
+
+    # Install a pinned version of uv into a throwaway tools venv.
+    python3 -m venv "${VENVS}/tools"
+    "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14
+
+    # Use the explicit path so the script works regardless of PATH.
+    UV="${VENVS}/tools/bin/uv"
+
+    # Create the app venv with --seed (ships pip, matching the hermetic path's
+    # python -m venv behavior).
+    "${UV}" venv --seed "${UV_PROJECT_ENVIRONMENT}"
+
+    # Sync from uv.lock. --locked fails if the lock is stale.
+    # shellcheck disable=SC2086  # UV_BINARY_FLAG intentionally word-splits when non-empty
+    "${UV}" sync --locked --no-cache --no-dev --no-editable ${UV_BINARY_FLAG}
+fi


### PR DESCRIPTION
Follow-up to #324 — addresses [samdoran's review feedback](https://github.com/rhel-lightspeed/okp-mcp/pull/324#discussion_r3492859689) to extract the complex inline `RUN` blocks into a standalone script.

## What changed

Both `Containerfile` and `Containerfile-source` had near-identical heredoc `RUN` blocks (~40 lines each) for the hermetic/local install logic. This PR:

- Extracts the shared logic into `scripts/container-install.sh` with comments explaining every step
- `Containerfile` runs it with `BUILD_FROM_SOURCE` unset (prebuilt manylinux wheels)
- `Containerfile-source` sets `ENV BUILD_FROM_SOURCE=1` (compiles from source)
- Uses explicit `${VENVS}/tools/bin/uv` path so the script works regardless of `PATH`

No behavioral change — same install logic, just easier to read and maintain.
