### PR TITLE
build: switch to UBI 10 base images and enable hermetic builds

### DIFF
--- a/.konflux/requirements-build-all.txt
+++ b/.konflux/requirements-build-all.txt
@@ -1,0 +1,456 @@
+calver==2025.10.20 \
+    --hash=sha256:c98b376c2424642224d456b2f70c51402343e008c63d204634665e1a2a2835f5 \
+    --hash=sha256:d7d75224eed9d9263f4fb30008487615196d208d14752bfd93fea7af2c84f508
+    # via trove-classifiers
+cffi==2.0.0 ; platform_python_implementation != "PyPy" \
+    --hash=sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb \
+    --hash=sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b \
+    --hash=sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f \
+    --hash=sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9 \
+    --hash=sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44 \
+    --hash=sha256:0f6084a0ea23d05d20c3edcda20c3d006f9b6f3fefeac38f59262e10cef47ee2 \
+    --hash=sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c \
+    --hash=sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75 \
+    --hash=sha256:1cd13c99ce269b3ed80b417dcd591415d3372bcac067009b6e0f59c7d4015e65 \
+    --hash=sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e \
+    --hash=sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a \
+    --hash=sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e \
+    --hash=sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25 \
+    --hash=sha256:2081580ebb843f759b9f617314a24ed5738c51d2aee65d31e02f6f7a2b97707a \
+    --hash=sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe \
+    --hash=sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b \
+    --hash=sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91 \
+    --hash=sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592 \
+    --hash=sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187 \
+    --hash=sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c \
+    --hash=sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1 \
+    --hash=sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94 \
+    --hash=sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba \
+    --hash=sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb \
+    --hash=sha256:3f4d46d8b35698056ec29bca21546e1551a205058ae1a181d871e278b0b28165 \
+    --hash=sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529 \
+    --hash=sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca \
+    --hash=sha256:4647afc2f90d1ddd33441e5b0e85b16b12ddec4fca55f0d9671fef036ecca27c \
+    --hash=sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6 \
+    --hash=sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c \
+    --hash=sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0 \
+    --hash=sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743 \
+    --hash=sha256:61d028e90346df14fedc3d1e5441df818d095f3b87d286825dfcbd6459b7ef63 \
+    --hash=sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5 \
+    --hash=sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5 \
+    --hash=sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4 \
+    --hash=sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d \
+    --hash=sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b \
+    --hash=sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93 \
+    --hash=sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205 \
+    --hash=sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27 \
+    --hash=sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512 \
+    --hash=sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d \
+    --hash=sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c \
+    --hash=sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037 \
+    --hash=sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26 \
+    --hash=sha256:89472c9762729b5ae1ad974b777416bfda4ac5642423fa93bd57a09204712322 \
+    --hash=sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb \
+    --hash=sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c \
+    --hash=sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8 \
+    --hash=sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4 \
+    --hash=sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414 \
+    --hash=sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9 \
+    --hash=sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664 \
+    --hash=sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9 \
+    --hash=sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775 \
+    --hash=sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739 \
+    --hash=sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc \
+    --hash=sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062 \
+    --hash=sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe \
+    --hash=sha256:b882b3df248017dba09d6b16defe9b5c407fe32fc7c65a9c69798e6175601be9 \
+    --hash=sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92 \
+    --hash=sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5 \
+    --hash=sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13 \
+    --hash=sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d \
+    --hash=sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26 \
+    --hash=sha256:cb527a79772e5ef98fb1d700678fe031e353e765d1ca2d409c92263c6d43e09f \
+    --hash=sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495 \
+    --hash=sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b \
+    --hash=sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6 \
+    --hash=sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c \
+    --hash=sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef \
+    --hash=sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5 \
+    --hash=sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18 \
+    --hash=sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad \
+    --hash=sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3 \
+    --hash=sha256:de8dad4425a6ca6e4e5e297b27b5c824ecc7581910bf9aee86cb6835e6812aa7 \
+    --hash=sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5 \
+    --hash=sha256:e6e73b9e02893c764e7e8d5bb5ce277f1a009cd5243f8228f75f842bf937c534 \
+    --hash=sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49 \
+    --hash=sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2 \
+    --hash=sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5 \
+    --hash=sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453 \
+    --hash=sha256:fe562eb1a64e67dd297ccc4f5addea2501664954f2692b69a76449ec7913ecbf
+    # via cryptography
+coherent-licensed==0.5.2 \
+    --hash=sha256:d8071403ce742d3ac3592ddc4fb7057a46caffb415b928b4d52802e5f208416d \
+    --hash=sha256:edccc5193ca2786f8fb3f0c7374637a143985f781f7eaa21aca3af2bd634b82f
+    # via
+    #   jaraco-context
+    #   jaraco-functools
+    #   keyring
+cython==3.2.8 \
+    --hash=sha256:0961ba91f59492d1bef974cc6b45993c743162776188bcb79e029b442d5d4fcc \
+    --hash=sha256:0d78205f525287de94effa2f2fab6b9edafdab44ef8c58ecf52fcb1013225d68 \
+    --hash=sha256:1034facc082cb882e1e5beb61e136ae8e282df2eafa11e9771e9b0a15c860801 \
+    --hash=sha256:127bc4039be48c6eebe7f1d68c33d23eb3a0c5ae95e1d730bdd048837751438b \
+    --hash=sha256:1c3a33c2ff250d0277d0ee8b080ba0a0391a00e48af4a96fb09dbebbd1ac4b0e \
+    --hash=sha256:1c7f4143d0f9fb7b26444e00ebf7c8845f585d56f37b73bd3fb3dac269af8732 \
+    --hash=sha256:2d6858eb212b9272c5daed9d76e1c82b857e4963b2b892acf7ece4f8bb22aee6 \
+    --hash=sha256:3142407b9d63f233c766e17000e2aac782411bf0409b9adc97cb7c320aecd199 \
+    --hash=sha256:3fd6464433d925cba66ae31bf5780c8a469a06da1d109180cffb39ee3c88ae20 \
+    --hash=sha256:41c118fd91d320cd72af26e29232ff3f1a0a170c47d477c9a176d766067a4718 \
+    --hash=sha256:474d9c5378032c0237b70c7af4d2122eb00719fec2cab296ddc9cf2907d55d58 \
+    --hash=sha256:4e9447d9b652396a285cdfbd4f9f0721842c63c6df281720e87dcc4b9ea65af5 \
+    --hash=sha256:4f1bbec7a7bd2c3836314e84f68e3f9a4c20e11cd164a01990a9ca34f595d5dd \
+    --hash=sha256:51a1d2df1545c480f377f1bb2aea514e28956c87908f351bedc3772b3737c598 \
+    --hash=sha256:61767412d252558104f14c006bc89eefe00496d4f57dd951dd13666bda2ff43b \
+    --hash=sha256:6335c6e8737a39734e20d25f89f425bf3274c104fc7efc05aacc7ed1a4858c9d \
+    --hash=sha256:6c9bf89ac1d43a9e1c3bfee61e7b4dd8d1ef7a610001aa7779f0cb824bad8ae7 \
+    --hash=sha256:6f788a2fec204bdd9291d5d542a4856db101dba59f8d83789d3f1eb2895971a0 \
+    --hash=sha256:70db7a0c5fe5aebf272a56ddfc177bf608d6355571fd714b38f5ce14cba3b17c \
+    --hash=sha256:75770f79cf67f89f7d0b08590ffc114c7a1b47352ef0ee5a3494d5fc098299f0 \
+    --hash=sha256:7cae933e6b82c198b42e934472a41d2a14c5e115da6ea794c33039c2694ce4e5 \
+    --hash=sha256:8297efe129e6421c34ddbeb09ed5627ef6c0fc4868bf7f9bdf6c147f595ccaed \
+    --hash=sha256:84def174fbf8886fb026e04716908276c074d8c231e66db803abd04afcdcb998 \
+    --hash=sha256:8896ff6b133f346ebcf22aa23706c4031e8d9d5ae184433dfc67dc1053318b69 \
+    --hash=sha256:89b0fdc2ca0b502afedc4dd4ddbc4f9cb5a135245afacf9483e556e8ad3ada3b \
+    --hash=sha256:a134a19bba6ce7b1dd21dedc5cb2d4ea39a4177e42e535e333786eb9d0ba61a7 \
+    --hash=sha256:a7761e1a97081b707a9ea4fb7c8ecdeddcc6b5ae00dda0f0b7bbf933c1b599f9 \
+    --hash=sha256:ab1fe11ebd61e497a848622cdd157a4324ac06e7935b1219715408844e15dd13 \
+    --hash=sha256:ad9a80e5dda71cf30b9c9577902f0c080aa14a215d7c178d669cda21cf5ab801 \
+    --hash=sha256:c85c2ceb6bc6d3bc442241038c4e8bdd9883a3afd655a9b47e1222e10fe9edf1 \
+    --hash=sha256:d497b1048c61a94cff61baaa1db1c441254935671311f9fb0f84c8912e532d60 \
+    --hash=sha256:d63a43813fef3f3e8fb14502b8526d9bb9ad2eabd0c899b22f6409c4a97d265f \
+    --hash=sha256:e2221be06b6aa92486d7c3644c18cb3643b3e794600f0d6c8555a523e959a069 \
+    --hash=sha256:e480ae9f195cd29e5ce334e3d434c83dbac0783c0cc88f2407e31ba997724192 \
+    --hash=sha256:eb25b2afedc6a3585c5ae50db79ba0c3d6277ee8e1d6ce0223528db2c4981d9b \
+    --hash=sha256:f2547a31fbd3b1610a8859a16edee2a141f7781691cb98a2c6fd54870c5f7541 \
+    --hash=sha256:f3bce1f079734753649f8a3d3a95832297207feb120d0ef4fd5db4c813cc6c04 \
+    --hash=sha256:f4f23a56b25221a06f91817fe8f3114ab8b48a4fac73187dbb64bc2c4a87961f \
+    --hash=sha256:f635e113677666de13a2ec2979e9b1d5b90617cdfd1a691d3559be81e2dd6cb9
+    # via pyyaml
+dunamai==1.26.1 \
+    --hash=sha256:2727d939c5b4257cb01ea404372803b477f5176e5a347c43beaf89cd5072e853 \
+    --hash=sha256:3b46007bd65b00b4824ead0a1aee365fd22d0ec2b9c219497d4fd48f52860c8b
+    # via uv-dynamic-versioning
+flit-core==3.12.0 \
+    --hash=sha256:18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2 \
+    --hash=sha256:e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c
+    # via
+    #   click
+    #   coherent-licensed
+    #   flit-scm
+    #   idna
+    #   jeepney
+    #   jinja2
+    #   markdown-it-py
+    #   mdurl
+    #   more-itertools
+    #   packaging
+    #   pathspec
+    #   typing-extensions
+    #   wheel
+flit-scm==1.7.0 \
+    --hash=sha256:961bd6fb24f31bba75333c234145fff88e6de0a90fc0f7e5e7c79deca69f6bb2 \
+    --hash=sha256:9e864caa8a63f708f5bb2f1b5b53eedcd4da75ec2cc6221a64cea7aa5c9eae1a
+    # via exceptiongroup
+hatch-fancy-pypi-readme==25.1.0 \
+    --hash=sha256:9c58ed3dff90d51f43414ce37009ad1d5b0f08ffc9fc216998a06380f01c0045 \
+    --hash=sha256:ce0134c40d63d874ac48f48ccc678b8f3b62b8e50e9318520d2bffc752eedaf3
+    # via
+    #   attrs
+    #   httpcore
+    #   httpx
+    #   jsonschema
+    #   pydantic
+hatch-vcs==0.5.0 \
+    --hash=sha256:0395fa126940340215090c344a2bf4e2a77bcbe7daab16f41b37b98c95809ff9 \
+    --hash=sha256:b49677dbdc597460cc22d01b27ab3696f5e16a21ecf2700fb01bc28e1f2a04a7
+    # via
+    #   attrs
+    #   cyclopts
+    #   jsonschema
+    #   jsonschema-specifications
+    #   platformdirs
+    #   referencing
+    #   uncalled-for
+    #   urllib3
+hatchling==1.30.1 \
+    --hash=sha256:161eacafb3c6f91526e92116d21426369f2c36e98c36a864f11a96345ad4ee31 \
+    --hash=sha256:eee4fd45357f72ebb3d7a42e5d72cfb5e29ed426d79e8836288926c4258d5f2e
+    # via
+    #   aiofile
+    #   annotated-types
+    #   attrs
+    #   beartype
+    #   cyclopts
+    #   dnspython
+    #   docstring-parser
+    #   fastmcp
+    #   fastmcp-slim
+    #   griffelib
+    #   hatch-fancy-pypi-readme
+    #   hatch-vcs
+    #   httpcore
+    #   httpx
+    #   jsonschema
+    #   jsonschema-specifications
+    #   mcp
+    #   opentelemetry-api
+    #   platformdirs
+    #   pydantic
+    #   pydantic-settings
+    #   pygments
+    #   python-multipart
+    #   referencing
+    #   starlette
+    #   typing-inspection
+    #   uncalled-for
+    #   urllib3
+    #   uv-dynamic-versioning
+    #   uvicorn
+jinja2==3.1.6 \
+    --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
+    --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
+    # via uv-dynamic-versioning
+markupsafe==3.0.3 \
+    --hash=sha256:0303439a41979d9e74d18ff5e2dd8c43ed6c6001fd40e5bf2e43f7bd9bbc523f \
+    --hash=sha256:068f375c472b3e7acbe2d5318dea141359e6900156b5b2ba06a30b169086b91a \
+    --hash=sha256:0bf2a864d67e76e5c9a34dc26ec616a66b9888e25e7b9460e1c76d3293bd9dbf \
+    --hash=sha256:0db14f5dafddbb6d9208827849fad01f1a2609380add406671a26386cdf15a19 \
+    --hash=sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf \
+    --hash=sha256:0f4b68347f8c5eab4a13419215bdfd7f8c9b19f2b25520968adfad23eb0ce60c \
+    --hash=sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175 \
+    --hash=sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219 \
+    --hash=sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb \
+    --hash=sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6 \
+    --hash=sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab \
+    --hash=sha256:15d939a21d546304880945ca1ecb8a039db6b4dc49b2c5a400387cdae6a62e26 \
+    --hash=sha256:177b5253b2834fe3678cb4a5f0059808258584c559193998be2601324fdeafb1 \
+    --hash=sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce \
+    --hash=sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218 \
+    --hash=sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634 \
+    --hash=sha256:1ba88449deb3de88bd40044603fafffb7bc2b055d626a330323a9ed736661695 \
+    --hash=sha256:1cc7ea17a6824959616c525620e387f6dd30fec8cb44f649e31712db02123dad \
+    --hash=sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73 \
+    --hash=sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c \
+    --hash=sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe \
+    --hash=sha256:2a15a08b17dd94c53a1da0438822d70ebcd13f8c3a95abe3a9ef9f11a94830aa \
+    --hash=sha256:2f981d352f04553a7171b8e44369f2af4055f888dfb147d55e42d29e29e74559 \
+    --hash=sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa \
+    --hash=sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37 \
+    --hash=sha256:3537e01efc9d4dccdf77221fb1cb3b8e1a38d5428920e0657ce299b20324d758 \
+    --hash=sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f \
+    --hash=sha256:38664109c14ffc9e7437e86b4dceb442b0096dfe3541d7864d9cbe1da4cf36c8 \
+    --hash=sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d \
+    --hash=sha256:3b562dd9e9ea93f13d53989d23a7e775fdfd1066c33494ff43f5418bc8c58a5c \
+    --hash=sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97 \
+    --hash=sha256:4bd4cd07944443f5a265608cc6aab442e4f74dff8088b0dfc8238647b8f6ae9a \
+    --hash=sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19 \
+    --hash=sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9 \
+    --hash=sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9 \
+    --hash=sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc \
+    --hash=sha256:591ae9f2a647529ca990bc681daebdd52c8791ff06c2bfa05b65163e28102ef2 \
+    --hash=sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4 \
+    --hash=sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354 \
+    --hash=sha256:6b5420a1d9450023228968e7e6a9ce57f65d148ab56d2313fcd589eee96a7a50 \
+    --hash=sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698 \
+    --hash=sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9 \
+    --hash=sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b \
+    --hash=sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc \
+    --hash=sha256:7be7b61bb172e1ed687f1754f8e7484f1c8019780f6f6b0786e76bb01c2ae115 \
+    --hash=sha256:7c3fb7d25180895632e5d3148dbdc29ea38ccb7fd210aa27acbd1201a1902c6e \
+    --hash=sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485 \
+    --hash=sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f \
+    --hash=sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12 \
+    --hash=sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025 \
+    --hash=sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009 \
+    --hash=sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d \
+    --hash=sha256:949b8d66bc381ee8b007cd945914c721d9aba8e27f71959d750a46f7c282b20b \
+    --hash=sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a \
+    --hash=sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5 \
+    --hash=sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f \
+    --hash=sha256:a320721ab5a1aba0a233739394eb907f8c8da5c98c9181d1161e77a0c8e36f2d \
+    --hash=sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1 \
+    --hash=sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287 \
+    --hash=sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6 \
+    --hash=sha256:bc51efed119bc9cfdf792cdeaa4d67e8f6fcccab66ed4bfdd6bde3e59bfcbb2f \
+    --hash=sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581 \
+    --hash=sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed \
+    --hash=sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b \
+    --hash=sha256:c0c0b3ade1c0b13b936d7970b1d37a57acde9199dc2aecc4c336773e1d86049c \
+    --hash=sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026 \
+    --hash=sha256:c4ffb7ebf07cfe8931028e3e4c85f0357459a3f9f9490886198848f4fa002ec8 \
+    --hash=sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676 \
+    --hash=sha256:d2ee202e79d8ed691ceebae8e0486bd9a2cd4794cec4824e1c99b6f5009502f6 \
+    --hash=sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e \
+    --hash=sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d \
+    --hash=sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d \
+    --hash=sha256:de8a88e63464af587c950061a5e6a67d3632e36df62b986892331d4620a35c01 \
+    --hash=sha256:df2449253ef108a379b8b5d6b43f4b1a8e81a061d6537becd5582fba5f9196d7 \
+    --hash=sha256:e1c1493fb6e50ab01d20a22826e57520f1284df32f2d8601fdd90b6304601419 \
+    --hash=sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795 \
+    --hash=sha256:e2103a929dfa2fcaf9bb4e7c091983a49c9ac3b19c9061b6d5427dd7d14d81a1 \
+    --hash=sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5 \
+    --hash=sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d \
+    --hash=sha256:e8fc20152abba6b83724d7ff268c249fa196d8259ff481f3b1476383f8f24e42 \
+    --hash=sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe \
+    --hash=sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda \
+    --hash=sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e \
+    --hash=sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737 \
+    --hash=sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523 \
+    --hash=sha256:f42d0984e947b8adf7dd6dde396e720934d12c506ce84eea8476409563607591 \
+    --hash=sha256:f71a396b3bf33ecaa1626c255855702aca4d3d9fea5e051b41ac59a9c1c41edc \
+    --hash=sha256:f9e130248f4462aaa8e2552d547f36ddadbeaa573879158d721bbd33dfe4743a \
+    --hash=sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50
+    # via jinja2
+maturin==1.14.1 \
+    --hash=sha256:15cea8fcb3ba47dd636f50092bb34baea8b04ac777392f23e6bf8a9a61efb894 \
+    --hash=sha256:1a04de0a20188f95c721b5702eed18140bdcccb28c386797093eca3f62f4d4e0 \
+    --hash=sha256:3c9f94640ecc4895e94abaf834a0684430032c865b2748a36c12461fd9252fdd \
+    --hash=sha256:522292398945442cdafa9daeb2271b2340fbde57027b818f923f88eab04174f8 \
+    --hash=sha256:5282dffd4b539d2be245f4e5b1a5ab6bc1033b58f4a4872f5833f9d43c954aa4 \
+    --hash=sha256:994a0c8ba3ad8a92b3a9ee1b02645d200d610216b15cff5102b0fe65e8e08666 \
+    --hash=sha256:9d6577a62cd08e0ceba7a0db06fb098e0c9b1b3429bad747a4f3a18215a1b3df \
+    --hash=sha256:a131d912b5267e640bc96d70f4914e10590aed64082ec9abacba7cea52004224 \
+    --hash=sha256:be18fc568fb76884c0205456336892a75105ec398e6b667cd777c6268bd06d69 \
+    --hash=sha256:be80866363e605d137991b491a741a84cde9ae350183c4c85f49690ca9aaaa65 \
+    --hash=sha256:cd457cd88961156e26379e1155bd287cc0ec1c8b2f1582b0660fb31b87c8842d \
+    --hash=sha256:dfc54ae32e6fcb18302193ab9a30b0b25eefffba994ae13238974805533ef75e \
+    --hash=sha256:f3306078070c1508fd715b9116070cbcaff5959024272a9f1e6f5cb29768b86c \
+    --hash=sha256:ffe5ad71f21d1e6603c4dd75f7fee34adf5ed5ebcebb692886549888ebb329ed
+    # via
+    #   cryptography
+    #   pydantic-core
+    #   rpds-py
+    #   uv-build
+    #   watchfiles
+packaging==26.2 \
+    --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
+    --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via
+    #   hatchling
+    #   setuptools-scm
+    #   vcs-versioning
+    #   wheel
+pathspec==1.1.1 \
+    --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a \
+    --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
+    # via hatchling
+pdm-backend==2.4.9 \
+    --hash=sha256:8d1064751dadb0c40b1026b46826a448d85c8228a564985c62fb53d4aba538a1 \
+    --hash=sha256:c41a852ccbf4b567b033db9b2ae78660d7a4ea49307719959ab88a01f0aabb2e
+    # via griffelib
+pdm-pep517==1.1.4 \
+    --hash=sha256:7f49121e70b42dca296fac962210dd2da07a39575fc5673137ad661633b2cf3f \
+    --hash=sha256:c9fe65d06cf193f864ac2b38372a355450ff7f847aefc9b59e89fe2cf19f32b9
+    # via jsonref
+pluggy==1.6.0 \
+    --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
+    --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+    # via hatchling
+poetry-core==2.4.1 \
+    --hash=sha256:89dceb6c10e9c6d8650a16183400e3c9ff9ddee13b0a81023b5575334a2b3744 \
+    --hash=sha256:acf06f9537cd2625bdaec926d95d90b557ba15353bc71d27a3a8a441042b5316
+    # via
+    #   dunamai
+    #   jsonschema-path
+    #   openapi-pydantic
+    #   pathable
+    #   rich
+    #   tomlkit
+pycparser==3.0 ; implementation_name != "PyPy" and platform_python_implementation != "PyPy" \
+    --hash=sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29 \
+    --hash=sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992
+    # via cffi
+semantic-version==2.10.0 \
+    --hash=sha256:bdabb6d336998cbb378d4b9db3a4b56a1e3235701dc05ea2690d9a997ed5041c \
+    --hash=sha256:de78a3b8e0feda74cabc54aab2da702113e33ac9d9eb9d2389bcf1f58b7d9177
+    # via setuptools-rust
+setuptools-scm==10.2.0 \
+    --hash=sha256:6cc5ac7da8e54d74e43503be2fa023eb7a1ca820d5c318e6ae20efc48110d6c7 \
+    --hash=sha256:ec8ea1738b92e42146a46e29a0e9de9ad462744c63cf9778677b95dfd605adde
+    # via
+    #   anyio
+    #   cachetools
+    #   flit-scm
+    #   hatch-vcs
+    #   httpx-sse
+    #   jaraco-classes
+    #   jaraco-context
+    #   jaraco-functools
+    #   keyring
+    #   pluggy
+    #   setuptools-rust
+    #   urllib3
+tomlkit==0.15.0 \
+    --hash=sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738 \
+    --hash=sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3
+    # via uv-dynamic-versioning
+trove-classifiers==2026.6.1.19 \
+    --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
+    --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
+    # via hatchling
+uv-build==0.11.7 \
+    --hash=sha256:258e3a10929b5de79074078ba1ad8edbdd4db5d9c3cafba81f11b329eeaaca08
+    # via py-key-value-aio
+uv-dynamic-versioning==0.14.0 \
+    --hash=sha256:574fbc07e87ace45c01d55967ad3b864871257b98ff5b8ac87c261227ac8db5b \
+    --hash=sha256:e087c346a786e98d41292ac2315180fb700cedfb30565fc973d64ce11a112387
+    # via
+    #   fastmcp
+    #   fastmcp-slim
+    #   griffelib
+    #   mcp
+wheel==0.47.0 \
+    --hash=sha256:212281cab4dff978f6cedd499cd893e1f620791ca6ff7107cf270781e587eced \
+    --hash=sha256:cc72bd1009ba0cf63922e28f94d9d83b920aa2bb28f798a31d0691b02fa3c9b3
+    # via
+    #   authlib
+    #   httpx-sse
+    #   pycparser
+
+# The following packages are considered to be unsafe in a requirements file:
+setuptools==82.0.1 \
+    --hash=sha256:7d872682c5d01cfde07da7bccc7b65469d3dca203318515ada1de5eda35efbf9 \
+    --hash=sha256:a59e362652f08dcd477c78bb6e7bd9d80a7995bc73ce773050228a348ce2e5bb
+    # via
+    #   anyio
+    #   authlib
+    #   cachetools
+    #   caio
+    #   calver
+    #   certifi
+    #   cffi
+    #   cryptography
+    #   httpx-sse
+    #   jaraco-classes
+    #   jaraco-context
+    #   jaraco-functools
+    #   joserfc
+    #   keyring
+    #   markupsafe
+    #   maturin
+    #   pathspec
+    #   pluggy
+    #   prometheus-client
+    #   pycparser
+    #   pyjwt
+    #   pyperclip
+    #   python-dotenv
+    #   pyyaml
+    #   rich-rst
+    #   secretstorage
+    #   setuptools-rust
+    #   setuptools-scm
+    #   sse-starlette
+    #   trove-classifiers
+    #   vcs-versioning
+    #   websockets

