### PR TITLE
ci(tekton): build on linux-c4xlarge platforms

### DIFF
--- a/.tekton/pipeline-build-multiarch.yaml
+++ b/.tekton/pipeline-build-multiarch.yaml
@@ -22,8 +22,8 @@ spec:
       description: List of platforms to build the container images on. The available set of values is determined by the configuration of the multi-platform-controller.
       type: array
       default:
-        - linux/arm64
-        - linux/amd64
+        - linux-c4xlarge/arm64
+        - linux-c4xlarge/amd64
 
     - name: path-context
       description: Path to the source code of an application's component from where to build image.


### PR DESCRIPTION
Switches the multiarch build pipeline's `build-platforms` default from `linux/{arm64,amd64}` to the larger `linux-c4xlarge/{arm64,amd64}` instances so container builds run faster.

Extracted from #326 so this speedup can land independently of the hermetic-build work. Only the build platform selection changes — no task digest bumps.