### PR TITLE
build: maximize cpu usage for from-source wheel builds

### DIFF
--- a/scripts/container-install.sh
+++ b/scripts/container-install.sh
@@ -20,6 +20,10 @@ set -euo pipefail
 if [ "${BUILD_FROM_SOURCE:-0}" = "1" ]; then
     PIP_BINARY_FLAG="--no-binary=:all:"
     UV_BINARY_FLAG="--no-binary"
+    export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
+    export MAX_JOBS="$(nproc)"
+    export CARGO_BUILD_JOBS="$(nproc)"
+    export MAKEFLAGS="-j$(nproc)"
 else
     PIP_BINARY_FLAG="--only-binary=:all:"
     UV_BINARY_FLAG=""


### PR DESCRIPTION
- export parallel build env vars for cmake, make, cargo, and pip
- sets jobs to $(nproc) when BUILD_FROM_SOURCE=1

This speeds up from-source wheel compilation during container builds by ensuring C and Rust extensions use all available CPU cores.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved source-based container installs by enabling parallel builds across supported toolchains, which can reduce build and setup time when building from source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->