--- a/.konflux/requirements-build-pypi.txt
+++ b/.konflux/requirements-build-pypi.txt
@@ -1,0 +1,10 @@
+--index-url https://pypi.org/simple/
+
+setuptools-rust==1.13.0 \
+    --hash=sha256:666439c4d90e968bb625bcf87ec0aa02b4f49e599d2f5dc255c633a04e8eca99 \
+    --hash=sha256:f2afcf4baeee689910ce49cfa8aad4e08cce72f417449bcc32891b8664fdc726
+    # via maturin
+vcs-versioning==2.2.2 \
+    --hash=sha256:4ac4ded78720cdb4d0291ae58ace87e1e9201912e1023f3029c6cce5c9152cfb \
+    --hash=sha256:fe7fb216f8780a5516e7864a9333aacb1b70015b087a9be3918da76ef2760808
+    # via setuptools-scm

--- a/.konflux/requirements-build.txt
+++ b/.konflux/requirements-build.txt
@@ -4,12 +4,16 @@ hatchling==1.30.1 \
 packaging==26.2 \
     --hash=sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e \
     --hash=sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661
+    # via hatchling
 pathspec==1.1.1 \
     --hash=sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a \
     --hash=sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189
+    # via hatchling
 pluggy==1.6.0 \
     --hash=sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3 \
     --hash=sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+    # via hatchling
 trove-classifiers==2026.6.1.19 \
     --hash=sha256:ab4c4ec93cc4a4e7815fa759906e05e6bb3f2fbd92ea0f897288c6a43efd15b3 \
     --hash=sha256:c5132b4b61a829d11cfbd2d72e97f20a45ed6edb95e45c5efdeb5e00836b2745
