### PR TITLE
build: enable Hermeto sdist-only prefetch in Konflux pipelines

### DIFF
--- a/.tekton/pull_request.yaml
+++ b/.tekton/pull_request.yaml
@@ -47,12 +47,10 @@ spec:
     - name: hermetic
       value: "false"
 
-    # Empty prefetch-input disables Cachi2/hermeto prefetch entirely. The
-    # prefetch-dependencies task keys off this input, not the hermetic flag, so
-    # leaving it populated would still stamp hermeto:pip:package:binary=true
-    # into the SBOM and trip Conforma's disallowed_package_attributes rule.
+    # Hermeto sdist-only prefetch (no binary field = no binary SBOM annotations).
+    # hermetic is still false so the network stays available as a fallback.
     - name: prefetch-input
-      value: ""
+      value: '{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build.txt"]}'
 
     - name: image-expires-after
       value: 5d

--- a/.tekton/push.yaml
+++ b/.tekton/push.yaml
@@ -52,12 +52,10 @@ spec:
     - name: hermetic
       value: "false"
 
-    # Empty prefetch-input disables Cachi2/hermeto prefetch entirely. The
-    # prefetch-dependencies task keys off this input, not the hermetic flag, so
-    # leaving it populated would still stamp hermeto:pip:package:binary=true
-    # into the SBOM and trip Conforma's disallowed_package_attributes rule.
+    # Hermeto sdist-only prefetch (no binary field = no binary SBOM annotations).
+    # hermetic is still false so the network stays available as a fallback.
     - name: prefetch-input
-      value: ""
+      value: '{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build.txt"]}'
 
     - name: additional-tags
       value:


### PR DESCRIPTION
- set prefetch-input to use .konflux/requirements.txt and .konflux/requirements-build.txt
- remove allow_binary to force sdist prefetch (prevents SBOM binary mismatch errors)
- leave hermetic set to false so the build network is still available for now