+    # via hatchling

--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -349,7 +349,7 @@ spec:
             value: source-build-oci-ta
 
           - name: bundle
-            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:8567bb7bf8fa9147c96b297533336fa7079ecf972cb86c09ccdd6bddedb25711
+            value: quay.io/konflux-ci/tekton-catalog/task-source-build-oci-ta:0.3@sha256:d8115c74aed42fe9b1b3df149c534ced09f33c7bc6e51449bcaf8ec50699b8a0
 
           - name: kind
             value: task

--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -21,16 +21,6 @@ metadata:
   name: rhel-knowledge-bridge-on-pull-request
 
 spec:
-  taskRunSpecs:
-    - pipelineTaskName: build-images
-      computeResources:
-        requests:
-          cpu: "4"
-          memory: 8Gi
-        limits:
-          cpu: "4"
-          memory: 8Gi
-
   params:
     - name: git-url
       value: '{{ source_url }}'
@@ -45,14 +35,13 @@ spec:
       value: /Containerfile-source
 
     - name: hermetic
-      value: "false"
+      value: "true"
 
-    # Empty prefetch-input disables Cachi2/hermeto prefetch entirely. The
-    # prefetch-dependencies task keys off this input, not the hermetic flag, so
-    # leaving it populated would still stamp hermeto:pip:package:binary=true
-    # into the SBOM and trip Conforma's disallowed_package_attributes rule.
+    # Hermeto prefetch: pip sdists (no binary field = no binary SBOM annotations)
+    # plus the build-toolchain RPMs (rpms.lock.yaml). hermetic builds compile
+    # every wheel from source, so the network is fully isolated.
     - name: prefetch-input
-      value: ""
+      value: '[{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build-all.txt", ".konflux/requirements-build-pypi.txt"]}, {"type": "rpm", "path": "."}]'
 
     - name: image-expires-after
       value: 5d

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -26,16 +26,6 @@ metadata:
   name: rhel-knowledge-bridge-on-push
 
 spec:
-  taskRunSpecs:
-    - pipelineTaskName: build-images
-      computeResources:
-        requests:
-          cpu: "4"
-          memory: 8Gi
-        limits:
-          cpu: "4"
-          memory: 8Gi
-
   params:
     - name: git-url
       value: '{{ source_url }}'
@@ -50,14 +40,13 @@ spec:
       value: /Containerfile-source
 
     - name: hermetic
-      value: "false"
+      value: "true"
 
-    # Empty prefetch-input disables Cachi2/hermeto prefetch entirely. The
-    # prefetch-dependencies task keys off this input, not the hermetic flag, so
-    # leaving it populated would still stamp hermeto:pip:package:binary=true
-    # into the SBOM and trip Conforma's disallowed_package_attributes rule.
+    # Hermeto prefetch: pip sdists (no binary field = no binary SBOM annotations)
+    # plus the build-toolchain RPMs (rpms.lock.yaml). hermetic builds compile
+    # every wheel from source, so the network is fully isolated.
     - name: prefetch-input
-      value: ""
+      value: '[{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build-all.txt", ".konflux/requirements-build-pypi.txt"]}, {"type": "rpm", "path": "."}]'
 
     - name: additional-tags
       value:

--- a/Containerfile
+++ b/Containerfile
@@ -1,13 +1,14 @@
-# Stage 1: Builder - Red Hat Hardened Image (Project Hummingbird) with shell + dnf.
-# Pinned to a digest for reproducibility; resolves to Python 3.12.13.
-FROM registry.access.redhat.com/hi/python:3.12-builder@sha256:3d37bf07a9b663ac561e94dab30d771d0cb4a1dffbcd6aa4785af1d9b6bc5848 AS builder
+# Stage 1: Builder - UBI 10 base image with shell + dnf.
+# Pinned to a digest for reproducibility.
+FROM registry.access.redhat.com/ubi10/ubi:latest@sha256:516ef28e78e388d12e31618326da68e21dcfc40f767f0c37c3b57059c642a4f0 AS builder
 
-# Build entirely as the image's non-root user (UID 65532). HOME is owned by that
-# user, so no root escalation is needed. The whole app venv is copied into the
-# distroless runtime stage.
-ENV VENVS=${HOME}/.venvs
-ENV PATH=${VENVS}/tools/bin:${PATH}
-ENV UV_PROJECT=${HOME}/build
+# Install Python 3.12 and pip. The UBI base image has dnf but no Python.
+RUN dnf install -y python3.12 python3.12-pip && dnf clean all
+
+# Venv path uses the runtime image's HOME (/opt/app-root/src) so console-script
+# shebangs (which bake an absolute interpreter path) stay valid across stages.
+ENV VENVS=/opt/app-root/src/.venvs
+ENV UV_PROJECT=/build
 ENV UV_PROJECT_ENVIRONMENT=${VENVS}/okp-mcp
 ENV UV_PYTHON=/usr/bin/python3
 
@@ -26,8 +27,8 @@ WORKDIR ${UV_PROJECT}
 # BUILD_FROM_SOURCE is unset here → uses prebuilt manylinux wheels (fast).
 RUN scripts/container-install.sh
 
-# Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).
-FROM registry.access.redhat.com/hi/python:3.12@sha256:227cd08bc68a2fb2d79ed21d198c5dad0d130238feb4088881670296902c2754 AS runtime
+# Stage 2: Runtime - UBI 10 Python 3.12 Minimal (has shell, microdnf, python3.12).
+FROM registry.access.redhat.com/ubi10/python-312-minimal:latest@sha256:c060604f820e6aed184f2b61aeed8faddb5c60344b2cf6e4c6e4e478196d729e AS runtime
 
 LABEL com.redhat.component=okp-mcp
 LABEL description="MCP server for the RHEL Offline Knowledge Portal"
@@ -36,17 +37,15 @@ LABEL summary="OKP MCP Server"
 LABEL vendor="Red Hat, Inc."
 
 # Copy the dependency venv from the builder stage. It keeps the SAME path it was
-# created at in the builder, so console-script shebangs (which bake an absolute
-# interpreter path) stay valid without rewriting. All runtime dependencies are
-# pure Python (no C/C++ extensions), so the distroless image needs no extra
-# shared libraries.
-COPY --from=builder ${HOME}/.venvs/okp-mcp ${HOME}/.venvs/okp-mcp
+# created at in the builder, so console-script shebangs stay valid without
+# rewriting.
+COPY --from=builder /opt/app-root/src/.venvs/okp-mcp /opt/app-root/src/.venvs/okp-mcp
 
 # License required by Red Hat preflight certification.
 COPY LICENSE /licenses/LICENSE
 
 # Put the venv on PATH so its console scripts and interpreter resolve first.
-ENV PATH=${HOME}/.venvs/okp-mcp/bin:${PATH}
+ENV PATH=/opt/app-root/src/.venvs/okp-mcp/bin:${PATH}
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
@@ -65,13 +64,12 @@ ENV MCP_PORT=8000
 
 EXPOSE 8000
 
-# Distroless-safe liveness probe (no shell required): exec-form TCP connect to
-# the listening port using the venv interpreter.
+# Liveness probe: exec-form TCP connect to the listening port.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["python", "-c", "import os,socket,sys; p=int(os.getenv('MCP_PORT','8000')); s=socket.socket(); s.settimeout(3); sys.exit(0 if s.connect_ex(('127.0.0.1', p)) == 0 else 1)"]
 
-# Run as the image's non-root user (UID 65532).
-USER 65532
+# Run as the image's non-root user (UID 1001).
+USER 1001
 
 # Relative path: the runtime resolves this against PATH via execvp.
 ENTRYPOINT ["okp-mcp"]

--- a/Containerfile-source
+++ b/Containerfile-source
@@ -1,35 +1,29 @@
-# Stage 1: Builder - Red Hat Hardened Image (Project Hummingbird) with shell + dnf.
-# Pinned to a digest for reproducibility; resolves to Python 3.12.13.
-FROM registry.access.redhat.com/hi/python:3.12-builder@sha256:3d37bf07a9b663ac561e94dab30d771d0cb4a1dffbcd6aa4785af1d9b6bc5848 AS builder
+# Stage 1: Builder - UBI 10 base image with shell + dnf.
+# Pinned to a digest for reproducibility.
+FROM registry.access.redhat.com/ubi10/ubi:latest@sha256:516ef28e78e388d12e31618326da68e21dcfc40f767f0c37c3b57059c642a4f0 AS builder
 
-# Build entirely as the image's non-root user (UID 65532). HOME is owned by that
-# user, so no root escalation is needed. The whole app venv is copied into the
-# distroless runtime stage.
-ENV VENVS=${HOME}/.venvs
-ENV PATH=${VENVS}/tools/bin:${PATH}
-ENV UV_PROJECT=${HOME}/build
+# Venv path uses the runtime image's HOME (/opt/app-root/src) so console-script
+# shebangs (which bake an absolute interpreter path) stay valid across stages.
+ENV VENVS=/opt/app-root/src/.venvs
+ENV UV_PROJECT=/build
 ENV UV_PROJECT_ENVIRONMENT=${VENVS}/okp-mcp
 ENV UV_PYTHON=/usr/bin/python3
 
 # Copy dependency files first for layer caching. .konflux holds the
-# hash-pinned manifests Cachi2 prefetches for hermetic builds; they are
-# generated from uv.lock by scripts/konflux_requirements.sh.
-COPY pyproject.toml uv.lock README.md ${UV_PROJECT}/
+# hash-pinned Python manifests Hermeto prefetches for hermetic builds; they are
+# generated from uv.lock by scripts/konflux_requirements.sh. rpms.lock.yaml
+# pins the build-toolchain RPMs Hermeto prefetches (see rpms.in.yaml).
+COPY pyproject.toml uv.lock README.md rpms.lock.yaml ${UV_PROJECT}/
 COPY .konflux/ ${UV_PROJECT}/.konflux/
 COPY src/ ${UV_PROJECT}/src/
-COPY --chmod=0755 scripts/container-install.sh ${UV_PROJECT}/scripts/
+COPY --chmod=0755 scripts/ ${UV_PROJECT}/scripts/
 
 WORKDIR ${UV_PROJECT}
 
 # Product Security requirement: build all wheels from source instead of manylinux.
-# Requires root to install C/Rust toolchains before dropping back to non-root.
-USER root
-RUN <<EORUN
-set -euo pipefail
-dnf install -y gcc gcc-c++ python3.12-devel openssl-devel rust cargo pkg-config libffi-devel
-dnf clean all
-EORUN
-USER 65532
+# Install Python 3.12 + pip and the C/Rust build toolchain.
+# See scripts/install-toolchain.sh for hermetic repo handling and package list.
+RUN scripts/install-toolchain.sh
 
 # Install dependencies via the shared build script.
 # See scripts/container-install.sh for detailed comments on each step.
@@ -37,8 +31,8 @@ USER 65532
 ENV BUILD_FROM_SOURCE=1
 RUN scripts/container-install.sh
 
-# Stage 2: Runtime - distroless Red Hat Hardened Image (no shell, no package manager).
-FROM registry.access.redhat.com/hi/python:3.12@sha256:227cd08bc68a2fb2d79ed21d198c5dad0d130238feb4088881670296902c2754 AS runtime
+# Stage 2: Runtime - UBI 10 Python 3.12 Minimal (has shell, microdnf, python3.12).
+FROM registry.access.redhat.com/ubi10/python-312-minimal:latest@sha256:c060604f820e6aed184f2b61aeed8faddb5c60344b2cf6e4c6e4e478196d729e AS runtime
 
 LABEL com.redhat.component=okp-mcp
 LABEL description="MCP server for the RHEL Offline Knowledge Portal"
@@ -47,17 +41,15 @@ LABEL summary="OKP MCP Server"
 LABEL vendor="Red Hat, Inc."
 
 # Copy the dependency venv from the builder stage. It keeps the SAME path it was
-# created at in the builder, so console-script shebangs (which bake an absolute
-# interpreter path) stay valid without rewriting. All runtime dependencies are
-# pure Python (no C/C++ extensions), so the distroless image needs no extra
-# shared libraries.
-COPY --from=builder ${HOME}/.venvs/okp-mcp ${HOME}/.venvs/okp-mcp
+# created at in the builder, so console-script shebangs stay valid without
+# rewriting.
+COPY --from=builder /opt/app-root/src/.venvs/okp-mcp /opt/app-root/src/.venvs/okp-mcp
 
 # License required by Red Hat preflight certification.
 COPY LICENSE /licenses/LICENSE
 
 # Put the venv on PATH so its console scripts and interpreter resolve first.
-ENV PATH=${HOME}/.venvs/okp-mcp/bin:${PATH}
+ENV PATH=/opt/app-root/src/.venvs/okp-mcp/bin:${PATH}
 ENV PYTHONUNBUFFERED=1
 ENV PYTHONDONTWRITEBYTECODE=1
 
@@ -76,13 +68,12 @@ ENV MCP_PORT=8000
 
 EXPOSE 8000
 
-# Distroless-safe liveness probe (no shell required): exec-form TCP connect to
-# the listening port using the venv interpreter.
+# Liveness probe: exec-form TCP connect to the listening port.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
   CMD ["python", "-c", "import os,socket,sys; p=int(os.getenv('MCP_PORT','8000')); s=socket.socket(); s.settimeout(3); sys.exit(0 if s.connect_ex(('127.0.0.1', p)) == 0 else 1)"]
 
-# Run as the image's non-root user (UID 65532).
-USER 65532
+# Run as the image's non-root user (UID 1001).
+USER 1001
 
 # Relative path: the runtime resolves this against PATH via execvp.
 ENTRYPOINT ["okp-mcp"]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fix lint format typecheck radon test ci setup konflux-requirements check-konflux-requirements
+.PHONY: fix lint format typecheck radon test ci setup konflux-requirements check-konflux-requirements rpm-lock hermeto-prefetch hermeto-clean
 
 fix:
 	uv run --locked ruff check --fix
@@ -39,3 +39,32 @@ check-konflux-requirements:
 setup:
 	uv sync --locked --group dev
 	pre-commit install
+
+# Run Hermeto locally to validate sdist-only prefetch (no binary annotations).
+# Requires podman. Output lands in .hermeto-out/ (gitignored).
+# The extra GIT_COMMON_DIR mount handles git worktrees: .git is a file pointing
+# to the main repo, so Hermeto needs both paths visible inside the container.
+HERMETO_IMAGE ?= ghcr.io/hermetoproject/hermeto:0.56.0
+hermeto-prefetch:
+	GIT_COMMON=$$(cd "$$(git rev-parse --git-common-dir)" && pwd -P) && \
+	podman run --rm \
+	  -v "$$(pwd):$$(pwd):z" \
+	  -v "$$GIT_COMMON:$$GIT_COMMON:z" \
+	  -w "$$(pwd)" \
+	  $(HERMETO_IMAGE) fetch-deps \
+	  --source . --output ./.hermeto-out \
+	  '[{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build-all.txt", ".konflux/requirements-build-pypi.txt"]}, {"type": "rpm", "path": "."}]'
+
+hermeto-clean:
+	rm -rf .hermeto-out/
+
+# Regenerate rpms.lock.yaml from rpms.in.yaml against the Containerfile-source
+# builder image. Resolves the build-toolchain RPM tree for every target arch so
+# Hermeto can prefetch them for hermetic builds. Requires podman; the builder
+# digest is read straight from Containerfile-source to avoid duplication.
+# RLP_IMAGE defaults to the Konflux tool image (needs `podman login quay.io`).
+RLP_IMAGE ?= quay.io/konflux-ci/rpm-lockfile-prototype:latest
+rpm-lock:
+	BUILDER=$$(grep -oE 'registry.access.redhat.com/ubi10/ubi:[^@]+@sha256:[a-f0-9]+' Containerfile-source | head -1) && \
+	podman run --rm -v "$$(pwd):/work:z" -w /work \
+	  $(RLP_IMAGE) --image "$$BUILDER" rpms.in.yaml

--- a/rpms.in.yaml
+++ b/rpms.in.yaml
@@ -1,0 +1,29 @@
+# Build-toolchain RPMs prefetched by Hermeto for hermetic Konflux builds.
+# Containerfile-source compiles all Python wheels from source, which needs a
+# C/Rust toolchain that the UBI 10 base image does not ship. In hermetic mode
+# every RUN is network-isolated, so these RPMs must be prefetched.
+# Regenerate rpms.lock.yaml after editing this file:
+#   make rpm-lock
+packages:
+  - python3.12
+  - python3.12-pip
+  - python3-devel
+  - gcc
+  - gcc-c++
+  - openssl-devel
+  - rust
+  - cargo
+  - pkgconf
+  - libffi-devel
+contentOrigin:
+  repos:
+    - repoid: ubi-10-for-x86_64-baseos-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/baseos/os
+    - repoid: ubi-10-for-x86_64-appstream-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/appstream/os
+    - repoid: codeready-builder-for-ubi-10-x86_64-rpms
+      baseurl: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/$basearch/codeready-builder/os
+arches:
+  - x86_64
+  - aarch64
+installWeakDeps: false

--- a/rpms.lock.yaml
+++ b/rpms.lock.yaml
@@ -1,0 +1,428 @@
+---
+lockfileVersion: 1
+lockfileVendor: redhat
+arches:
+- arch: aarch64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/b/binutils-2.41-63.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 7014844
+    checksum: sha256:2769d9fcb49b432600267e90437889cfa2aeb1ed31179c550bf108a699405ea6
+    name: binutils
+    evr: 2.41-63.el10
+    sourcerpm: binutils-2.41-63.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/b/binutils-gold-2.41-63.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 965271
+    checksum: sha256:2216002e9e74611aaf021a616b92ac6e6138aefa8b09b2098332e43b3b3b554a
+    name: binutils-gold
+    evr: 2.41-63.el10
+    sourcerpm: binutils-2.41-63.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/c/cargo-1.92.0-1.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 7843176
+    checksum: sha256:39e51197af1e102c06220cb0334dfe585e3f6a46b487594a21cdfda28f07e581
+    name: cargo
+    evr: 1.92.0-1.el10
+    sourcerpm: rust-1.92.0-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/c/cpp-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 11968594
+    checksum: sha256:0134a1bd44610567f30d074ecc97c14bab45e238b25177991ca302873c9fe21a
+    name: cpp
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-2.el10_2.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 50064
+    checksum: sha256:a2d93995a8810dd8fa5c5cf6926eae02f104a3d6d99a0a7c73902d1584e70569
+    name: elfutils-debuginfod-client
+    evr: 0.194-2.el10_2
+    sourcerpm: elfutils-0.194-2.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/g/gcc-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 36222528
+    checksum: sha256:e78b091cd235ee71a243ac54f8605b7a5e817c7284ddc4beea2792825341b896
+    name: gcc
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/g/gcc-c++-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 14297077
+    checksum: sha256:b1173e9d148434d42a167c7ea5a7d71198e09db5087bd678442ce940666766e6
+    name: gcc-c++
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/g/glibc-devel-2.39-124.el10_2.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 596601
+    checksum: sha256:8a3db786bb0725f4821f142917a277c80a17d7555a4f0ce4621c966994771752
+    name: glibc-devel
+    evr: 2.39-124.el10_2
+    sourcerpm: glibc-2.39-124.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/j/jansson-2.14-3.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 50745
+    checksum: sha256:c086696b0319fe183481eeb8a8f61679fe538f14e78fe83b9bb7995095f9d701
+    name: jansson
+    evr: 2.14-3.el10
+    sourcerpm: jansson-2.14-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/k/kernel-headers-6.12.0-211.28.1.el10_2.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 3626469
+    checksum: sha256:ae76e254f13b4f45e626ff9c63a0c58723b551be750bad4666ba69f4b59a1c93
+    name: kernel-headers
+    evr: 6.12.0-211.28.1.el10_2
+    sourcerpm: kernel-6.12.0-211.28.1.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/libasan-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 543502
+    checksum: sha256:f4cf89957e639ae03c2a2e2586ba7f32e4c29d8d9ca101b3c9fdb5fbc4fc4103
+    name: libasan
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/l/libatomic-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 58232
+    checksum: sha256:59cb227257420e69536897631f060c29e465ed41374888709f73d5639d97a0bd
+    name: libatomic
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/l/libedit-3.1-52.20230828cvs.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 111166
+    checksum: sha256:edede3ee0501345f472dbca12e9f1fdec315dcf023ee9de175ae046820013067
+    name: libedit
+    evr: 3.1-52.20230828cvs.el10
+    sourcerpm: libedit-3.1-52.20230828cvs.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/libffi-devel-3.4.4-10.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 28871
+    checksum: sha256:8ebc289a32a591d8a283a5fe61e07f549183c9a5898654cb0d3a68ad0a758cd5
+    name: libffi-devel
+    evr: 3.4.4-10.el10
+    sourcerpm: libffi-3.4.4-10.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/libmpc-1.3.1-7.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 77469
+    checksum: sha256:9fb353bc4d020f1a1634aceab84c4889c1193aad607c3eb603bc5bb02127556e
+    name: libmpc
+    evr: 1.3.1-7.el10
+    sourcerpm: libmpc-1.3.1-7.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/l/libpkgconf-2.1.0-3.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 41845
+    checksum: sha256:2908c348489009174b1a4b2fbccd40abad6a5f20635e3bd481abd0da9d585f14
+    name: libpkgconf
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/libstdc++-devel-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 2974501
+    checksum: sha256:387a6634a5b3424858b4dbe193ab33c018773959b06e83faf3f162ac5d844732
+    name: libstdc++-devel
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/libubsan-14.3.1-4.4.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 243121
+    checksum: sha256:39a93a800b0e9dd81ff3592e8570a1834e628b0fc141c4c6aeb7db1ec9ecb428
+    name: libubsan
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/libxcrypt-devel-4.4.36-10.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 34008
+    checksum: sha256:7244a65268c3523d00b24ab0f4b99f97bf7876a569ba773791ca0dc6d4d02d79
+    name: libxcrypt-devel
+    evr: 4.4.36-10.el10
+    sourcerpm: libxcrypt-4.4.36-10.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/llvm-filesystem-21.1.8-1.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 20021
+    checksum: sha256:f5ef6de695515c905228a543b80f47500061497ccb723fbb1c91a851fe301e30
+    name: llvm-filesystem
+    evr: 21.1.8-1.el10
+    sourcerpm: llvm-21.1.8-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/l/llvm-libs-21.1.8-1.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 30752847
+    checksum: sha256:96c2c5e02f37eb3e2dc3e478cfeb10319633a3c4e973f5356c0ddee4f796291c
+    name: llvm-libs
+    evr: 21.1.8-1.el10
+    sourcerpm: llvm-21.1.8-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/m/make-4.4.1-9.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 602747
+    checksum: sha256:c769abf96f39bf5c24a47f21191ecfc01bddca35203e8798da6adfb94fb45981
+    name: make
+    evr: 4.4.1-9.el10
+    sourcerpm: make-4.4.1-9.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/o/openssl-devel-3.5.5-4.el10_2.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 4405532
+    checksum: sha256:320ea322d2199b599342b1e7b2857e11fe67ca533cc37e6266edd190f3498cc4
+    name: openssl-devel
+    evr: 3.5.5-4.el10_2
+    sourcerpm: openssl-3.5.5-4.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/p/pkgconf-2.1.0-3.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 49088
+    checksum: sha256:0ead3befa3f846feaccf78813a7cd0858e81b0de8b658ea7a6aef69ec40bc337
+    name: pkgconf
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/p/pkgconf-m4-2.1.0-3.el10.noarch.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 15861
+    checksum: sha256:f6a99c6e64b9358a0b4db60e4fb2b5c858eb0487a504690e80d1b84b9d044995
+    name: pkgconf-m4
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/baseos/os/Packages/p/pkgconf-pkg-config-2.1.0-3.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-baseos-rpms
+    size: 12181
+    checksum: sha256:e3fdfa8044e29a44285760db8e765c0d726468bdcb11c9097f3f07a5e14c7749
+    name: pkgconf-pkg-config
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/p/python3-devel-3.12.13-2.el10_2.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 344518
+    checksum: sha256:538425324ab7a41015e3436e175c8cf124000f7c9eb36077f1612fd31a8c2119
+    name: python3-devel
+    evr: 3.12.13-2.el10_2
+    sourcerpm: python3.12-3.12.13-2.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/p/python3-pip-23.3.2-11.el10_2.noarch.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 3397397
+    checksum: sha256:9ec169d6dbee7913aed17a167c46d72106299b3311c21f4f6408cc8d3404b026
+    name: python3-pip
+    evr: 23.3.2-11.el10_2
+    sourcerpm: python-pip-23.3.2-11.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/r/rust-1.92.0-1.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 29429656
+    checksum: sha256:0ed38bf2664ab7487a08cb2a6629412135c8129f20bbe52894aa3320a64c4863
+    name: rust
+    evr: 1.92.0-1.el10
+    sourcerpm: rust-1.92.0-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/aarch64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el10.aarch64.rpm
+    repoid: ubi-10-for-aarch64-appstream-rpms
+    size: 41505497
+    checksum: sha256:05a14a8e02e117a55d4e284ca6421f3c9f07dcdf480f8eec4db75802b3b32b3b
+    name: rust-std-static
+    evr: 1.92.0-1.el10
+    sourcerpm: rust-1.92.0-1.el10.src.rpm
+- arch: x86_64
+  packages:
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/b/binutils-2.41-63.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 6713167
+    checksum: sha256:6c9a5b31e855a216845858b4c642f67fe31cfd3dff5aa5d63e8ecff963904c0c
+    name: binutils
+    evr: 2.41-63.el10
+    sourcerpm: binutils-2.41-63.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/b/binutils-gold-2.41-63.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 820424
+    checksum: sha256:da272acde4bce4b8421c3b5ac9940f0bd8a9f3d88176769e05687d59ce700552
+    name: binutils-gold
+    evr: 2.41-63.el10
+    sourcerpm: binutils-2.41-63.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/c/cargo-1.92.0-1.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 8426261
+    checksum: sha256:28c9e31b3cb704763452eeae51ecbaaa5ca5e2184f6e049df1da147b6ef11dbf
+    name: cargo
+    evr: 1.92.0-1.el10
+    sourcerpm: rust-1.92.0-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/c/cpp-14.3.1-4.4.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 13449388
+    checksum: sha256:52a30ef8bfce05a3a5417f19eb141c566c33d17891c23af93d29b2744104ed7c
+    name: cpp
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/e/elfutils-debuginfod-client-0.194-2.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 50760
+    checksum: sha256:41d8283ea8b643836aa1885a79c55919885d2009bdf31d81b35c179877d9a483
+    name: elfutils-debuginfod-client
+    evr: 0.194-2.el10_2
+    sourcerpm: elfutils-0.194-2.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/g/gcc-14.3.1-4.4.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 39854147
+    checksum: sha256:ccba654a3d240e2a3a3c4a1c3c2f8b1adb841db4f69879c823613735476765d1
+    name: gcc
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/g/gcc-c++-14.3.1-4.4.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 15868182
+    checksum: sha256:e3fc0557ea59a1de4f3eeb2533dfd1be44275133ba363c796a6f55c2f81c4cc0
+    name: gcc-c++
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/g/glibc-2.39-126.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 2207034
+    checksum: sha256:758caa64942e66d9c902cf574a2d681271d9b5acf7ab9d4762e41f961ad4987e
+    name: glibc
+    evr: 2.39-126.el10_2
+    sourcerpm: glibc-2.39-126.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/g/glibc-common-2.39-126.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 333367
+    checksum: sha256:b8c5d31097662a733ea36443b4ba474717cbac0a402781620b0d4ab400dc8bc6
+    name: glibc-common
+    evr: 2.39-126.el10_2
+    sourcerpm: glibc-2.39-126.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/g/glibc-devel-2.39-126.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 604263
+    checksum: sha256:b605f67bd7fa18826e2ee552ff41c8116f9ac35feaacf25e749b6e6f85d629b2
+    name: glibc-devel
+    evr: 2.39-126.el10_2
+    sourcerpm: glibc-2.39-126.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/g/glibc-langpack-en-2.39-126.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 686586
+    checksum: sha256:eb7eac1e6c2da295d694f5b2ade193ce14ced5a841d36fc6b6a6f8412165be76
+    name: glibc-langpack-en
+    evr: 2.39-126.el10_2
+    sourcerpm: glibc-2.39-126.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/j/jansson-2.14-3.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 49616
+    checksum: sha256:b5d6eeea14961f64ece8b3bbefeb53a61424822ccbaedb833f7fc7e50f6707c5
+    name: jansson
+    evr: 2.14-3.el10
+    sourcerpm: jansson-2.14-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/k/kernel-headers-6.12.0-211.28.1.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 3664637
+    checksum: sha256:8d5b4531b5a56ab85aaa53ac59adc62b7447b398e631bd5d58c09afdf71b49a6
+    name: kernel-headers
+    evr: 6.12.0-211.28.1.el10_2
+    sourcerpm: kernel-6.12.0-211.28.1.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/l/libedit-3.1-52.20230828cvs.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 110822
+    checksum: sha256:d984e5aa4856820528bd2829f086c2f3883173b91daa0a304af215e3a0c6a6be
+    name: libedit
+    evr: 3.1-52.20230828cvs.el10
+    sourcerpm: libedit-3.1-52.20230828cvs.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/l/libffi-devel-3.4.4-10.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 29841
+    checksum: sha256:1adc20d5289e871e92d6e5b3660bc2ca1dc4325fa2077fa3796395db01c3bd8a
+    name: libffi-devel
+    evr: 3.4.4-10.el10
+    sourcerpm: libffi-3.4.4-10.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/l/libmpc-1.3.1-7.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 75330
+    checksum: sha256:0ffe6cc4aa8936e1ed0d807c8bb059a864aa5cb687cde85f211f3d050a45a1a2
+    name: libmpc
+    evr: 1.3.1-7.el10
+    sourcerpm: libmpc-1.3.1-7.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/l/libpkgconf-2.1.0-3.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 41667
+    checksum: sha256:3c771e6212564874eb7e6200f22cb2e05265e7319984590c0f4de3eb5733b75f
+    name: libpkgconf
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/l/libstdc++-devel-14.3.1-4.4.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 2985327
+    checksum: sha256:5614ba091b6beb17d309b2ebd914b50e093b903abcbf121d033a885df6edd3bc
+    name: libstdc++-devel
+    evr: 14.3.1-4.4.el10
+    sourcerpm: gcc-14.3.1-4.4.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/l/libxcrypt-devel-4.4.36-10.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 34028
+    checksum: sha256:5e98ac0095da4e23b8a7b0dfc8d6fc97b0fa0d6c5d7bb0d70fe1dbf97ae64eb6
+    name: libxcrypt-devel
+    evr: 4.4.36-10.el10
+    sourcerpm: libxcrypt-4.4.36-10.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/l/llvm-filesystem-21.1.8-1.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 20065
+    checksum: sha256:266827c40fe683f62a32c6aabddf8752c70bf97cdfd15b091f78362fd1351dcf
+    name: llvm-filesystem
+    evr: 21.1.8-1.el10
+    sourcerpm: llvm-21.1.8-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/l/llvm-libs-21.1.8-1.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 32089714
+    checksum: sha256:552a89a0b1cece21ad2a2dd315383dabc043ff53d11bf1c9bc361989e3877697
+    name: llvm-libs
+    evr: 21.1.8-1.el10
+    sourcerpm: llvm-21.1.8-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/m/make-4.4.1-9.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 605276
+    checksum: sha256:1c7b61c065106c0eb3a958e55ffbe37734aebcf440b0c36435ca7eb41b8e0110
+    name: make
+    evr: 4.4.1-9.el10
+    sourcerpm: make-4.4.1-9.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/o/openssl-devel-3.5.5-4.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 4405852
+    checksum: sha256:fc196a4a2f690b0132754ec06d8b5b20f604d9966a622e738153c1dbfa3a43da
+    name: openssl-devel
+    evr: 3.5.5-4.el10_2
+    sourcerpm: openssl-3.5.5-4.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/p/pkgconf-2.1.0-3.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 49544
+    checksum: sha256:63c965654dfd260d755bd36bdb19ced0036aa4c1e2b64d726c95fad98b2dc041
+    name: pkgconf
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/p/pkgconf-m4-2.1.0-3.el10.noarch.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 15861
+    checksum: sha256:f6a99c6e64b9358a0b4db60e4fb2b5c858eb0487a504690e80d1b84b9d044995
+    name: pkgconf-m4
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/baseos/os/Packages/p/pkgconf-pkg-config-2.1.0-3.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-baseos-rpms
+    size: 12216
+    checksum: sha256:b90a31630640ca9a05ba842032ccbe7ae786318bb808ffb49f252acdb1419235
+    name: pkgconf-pkg-config
+    evr: 2.1.0-3.el10
+    sourcerpm: pkgconf-2.1.0-3.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/p/python3-devel-3.12.13-2.el10_2.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 344493
+    checksum: sha256:95ee2f1e333bc2ea08b3b98a7365b5b0abd0fa1cd43478f8c36c8af7eba113d4
+    name: python3-devel
+    evr: 3.12.13-2.el10_2
+    sourcerpm: python3.12-3.12.13-2.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/p/python3-pip-23.3.2-11.el10_2.noarch.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 3397397
+    checksum: sha256:9ec169d6dbee7913aed17a167c46d72106299b3311c21f4f6408cc8d3404b026
+    name: python3-pip
+    evr: 23.3.2-11.el10_2
+    sourcerpm: python-pip-23.3.2-11.el10_2.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/r/rust-1.92.0-1.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 31576709
+    checksum: sha256:c6f8e920b093999a87e550bb7ee667f8e2e3cb7f79f2aa184908ae64036d12a7
+    name: rust
+    evr: 1.92.0-1.el10
+    sourcerpm: rust-1.92.0-1.el10.src.rpm
+  - url: https://cdn-ubi.redhat.com/content/public/ubi/dist/ubi10/10/x86_64/appstream/os/Packages/r/rust-std-static-1.92.0-1.el10.x86_64.rpm
+    repoid: ubi-10-for-x86_64-appstream-rpms
+    size: 42988494
+    checksum: sha256:f1f01e324bfe36df0bbb5f8937462bc92fa617971836d0871f54f159c568c881
+    name: rust-std-static
+    evr: 1.92.0-1.el10
+    sourcerpm: rust-1.92.0-1.el10.src.rpm

--- a/scripts/container-install.sh
+++ b/scripts/container-install.sh
@@ -4,6 +4,14 @@
 # Shared by Containerfile (prebuilt wheels) and Containerfile-source (from-source).
 # The only behavioral difference is controlled by BUILD_FROM_SOURCE (see below).
 #
+# pip is used throughout — no uv. uv ships no RPM and cannot be fetched in a
+# hermetic Konflux build (network off, not in the offline mirror), so relying on
+# it forces a fragile "hermetic vs local" branch. A single pip path works in both
+# environments: in hermetic builds the prefetch task sets PIP_FIND_LINKS /
+# PIP_NO_INDEX and provides an offline mirror; local builds resolve from PyPI.
+# Either way the deps come from the hash-pinned .konflux manifests, which are
+# generated from uv.lock by scripts/konflux_requirements.sh.
+#
 # Required environment variables (set via Containerfile ENV):
 #   VENVS                    — base directory for virtual environments
 #   UV_PROJECT_ENVIRONMENT   — path to the application venv
@@ -11,7 +19,7 @@
 #
 # Optional:
 #   BUILD_FROM_SOURCE        — set to "1" to compile all wheels from source
-#                              (passes --no-binary to pip/uv instead of --only-binary)
+#                              (passes --no-binary to pip instead of --only-binary)
 set -euo pipefail
 
 # --- Determine pip binary-handling flags ---
@@ -19,65 +27,60 @@ set -euo pipefail
 # From-source builds use --no-binary=:all: (compiles every C/Rust extension).
 if [ "${BUILD_FROM_SOURCE:-0}" = "1" ]; then
     PIP_BINARY_FLAG="--no-binary=:all:"
-    UV_BINARY_FLAG="--no-binary"
     export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
     export MAX_JOBS="$(nproc)"
     export CARGO_BUILD_JOBS="$(nproc)"
     export MAKEFLAGS="-j$(nproc)"
 else
     PIP_BINARY_FLAG="--only-binary=:all:"
-    UV_BINARY_FLAG=""
 fi
 
+# Hermetic Konflux builds set PIP_FIND_LINKS / PIP_NO_INDEX in the build
+# environment so pip resolves from the prefetched offline mirror. Some prefetch
+# layouts also ship cachi2.env as a file; source it when present (harmless
+# otherwise). Local builds have neither and resolve from PyPI.
 if [ -f /cachi2/cachi2.env ]; then
-    # --- Hermetic Konflux build (Cachi2 present) ---
-    # Network is disabled. Cachi2 has prefetched every dependency into an offline
-    # mirror and written PIP_FIND_LINKS + PIP_NO_INDEX into cachi2.env.
-
-    # Source the Cachi2 environment so pip resolves packages from the offline mirror.
     # shellcheck source=/dev/null
     . /cachi2/cachi2.env
+fi
 
-    # 1. Throwaway build venv: install the hatchling build backend so we can
-    #    build the okp_mcp wheel without network access. This venv is never
-    #    copied to the runtime stage.
-    python3 -m venv "${VENVS}/build"
+# 1. Throwaway build venv: install the hatchling build backend so the okp_mcp
+#    wheel can be built without network access. This venv is never copied to
+#    the runtime stage.
+#
+#    From-source builds (BUILD_FROM_SOURCE=1) need the full transitive build
+#    dependency tree (every PEP 517 backend for every sdist: maturin,
+#    setuptools-rust, uv-build, etc.). Prebuilt-wheel builds only need
+#    hatchling — runtime deps install from manylinux wheels, not sdists.
+python3 -m venv "${VENVS}/build"
+if [ "${BUILD_FROM_SOURCE:-0}" = "1" ]; then
+    # Full build tree: every PEP 517 backend needed to compile every sdist
+    # (maturin, setuptools-rust, etc.). Split across three files because some
+    # packages are not available on the Konflux artifact proxy.
+    "${VENVS}/build/bin/pip" install --no-cache-dir "${PIP_BINARY_FLAG}" --require-hashes \
+        -r .konflux/requirements-build-all.txt \
+        -r .konflux/requirements-build-pypi.txt
+else
+    # Prebuilt-wheel path: only hatchling (our build backend) is needed.
+    # Runtime deps install from manylinux wheels, no sdist compilation.
     "${VENVS}/build/bin/pip" install --no-cache-dir "${PIP_BINARY_FLAG}" --require-hashes \
         -r .konflux/requirements-build.txt
-
-    # 2. Build the okp_mcp wheel from the local source tree.
-    #    --no-build-isolation: use the hatchling we just installed (no PyPI fetch).
-    #    --no-deps: the wheel has no bundled dependencies.
-    "${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
-
-    # 3. Application venv: install only the hash-pinned runtime dependencies.
-    python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
-    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir "${PIP_BINARY_FLAG}" --require-hashes \
-        -r .konflux/requirements.txt
-
-    # 4. Install the locally-built okp_mcp wheel into the app venv.
-    #    --no-deps --no-index: no PyPI, no transitive resolution — just the wheel.
-    "${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
-        --find-links "${HOME}/wheels" okp_mcp
-
-    # 5. Smoke-test: verify the package is importable before finishing the layer.
-    "${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"
-else
-    # --- Local / non-hermetic build ---
-    # Network available. Use uv for fast, locked dependency resolution.
-
-    # Install a pinned version of uv into a throwaway tools venv.
-    python3 -m venv "${VENVS}/tools"
-    "${VENVS}/tools/bin/python" -m pip install --no-cache-dir uv==0.11.14
-
-    # Use the explicit path so the script works regardless of PATH.
-    UV="${VENVS}/tools/bin/uv"
-
-    # Create the app venv with --seed (ships pip, matching the hermetic path's
-    # python -m venv behavior).
-    "${UV}" venv --seed "${UV_PROJECT_ENVIRONMENT}"
-
-    # Sync from uv.lock. --locked fails if the lock is stale.
-    # shellcheck disable=SC2086  # UV_BINARY_FLAG intentionally word-splits when non-empty
-    "${UV}" sync --locked --no-cache --no-dev --no-editable ${UV_BINARY_FLAG}
 fi
+
+# 2. Build the okp_mcp wheel from the local source tree.
+#    --no-build-isolation: use the hatchling we just installed (no extra fetch).
+#    --no-deps: the wheel has no bundled dependencies.
+"${VENVS}/build/bin/pip" wheel --no-cache-dir --no-build-isolation --no-deps . -w "${HOME}/wheels"
+
+# 3. Application venv: install only the hash-pinned runtime dependencies.
+python3 -m venv "${UV_PROJECT_ENVIRONMENT}"
+"${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir "${PIP_BINARY_FLAG}" --require-hashes \
+    -r .konflux/requirements.txt
+
+# 4. Install the locally-built okp_mcp wheel into the app venv.
+#    --no-deps --no-index: no PyPI, no transitive resolution — just the wheel.
+"${UV_PROJECT_ENVIRONMENT}/bin/pip" install --no-cache-dir --no-deps --no-index \
+    --find-links "${HOME}/wheels" okp_mcp
+
+# 5. Smoke-test: verify the package is importable before finishing the layer.
+"${UV_PROJECT_ENVIRONMENT}/bin/python" -c "import okp_mcp"

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# scripts/install-toolchain.sh — Install Python + C/Rust build toolchain for from-source builds.
+#
+# Used by Containerfile-source to compile all Python wheels from source instead
+# of manylinux prebuilt wheels (Product Security requirement).
+#
+# In hermetic Konflux builds the toolchain RPMs are prefetched by Hermeto
+# (rpms.in.yaml / rpms.lock.yaml) and Konflux injects a file:// repo into
+# /etc/yum.repos.d. The base image's repos point at network URLs that are
+# unreachable under --network none, so we detect the Hermeto-injected repo
+# and restrict dnf to it. Local non-hermetic builds keep the image's network
+# repos and resolve from the UBI CDN.
+#
+# --allowerasing is required because the UBI 10 base image ships
+# glibc-minimal-langpack which conflicts with glibc-devel's glibc dependency
+# when a newer glibc is available in the repo.
+set -euo pipefail
+
+dnf_args=(--allowerasing)
+
+if [ -f /cachi2/cachi2.env ]; then
+    # Find the Hermeto-injected repo (name varies); disable all others.
+    hermeto_repo=$(grep -lm1 'file:///cachi2' /etc/yum.repos.d/*.repo 2>/dev/null | head -1)
+    if [ -n "$hermeto_repo" ]; then
+        repo_id=$(grep -oP '(?<=\[)[^\]]+' "$hermeto_repo" | head -1)
+        dnf_args+=(--disablerepo='*' --enablerepo="$repo_id")
+    fi
+fi
+
+# NOTE: if you change this package list, update rpms.in.yaml too and run
+# `make rpm-lock` to regenerate rpms.lock.yaml for hermetic builds.
+dnf install -y "${dnf_args[@]}" \
+    python3.12 \
+    python3.12-pip \
+    python3-devel \
+    gcc \
+    gcc-c++ \
+    openssl-devel \
+    rust \
+    cargo \
+    pkgconf \
+    libffi-devel
+
+dnf clean all

--- a/scripts/konflux_requirements.sh
+++ b/scripts/konflux_requirements.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
-# Regenerate the Cachi2-consumable dependency manifests for hermetic Konflux builds.
+# Regenerate the Hermeto-consumable dependency manifests for hermetic Konflux builds.
 #
 # uv.lock stays the single source of truth. These manifests are generated
 # artifacts derived from it:
 #   .konflux/requirements.txt        runtime deps (hash-pinned, from uv.lock)
-#   .konflux/requirements-build.txt  build backend (hatchling, hash-pinned)
+#   .konflux/requirements-build.txt  transitive build deps (hash-pinned)
 #
-# The hermetic build (Cachi2 type:pip) prefetches these; the Containerfile
+# The hermetic build (Hermeto type:pip) prefetches these; the Containerfile
 # installs from the offline mirror. Local/dev builds still use `uv sync`.
 #
 # Run this whenever uv.lock or the build-system requirement changes, then
@@ -16,41 +16,18 @@ set -euo pipefail
 KONFLUX_DIR=".konflux"
 REQ_FILE="${KONFLUX_DIR}/requirements.txt"
 BUILD_FILE="${KONFLUX_DIR}/requirements-build.txt"
+BUILD_ALL_FILE="${KONFLUX_DIR}/requirements-build-all.txt"
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "${repo_root}"
 mkdir -p "${KONFLUX_DIR}"
-
-PYTHON_VERSION="$(grep -E '^FROM\s+.*python:[0-9]+\.[0-9]+' Containerfile | head -1 | grep -oE '[0-9]+\.[0-9]+')"
-if [ -z "${PYTHON_VERSION}" ]; then
-  echo "ERROR: could not extract Python version from Containerfile builder image" >&2
-  exit 1
-fi
-
-# Build-system requirement, parsed from pyproject.toml so it never drifts.
-# hatchling is a pure-Python backend; uv pip compile resolves it plus its build
-# deps (packaging, pathspec, pluggy, trove-classifiers) to hash-pinned wheels.
-# The hermetic build installs them wheel-only (--only-binary) into a throwaway
-# tools venv and builds the okp_mcp wheel with --no-build-isolation; none of
-# these reach the distroless runtime. hatchling's deps carry no win32-only
-# markers, so the Cachi2 prefetch enumerates the build manifest cleanly.
-if [[ ! -x $(command -v tomcli) ]]; then
-  echo "Unable to find tomcli. Please install it."
-  exit 1
-fi
-
-BUILD_REQUIRE="$(tomcli get -F newline-list pyproject.toml build-system.requires)"
-if [[ -z $BUILD_REQUIRE ]]; then
-  echo "ERROR: could not extract BUILD_REQUIRE from pyproject.toml build-system.requires" >&2
-  exit 1
-fi
 
 # Runtime deps: exported straight from uv.lock (hashes included, project itself
 # excluded). --frozen fails if uv.lock is stale, preserving the lock guarantee.
 #
 # --prune drops win32-only transitive deps (pywin32 via mcp, pywin32-ctypes via
 # keyring, colorama). uv export emits these with a `sys_platform == 'win32'`
-# marker, but Cachi2/hermeto prefetch enumerates every line and ignores markers,
+# marker, but Hermeto prefetch enumerates every line and ignores markers,
 # so it tries to fetch pywin32 for Linux, finds no distribution (Windows-only
 # wheels, no sdist), and fails the build. The runtime is always Linux/distroless,
 # so these packages are never installed anyway.
@@ -64,15 +41,61 @@ uv export \
   --prune pywin32-ctypes \
   -o "${REQ_FILE}"
 
-# Build backend: hash-pinned so the hermetic build can build the okp_mcp wheel
-# with --no-build-isolation against the prefetched mirror.
-echo "${BUILD_REQUIRE}" | uv pip compile - \
+# Build deps (hatchling only): just our own build backend and its transitive
+# deps. This is all the prebuilt-wheel Containerfile needs — runtime deps
+# install from manylinux wheels, no sdist compilation.
+echo 'hatchling' | uv pip compile --generate-hashes - 2>/dev/null \
+  | grep -vE '^(#|$)' > "${BUILD_FILE}"
+
+# Build deps (full tree): the full transitive build dependency tree for every
+# runtime dep plus our own build backend (hatchling). pybuild-deps reads
+# requirements.txt and pyproject.toml build-system.requires, resolves every
+# PEP 517 build backend needed to compile each sdist, and outputs a hash-pinned
+# manifest. This is used by Containerfile-source (BUILD_FROM_SOURCE=1) where
+# every wheel is compiled from source.
+#
+# pybuild-deps expects ~/.cache/pybuild-deps to exist; create it in case the
+# parent directory is missing (e.g. CI runners).
+mkdir -p "${HOME}/.cache/pybuild-deps"
+
+uvx pybuild-deps compile \
   --generate-hashes \
-  --python-version "${PYTHON_VERSION}" \
-  --no-annotate \
   --no-header \
-  -o "${BUILD_FILE}"
+  -o "${BUILD_ALL_FILE}" \
+  "${REQ_FILE}"
+
+# Pin uv-build to a version compatible with UBI 10's rustc (1.92). pybuild-deps
+# resolves the latest version, but uv-build >=0.11.8 requires rustc >=1.93 and
+# the from-source hermetic build compiles it from sdist. 0.11.7 is the newest
+# release with MSRV 1.92. py-key-value-aio accepts >=0.11.4,<0.12.
+awk '
+  /^uv-build==/ {
+    print "uv-build==0.11.7 \\"
+    print "    --hash=sha256:258e3a10929b5de79074078ba1ad8edbdd4db5d9c3cafba81f11b329eeaaca08"
+    skip = 1; next
+  }
+  skip && /^    --hash=/ { next }
+  skip { skip = 0 }
+  { print }
+' "${BUILD_ALL_FILE}" > "${BUILD_ALL_FILE}.tmp" && mv "${BUILD_ALL_FILE}.tmp" "${BUILD_ALL_FILE}"
+
+# Split out packages the Konflux artifact registry proxy cannot find.
+# These go into a separate file with --index-url pointing directly at PyPI.
+# Add new package names to PROXY_MISSING as failures are discovered.
+BUILD_PYPI_FILE="${KONFLUX_DIR}/requirements-build-pypi.txt"
+PROXY_MISSING="^(setuptools-rust|vcs-versioning)=="
+
+awk -v pattern="${PROXY_MISSING}" '
+  /^[a-zA-Z]/ { is_proxy = ($0 ~ pattern) }
+  { if (is_proxy) print > pypi; else print > keep }
+' pypi="${BUILD_PYPI_FILE}.tmp" keep="${BUILD_ALL_FILE}.tmp" "${BUILD_ALL_FILE}"
+
+mv "${BUILD_ALL_FILE}.tmp" "${BUILD_ALL_FILE}"
+{ echo '--index-url https://pypi.org/simple/'; echo; cat "${BUILD_PYPI_FILE}.tmp"; } > "${BUILD_PYPI_FILE}"
+rm -f "${BUILD_PYPI_FILE}.tmp"
 
 echo "Wrote ${REQ_FILE} ($(grep -c '^[a-zA-Z]' "${REQ_FILE}") packages)"
-echo "Wrote ${BUILD_FILE}"
-echo "Remember to commit both files."
+echo "Wrote ${BUILD_FILE} ($(grep -c '^[a-zA-Z]' "${BUILD_FILE}") packages, hatchling only)"
+echo "Wrote ${BUILD_ALL_FILE} ($(grep -c '^[a-zA-Z]' "${BUILD_ALL_FILE}") packages, full tree)"
+echo "Wrote ${BUILD_PYPI_FILE} ($(grep -c '^[a-zA-Z]' "${BUILD_PYPI_FILE}") packages, direct PyPI)"
+echo "Remember to commit all four files."


### PR DESCRIPTION
## What this does

- **UBI 10 base images** — replaces Hummingbird (`hi/python:3.12-builder` / `hi/python:3.12`) with `ubi10/ubi:latest` (builder) and `ubi10/python-312-minimal:latest` (runtime), fixing Konflux enterprise contract `rpm_repos.ids_known` violations
- **Toolchain install script** — `scripts/install-toolchain.sh` installs Python 3.12 + C/Rust build toolchain with hermetic repo detection and `--allowerasing` for UBI 10 glibc conflicts
- **Split build requirements** — `requirements-build.txt` is hatchling-only (prebuilt-wheel builds); `requirements-build-all.txt` has the full pybuild-deps tree (from-source builds via `BUILD_FROM_SOURCE=1`)
- **Pin uv-build to 0.11.7** — UBI 10 ships rustc 1.92; uv-build ≥0.11.8 needs ≥1.93. Pinned via awk in `konflux_requirements.sh` so regeneration is idempotent
- **RPM lockfile for UBI 10** — `rpms.in.yaml` and `rpms.lock.yaml` resolved against UBI 10 baseos/appstream repos (x86_64 + aarch64)
- **Runtime user** — UID 65532 (Hummingbird) → UID 1001 (UBI 10 convention)
- **Proxy package split** — packages unavailable on the Konflux artifact proxy (`setuptools-rust`, `vcs-versioning`) are split into `requirements-build-pypi.txt` via awk in `konflux_requirements.sh`
- **Hermetic build support** — PipelineRuns set `hermetic: "true"` with combined `[pip, rpm]` prefetch-input

## Verified

- `podman build -f Containerfile` succeeds, `import okp_mcp` works, runs as UID 1001
- All 394 unit tests pass
- `make check-konflux-requirements` is idempotent (uv-build pin survives regeneration)