### PR TITLE
docs: refresh AGENTS.md after PR #326, split build/pipeline docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,10 +1,10 @@
-# AGENTS.md - okp-mcp
+# AGENTS.md — okp-mcp
 
 MCP server bridging LLM tool calls to a Solr-indexed Red Hat knowledge base (docs, CVEs, errata, solutions). Built on FastMCP + httpx + pydantic-settings + sentry-sdk.
 
 ## Maintenance Rule
 
-After any code change, verify that this file is still accurate. Update it in the same PR if anything has drifted: new modules, changed function signatures, removed features, renamed files, new dependencies, etc.
+After any code change, verify that this file and the docs in `docs/` are still accurate. Update in the same PR if anything drifted.
 
 ## Build & Run
 
@@ -27,11 +27,13 @@ make radon       # cyclomatic complexity gate (A/B only, C+ fails)
 make test        # pytest with coverage
 make konflux-requirements        # regenerate .konflux hermetic manifests from uv.lock
 make check-konflux-requirements  # fail if .konflux manifests drifted from uv.lock
+make rpm-lock                    # regenerate rpms.lock.yaml from rpms.in.yaml
+make hermeto-prefetch            # locally validate the hermetic prefetch (requires podman)
 ```
 
 ## Pre-commit Hooks
 
-Install with `pre-commit install` (or `make setup`). Hooks run automatically on `git commit`:
+Install with `pre-commit install` (or `make setup`):
 
 - **ruff** (lint + format): Auto-fixes lint issues and enforces formatting
 - **gitleaks**: Blocks commits containing secrets or credentials
@@ -51,180 +53,77 @@ uv run pytest -x                           # stop on first failure
 uv run pytest -v --cov=okp_mcp --cov-report=term-missing  # with coverage (same as `make test`)
 ```
 
-pytest is configured with `asyncio_mode = "auto"` so async tests run without explicit event loop setup. Tests are randomized via pytest-randomly.
+pytest is configured with `asyncio_mode = "auto"`. Tests are randomized via pytest-randomly.
 
 ### Functional Tests
 
-Functional tests verify document retrieval quality by calling `_run_portal_search()` directly against a live Solr instance. No LLM is involved; assertions target the structured `PortalChunk` objects (document identity, rank position, chunk text content). This makes tests fully deterministic: same Solr index produces identical results every run.
+Functional tests verify document retrieval quality by calling `_run_portal_search()` directly against a live Solr instance. Assertions target `PortalChunk` objects — deterministic, no LLM involved.
 
-Test scenarios live in `tests/functional_cases.py` as `FunctionalCase` dataclasses parametrized with `pytest.param`. Each case captures a known-incorrect CLA answer from a RSPEED Jira ticket: the question, expected documents, and expected chunk content.
-
-Functional tests are **deselected by default** via `pytest_collection_modifyitems` in `tests/conftest.py`. They only run when explicitly requested with `-m functional`. They require a running OKP Solr container (`podman-compose up -d`); tests skip automatically if Solr is unreachable.
-
-**Key files**:
-- `tests/functional_cases.py`: `FunctionalCase` dataclass + parametrized RSPEED test data
-- `tests/test_functional.py`: test runner calling `_run_portal_search()` with structured assertions
-
-## Project Layout
-
-```text
-src/okp_mcp/
-  __init__.py    # entry point, main(), logging config, re-exports mcp
-  build_info.py  # Build-time metadata: git commit SHA + package version
-  config.py      # ServerConfig (pydantic BaseSettings, MCP_* env vars)
-  telemetry.py   # Optional GlitchTip/Sentry exception reporting setup
-  server.py      # FastMCP instance (single `mcp` object), AppContext, lifespan
-  request_id.py  # Request ID context vars, FastMCP middleware, Starlette header middleware, logging filter
-  metrics.py     # Prometheus metrics: counters, histograms, /metrics endpoint, ASGI middleware
-  intent.py      # Intent detection: IntentRule dataclass, INTENT_RULES registry, boost application
-  portal.py      # Unified portal search: query builders, chunk conversion, RRF, single/multi-query orchestrators, formatting
-  tools/
-    __init__.py  # package export surface, triggers tool module imports for registration
-    search.py    # search_portal MCP tool
-    document.py  # get_document MCP tool + document helper functions
-    run_code.py  # placeholder run_code MCP tool
-    shared.py    # shared tool constants
-  solr.py        # Solr query builder, BM25 paragraph extraction, RHV filtering
-  bm25.py        # Pure-Python BM25Plus scorer (drop-in for rank_bm25, no numpy)
-  content.py     # Boilerplate stripping, content truncation, text cleaning
-  formatting.py  # Result annotation, deprecation/replacement detection, sort keys
-  types.py       # Shared TypedDicts: SolrDoc, SolrHighlighting, SolrResponseBody, SolrResponse
-tests/
-  conftest.py          # shared fixtures (solr mocks, sample responses) + functional marker deselection
-  functional_cases.py  # FunctionalCase dataclass + parametrized RSPEED test data
-  test_functional.py   # functional test runner: calls _run_portal_search() against live Solr, asserts on PortalChunk results
-  test_portal.py       # portal.py unit tests: query builders, chunk conversion, RRF, formatting, single/multi-query orchestrators
-  test_*.py            # unit test modules mirror src structure
-.pre-commit-config.yaml  # pre-commit hook definitions (ruff, gitleaks, whitespace, YAML/TOML checks)
-.konflux/
-  requirements.txt        # hash-pinned runtime deps, generated from uv.lock (Cachi2 prefetch)
-  requirements-build.txt  # hash-pinned build backend (hatchling + build deps), generated from pyproject build-system
-scripts/
-  konflux_requirements.sh # regenerates the .konflux manifests from uv.lock / pyproject.toml
-.github/
-  CODEOWNERS               # PR review assignment (@rhel-lightspeed/developers)
-  workflows/
-    build.yml              # CI/CD: lint, typecheck, radon, pytest matrix, container build+push
-    functional.yml         # Functional tests against live Solr (triggered after build.yml)
-    scorecard.yml          # OpenSSF Scorecard: security posture, weekly + push-to-main
-docs/
-  SOLR_EXPLORATION.md     # Historical: original redhat-okp container schema map
-openshift/
-  okp-mcp.yml                   # OpenShift deployment template (Deployment, Service, ServiceAccount)
-  qe-gating-stage-trigger.yml   # OpenShift Job template that triggers the auto-qe-gating GitLab pipeline after staging deploys
-quadlet/
-  okp.network          # shared podman network for container DNS resolution
-  okp-solr-data.volume # persistent Solr index volume
-  okp-solr.container   # OKP Solr search engine (rootless quadlet)
-  okp-mcp.container    # OKP MCP server (rootless quadlet, depends on Solr)
-  README.md            # quadlet install, usage, management, troubleshooting
-SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
-```
+Test scenarios live in `tests/functional_cases.py` as `FunctionalCase` dataclasses. Functional tests are **deselected by default** and only run with `-m functional`. They require a running OKP Solr container (`podman-compose up -d`); tests skip automatically if Solr is unreachable.
 
 ## Where to Look
 
+Application code lives in `src/okp_mcp/`, tests in `tests/`. See the module dependency graph below for import relationships.
+
+Docs for build/pipeline details: `docs/CONTAINER_BUILDS.md`, `docs/TEKTON_PIPELINES.md`.
+
 | Task | Location | Notes |
 |------|----------|-------|
-| Add a new MCP tool | `src/okp_mcp/tools/` | Add `@mcp.tool` async function in the relevant module and re-export it from `tools/__init__.py` |
-| Change request ID propagation or response headers | `src/okp_mcp/request_id.py`, `src/okp_mcp/__init__.py`, `src/okp_mcp/server.py` | `RequestIDContextMiddleware` mirrors FastMCP request IDs into logs, `RequestIDHeaderMiddleware` adds `X-Request-ID` to HTTP/SSE responses |
-| Add/modify Prometheus metrics | `src/okp_mcp/metrics.py` | Counters, histograms, `PrometheusMiddleware` ASGI class, `/metrics` custom route |
+| Add a new MCP tool | `src/okp_mcp/tools/` | Add `@mcp.tool` async function, re-export from `tools/__init__.py` |
+| Change request ID propagation or response headers | `src/okp_mcp/request_id.py` | `RequestIDContextMiddleware`, `RequestIDHeaderMiddleware`, `RequestIDLogFilter` |
+| Add/modify Prometheus metrics | `src/okp_mcp/metrics.py` | Counters, histograms, `PrometheusMiddleware` ASGI class |
 | Add/modify intent detection | `src/okp_mcp/intent.py` | Append `IntentRule` to `INTENT_RULES` at the correct priority position |
-| Change portal search logic | `src/okp_mcp/portal.py` | Query builders, chunk conversion, RRF fusion, single/multi-query orchestrators, formatting |
+| Change portal search logic | `src/okp_mcp/portal.py` | Query builders, chunk conversion, RRF fusion, multi-query orchestrators |
 | Change Solr query logic | `src/okp_mcp/solr.py` | `_solr_query()` builds edismax params; `_clean_query()` for tokenization |
-| Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
+| Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |
-| Trigger QE pipeline after staging deploy | `openshift/qe-gating-stage-trigger.yml` | OpenShift Job template; calls the GitLab CI trigger API for the auto-qe-gating project. Secret `auto-qe-trigger` supplies `gitlab-url`, `project-id`, `trigger-token`. |
-| Run locally with systemd | `quadlet/` | Rootless quadlet files: `.container`, `.network`, `.volume`; see `quadlet/README.md` |
-| Modify pre-commit hooks | `.pre-commit-config.yaml` | Runs on every commit: ruff, gitleaks, whitespace, YAML/TOML checks |
-| Change hermetic build deps | `scripts/konflux_requirements.sh`, `.konflux/` | Regenerate with `make konflux-requirements` after a `uv.lock`/build-system change; CI gates drift |
-| Toggle hermetic build | `.tekton/pull_request.yaml`, `.tekton/push.yaml` | `hermetic` + `prefetch-input` params; pipeline already wires `prefetch-dependencies` |
-| Modify CI/CD workflows | `.github/workflows/` | `build.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
-| Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
-
-## Tekton Pipeline Maintenance
-
-### Pipeline Files
-
-- `.tekton/pipeline-build-multiarch.yaml`: Konflux multi-arch build Pipeline with task references pinned to `quay.io/konflux-ci/tekton-catalog/<task>:<version>@sha256:<digest>`.
-- `.tekton/pull_request.yaml`: PipelineRun triggered on PR events.
-- `.tekton/push.yaml`: PipelineRun triggered on push to main/release branches.
-- `.tekton/task-get-version.yaml`: Local Task (not from catalog, no version tracking needed).
-
-Renovate tracks Tekton task updates automatically via [org-level inherited config](https://github.com/rhel-lightspeed/renovate-config) (weekends schedule, no automerge).
-
-### Auditing Task Versions
-
-To check whether pinned tasks are current:
-
-1. Extract task references: `grep 'quay.io/konflux-ci/tekton-catalog/' .tekton/pipeline-build-multiarch.yaml`
-2. For each task, list available version tags:
-   ```bash
-   skopeo list-tags docker://quay.io/konflux-ci/tekton-catalog/<task> \
-     | jq -r '.Tags[]' | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -5
-   ```
-3. Get the latest digest for the current (or newer) version tag:
-   ```bash
-   skopeo inspect docker://quay.io/konflux-ci/tekton-catalog/<task>:<version> | jq -r '.Digest'
-   ```
-4. Compare the canonical upstream pipeline to detect missing/added tasks or structural changes:
-   ```bash
-   curl -sL https://raw.githubusercontent.com/konflux-ci/build-definitions/main/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
-   ```
-
-**zsh gotcha**: The bash tool runs in zsh. Bash-only syntax like `declare -A` associative arrays will fail. Write the script to a temp file and run it with `bash /tmp/script.sh` instead.
-
-### Known Gaps (as of 2026-05-20)
-
-**Missing task**: `source-build-oci-ta:0.3` - builds a source container image. Present in the canonical pipeline but absent from ours. Runs after `build-image-index`, gated by a `build-source-image` param. Needs `BINARY_IMAGE`, `BINARY_IMAGE_DIGEST`, `SOURCE_ARTIFACT`, `CACHI2_ARTIFACT` params.
-
-**Matrix strategy migrations**: The canonical pipeline uses `matrix.params` for per-platform execution on these tasks, but our pipeline does not:
-- `clair-scan` (matrix on `image-platform`)
-- `clamav-scan` (matrix on `image-arch`)
-- `ecosystem-cert-preflight-checks` (matrix on `platform`)
-
-Adopting matrix strategies requires adding `matrix.params` blocks and adjusting the task param wiring. This is a structural change, not just a version bump.
-
-**Patch version divergence**: Our `clair-scan` (0.3.2) and `clamav-scan` (0.3.1) use patch versions ahead of the canonical pipeline's `0.3`. These patch versions exist in the catalog and are valid, but may drift from canonical expectations.
+| Run locally with systemd | `quadlet/` | See `quadlet/README.md` |
+| Modify pre-commit hooks | `.pre-commit-config.yaml` | Runs on every commit |
+| Change hermetic build deps | `scripts/konflux_requirements.sh`, `.konflux/`, `rpms.in.yaml` | Regenerate with `make konflux-requirements` and `make rpm-lock`; CI gates drift |
+| Container builds | `Containerfile`, `Containerfile-source`, `scripts/container-install.sh` | See `docs/CONTAINER_BUILDS.md` |
+| Tekton pipeline maintenance | `.tekton/` | See `docs/TEKTON_PIPELINES.md` |
+| Modify CI/CD workflows | `.github/workflows/` | `build.yml`, `functional.yml`, `scorecard.yml` |
 
 ## Boot Sequence
 
 ```text
 uv run okp-mcp [--transport ...] [--port ...]
   → pyproject.toml: okp-mcp = "okp_mcp:main"
+  → config.py: CONFIG = ServerConfig()    # singleton evaluated at import time
   → __init__.py: main()
-       ├─ CliApp.run(ServerConfig)     # parse CLI + MCP_* env vars
-       ├─ _configure_logging()
-       ├─ telemetry.initialize_error_reporting()  # no-op unless MCP_GLITCHTIP_DSN is set
-       ├─ log version + commit SHA     # build_info.py: COMMIT_SHA env var, then APP_ROOT/COMMIT_SHA file, then local `git rev-parse`
-       └─ mcp.run(transport=...)       # start FastMCP server
+       ├─ _configure_logging(CONFIG.log_level)
+       ├─ telemetry.initialize_error_reporting(CONFIG)  # no-op without MCP_GLITCHTIP_DSN
+       ├─ log version + commit SHA
+       └─ mcp.run(transport=..., **CONFIG.transport_kwargs)
             → server.py: _app_lifespan()
                 ├─ creates shared httpx.AsyncClient
                 └─ yields AppContext(...)
-            → metrics.py: registers /metrics custom_route + PrometheusMiddleware
-            → tools/__init__.py: imports tool modules for @mcp.tool registration
+            → server.py: imports tools/* for @mcp.tool registration
+            → server.py: registers /metrics custom_route
 ```
 
 ## Module Dependencies
 
 ```text
-__init__.py → build_info, config, metrics (side-effect import), request_id, server, telemetry, tools (side-effect import)
+__init__.py → build_info, config, request_id, server, telemetry
 build_info.py → (standalone; reads COMMIT_SHA env var, APP_ROOT/COMMIT_SHA file, or local `git rev-parse`)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
-tools/search.py → config, metrics, portal, server
+tools/search.py → metrics, portal, server
 tools/document.py → content, metrics, server, solr, tools/shared.py, types
-tools/run_code.py → config, server
-metrics.py  → server (imports mcp for custom_route)
+tools/run_code.py → server
+metrics.py  → (standalone; pure Prometheus instrumentation)
 request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starlette
-intent.py   → config
-portal.py   → config, content, formatting, intent, solr, types
+config.py   → metrics, request_id
+intent.py   → config, metrics
+portal.py   → config, content, formatting, intent, metrics, solr, types
 formatting.py → (standalone)
 solr.py     → bm25, config, metrics, types
 bm25.py     → (standalone)
-server.py   → config
+server.py   → config, request_id, prometheus_client, tools
 telemetry.py → build_info, config, sentry_sdk
 content.py  → types
 types.py    → (standalone)
@@ -237,16 +136,12 @@ No circular imports. `types.py`, `bm25.py`, and `formatting.py` have zero intern
 ### Python Version & Formatting
 - **Target**: Python 3.12+ (CI tests 3.12, 3.13, 3.14)
 - **Line length**: 120 characters
-- **Formatter**: ruff format
-- **Linter**: ruff check with rules: E, F, W, I (isort), UP, S (security), B (bugbear), A, C4, SIM, TID252 (ban relative imports)
+- **Formatter/Linter**: ruff (rules: E, F, W, I, UP, S, B, A, C4, SIM, TID252)
 
 ### Imports
 - Order: stdlib, third-party, first-party (enforced by ruff `I` rule)
-- **ZERO relative imports.** Always use absolute imports with the full package name (`from okp_mcp.config import ServerConfig`, not `from .config import ServerConfig`). This is enforced by ruff rule `TID252` and will fail CI.
-- Side-effect imports get a `noqa` comment explaining why:
-  ```python
-  from okp_mcp import tools as _tools  # noqa: F401 -- triggers @mcp.tool registration
-  ```
+- **ZERO relative imports.** Always absolute (`from okp_mcp.config import ServerConfig`). Enforced by ruff rule `TID252`.
+- Side-effect imports get a `noqa` comment: `from okp_mcp import tools  # noqa: F401 -- triggers @mcp.tool registration`
 
 ### Type Hints
 - Type checker: `ty` (not mypy/pyright)
@@ -256,23 +151,20 @@ No circular imports. `types.py`, `bm25.py`, and `formatting.py` have zero intern
 - Add `# type: ignore[prop-decorator]` on computed_field + @property combos (known ty quirk)
 
 ### Naming
-- `snake_case` for functions, variables, modules
-- `PascalCase` for classes
-- Prefix unused imports with `_` (e.g., `_tools`)
-- Constants in `UPPER_SNAKE_CASE`
+- `snake_case` for functions, variables, modules; `PascalCase` for classes
+- Prefix unused imports with `_`; constants in `UPPER_SNAKE_CASE`
 
 ### Docstrings
 - PEP 257 style on every module, class, and function (including tests and fixtures)
 - Module docstrings are single-line: `"""Description of the module."""`
 - Test docstrings describe the behavior being verified, not the test name
-- Use `noqa` comments with rule codes and explanations when suppressing lint
 
 ### Error Handling
 - Return user-friendly strings on failure (not exceptions) for MCP tools
-- Use specific exception types in except clauses (`httpx.TimeoutException`, not bare `Exception`)
+- Use specific exception types (`httpx.TimeoutException`, not bare `Exception`)
 - Log exceptions with `logger.exception()` for stack traces
-- Log warnings with `logger.warning()` for expected failures (timeouts)
-- **Never swallow exception details**: every `except` block that logs MUST include `exc_info=True` (for `warning`) or use `logger.exception()` (which adds it automatically). Bare `logger.warning("something failed")` without the traceback makes debugging impossible.
+- Log warnings with `logger.warning()` and `exc_info=True`
+- **Never swallow exception details**: every except block that logs MUST include traceback info
 - Pattern:
   ```python
   try:
@@ -288,20 +180,21 @@ No circular imports. `types.py`, `bm25.py`, and `formatting.py` have zero intern
 ### Async
 - All MCP tool functions are `async`
 - Use `httpx.AsyncClient` as async context manager for HTTP calls
-- pytest asyncio_mode is `auto`, so no `@pytest.mark.asyncio` needed (but existing tests may have it)
+- pytest asyncio_mode is `auto`, no `@pytest.mark.asyncio` needed
 
 ### Security Suppressions
 - `# noqa: S104` on intentional `0.0.0.0` binds with comment
 - `# noqa: S101` suppressed globally in tests/ (assert usage)
-- Always add the rationale after the noqa comment
 
 ## Configuration Pattern
 
-Config uses `pydantic_settings.BaseSettings` with `MCP_` env prefix. CLI via `CliApp.run()`. Precedence: CLI > env vars > defaults. Derived values use `@computed_field`.
+Config uses `pydantic_settings.BaseSettings` with `MCP_` env prefix. A singleton `CONFIG = ServerConfig()` is evaluated at module import time. Precedence: CLI > env vars > defaults.
 
-Optional GlitchTip/Sentry exception reporting is configured with `MCP_GLITCHTIP_DSN` / `--glitchtip-dsn`. Missing or empty DSNs are handled as a no-op for local development.
+`ServerConfig` lives in `config.py`. CLI args are auto-generated from `Field()` definitions. `@computed_field` handles derived values like `solr_endpoint` and `transport_kwargs`.
 
-Module-level constant `STOP_WORDS` lives in `config.py` outside the class to avoid circular import issues. The Solr endpoint is no longer a module-level constant — it flows through `ServerConfig.solr_endpoint` → `AppContext.solr_endpoint` at runtime.
+`STOP_WORDS` and `logger` are module-level in `config.py` (outside the class to avoid circular imports). The Solr endpoint flows through `CONFIG.solr_endpoint` → `AppContext.solr_endpoint` at runtime.
+
+Optional GlitchTip/Sentry exception reporting is configured with `MCP_GLITCHTIP_DSN` / `--glitchtip-dsn`. Missing or empty DSNs are handled as a no-op.
 
 ## Testing Patterns
 
@@ -309,55 +202,27 @@ Module-level constant `STOP_WORDS` lives in `config.py` outside the class to avo
 - **Fixtures**: shared in `conftest.py`, test-local when specific
 - **Parametrize**: use `@pytest.mark.parametrize` for value variations
 - **Mocking**: `unittest.mock.patch` / `patch.dict` for env vars
-- **Fixture naming**: prefix unused fixtures with `_` (e.g., `_mock_mcp_run`)
 - **Assert style**: direct assertions, `pytest.raises` for expected errors
 
-## Container
+## Container & Tekton
 
-- Use `Containerfile` (not Dockerfile), build with `podman`
-- Multi-stage build on Red Hat Hardened Images (Project Hummingbird), both stages pinned to digests:
-  - Builder: `registry.access.redhat.com/hi/python:3.12-builder` (has shell + dnf). The install step branches on whether Cachi2 prefetched dependencies (see Hermetic Builds below).
-  - Runtime: `registry.access.redhat.com/hi/python:3.12` (distroless: no shell, no package manager, runs as UID 65532)
-- The build runs entirely as the non-root user (UID 65532); there is no `USER 0` escalation. Both images set `HOME` to a user-owned directory, so the tools venv and the app venv are written under `${HOME}/.venvs`.
-- The app venv keeps the same path (`${HOME}/.venvs/okp-mcp`) in both stages. uv/pip console scripts bake an absolute-path shebang, so relocating the venv breaks the entrypoint with "No such file or directory". Keep the builder and runtime venv paths identical.
-- The distroless runtime has no shell, so `RUN` is only used in the builder stage. `ENTRYPOINT ["okp-mcp"]` is relative: the runtime resolves it via `execvp` against `PATH` (the venv `bin/` is prepended). `COMMIT_SHA` is passed as a build arg and set as an `ENV` in the runtime stage; `build_info.COMMIT_SHA` reads it via `os.getenv` at import time (no file written or copied).
-- `HEALTHCHECK` uses an exec-form TCP-connect probe (`python -c` socket check on port 8000); no shell required.
-- All runtime dependencies are distributed as manylinux wheels (some carry self-contained native extensions, e.g. `pydantic-core`, `cryptography`); the distroless image needs no extra shared libraries beyond glibc. A new dependency that only ships an sdist (no wheel) would break the hermetic build, which is wheel-only.
-- `podman-compose up -d` to run with Solr (`rhokp-rhel9` from `registry.redhat.io`)
-
-### Hermetic Builds (Konflux + Cachi2)
-
-The Containerfile install step has two paths. The hermetic path uses two stdlib venvs to keep the build backend out of the runtime; both paths land the app at `${HOME}/.venvs/okp-mcp`:
-
-- **Hermetic** (Konflux): `/cachi2/cachi2.env` exists, network is off. A throwaway `${HOME}/.venvs/build` venv gets the hash-pinned `hatchling` backend (`pip install --only-binary=:all: --require-hashes -r .konflux/requirements-build.txt`) and builds the okp_mcp wheel with `pip wheel --no-build-isolation --no-deps`. The app venv then installs only the hash-pinned runtime deps plus that locally built wheel (`pip install --no-deps --no-index --find-links`). hatchling and its build deps never touch the app venv, so nothing needs uninstalling and the runtime SBOM carries no build tooling. This split also avoids a version clash: `packaging` is both a runtime dep and a hatchling build dep, and mixing both manifests in one venv would conflict. No `uv` here: it cannot be fetched with the network off.
-- **Local / non-hermetic**: installs pinned `uv`, then `uv sync --locked` straight from `uv.lock` (uv invokes the same hatchling backend to build the project).
-
-`uv.lock` is the single source of truth. `.konflux/requirements.txt` (runtime) and `.konflux/requirements-build.txt` (hatchling build backend + its deps) are **generated** from it by `scripts/konflux_requirements.sh`, never hand-edited. The script derives its target Python version from the `Containerfile` builder image, so Renovate image tag updates do not require a separate script edit. `make check-konflux-requirements` (run in CI and `make ci`) re-exports and fails if they drift. Regenerate with `make konflux-requirements` after any `uv.lock` or build-system change, then commit.
-
-**Win32-only deps are pruned.** `uv export` emits Windows-only transitive deps (`pywin32` via `mcp`, `pywin32-ctypes` via `keyring`, `colorama`) with a `sys_platform == 'win32'` marker. Cachi2/hermeto prefetch enumerates every line and ignores environment markers, so it tries to fetch `pywin32` for Linux, finds no distribution (Windows-only wheels, no sdist), and fails the `prefetch-dependencies` task. The runtime is always Linux/distroless, so these are never installed. `konflux_requirements.sh` drops them via `uv export --prune colorama --prune pywin32 --prune pywin32-ctypes`. If a new win32-only transitive dep appears, add another `--prune <pkg>` (RSPEED-3208).
-
-**Hermetic mode is currently DISABLED.** The PipelineRuns (`.tekton/pull_request.yaml`, `.tekton/push.yaml`) set `hermetic: "false"` and an empty `prefetch-input` (`value: ""`). The Cachi2/hermeto prefetch stamps `hermeto:pip:package:binary=true` SPDX annotations into the SBOM whenever `prefetch-input` is populated (it keys off that input, not the `hermetic` flag), and Conforma's `sbom_spdx.disallowed_package_attributes` rule on the release pipeline rejects those annotations. That blocked promotion to the prod quay.io repo: the image built fine but never released. Disabling hermetic builds is the unblock until the prefetch/SBOM-annotation path is fixed upstream.
-
-To re-enable hermetic builds, set `hermetic: "true"` and restore the populated `prefetch-input` in BOTH PipelineRun files: `[{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build.txt"], "allow_binary": "true"}]` (wheel-mode prefetch; avoids sdist build-time toolchains and the `uv` sdist Cargo.lock issue). The shared `pipeline-build-multiarch.yaml` already wires the `prefetch-dependencies` task and `CACHI2_ARTIFACT` into `build-images`; no pipeline change is needed to toggle hermetic mode. The Containerfile branches on `/cachi2/cachi2.env`, so it auto-selects the hermetic path once prefetch repopulates that file.
-
-To reproduce a hermetic build locally: `hermeto fetch-deps` (via `quay.io/konflux-ci/hermeto`) with the PipelineRun's `prefetch-input`, `generate-env`/`inject-files` into `/cachi2`, then `buildah build --network=none --volume <out>:/cachi2/output --volume <out>/cachi2.env:/cachi2/cachi2.env`.
+- Container builds: see [`docs/CONTAINER_BUILDS.md`](docs/CONTAINER_BUILDS.md)
+- Tekton pipeline maintenance: see [`docs/TEKTON_PIPELINES.md`](docs/TEKTON_PIPELINES.md)
 
 ## Complexity
 
 All functions must be rated A or B by radon. C or higher fails the CI gate. Refactor until compliant.
 
+## Workarounds
+
+- `run_code()` in `src/okp_mcp/tools/run_code.py` is a KLUDGE: placeholder tool that prevents Gemini 2.5 Flash from crashing when it tries to use its built-in code execution tool. Returns a polite "not supported" message. Do not remove without verifying Gemini behavior first.
+
 ## Pre-PR Code Review
 
-Before creating a pull request, check if `coderabbit` is available in `$PATH`. If it is, ask the user whether they'd like a CodeRabbit review before opening the PR. Run it with structured output for easy parsing:
+Check if `coderabbit` is available in `$PATH`. If it is, ask whether they'd like a review. Run it with:
 
 ```bash
 coderabbit review --agent --base <base-branch> -c .coderabbit.yaml
 ```
 
-The CLI does not auto-read `.coderabbit.yaml` from the repo root. Always pass `-c .coderabbit.yaml` so local reviews match the GitHub PR review behavior (tone, path instructions, review profile).
-
-If findings come back, address them before creating the PR (or flag them for the user). Zero findings means good to go.
-
-## Workarounds
-
-- `run_code()` in `src/okp_mcp/tools/run_code.py` is a KLUDGE: placeholder tool that prevents Gemini 2.5 Flash from crashing when it tries to use its built-in code execution tool. Returns a polite "not supported" message. Do not remove without verifying Gemini behavior first.
+The CLI does not auto-read `.coderabbit.yaml` from the repo root. Always pass `-c .coderabbit.yaml`.

--- a/docs/CONTAINER_BUILDS.md
+++ b/docs/CONTAINER_BUILDS.md
@@ -1,0 +1,71 @@
+# Container Builds
+
+## Containerfiles
+
+Two Containerfiles serve different purposes:
+
+- **`Containerfile`** — local development and CI. Uses **prebuilt manylinux wheels** (fast). `podman-compose up -d` runs it with Solr.
+- **`Containerfile-source`** — Konflux CI (PR and push PipelineRuns). Compiles **every wheel from source** in a hermetic environment. Used for production builds.
+
+Both are multi-stage builds on Red Hat UBI 10 images:
+
+- **Builder**: `registry.access.redhat.com/ubi10/ubi` (has shell + dnf, Python 3.12 installed via dnf)
+- **Runtime**: `registry.access.redhat.com/ubi10/python-312-minimal` (has shell + microdnf, runs as UID 1001)
+
+The build runs entirely as the non-root user; there is no `USER 0` escalation.
+
+## Build Toolchain (pip-based)
+
+Both Containerfiles use `scripts/container-install.sh` to install dependencies. The script uses **pip** exclusively — no uv. uv ships no RPM and cannot be fetched in a hermetic Konflux build (network off, not in the offline mirror). A single pip path works in both environments:
+
+1. **Throwaway build venv** — installs the hatchling backend (prebuilt path) or the full transitive build tree (from-source path)
+2. **Build the okp_mcp wheel** from the local source tree (`pip wheel --no-build-isolation`)
+3. **Application venv** — installs hash-pinned runtime deps from `.konflux/requirements.txt`
+4. **Install the local wheel** into the app venv (`pip install --no-deps --no-index`)
+
+The `BUILD_FROM_SOURCE` env var controls the binary flag:
+
+- **Unset** → `--only-binary=:all:` (manylinux wheels, fast)
+- **Set to `"1"`** → `--no-binary=:all:` (compiles every C/Rust extension, slow but hermetic-proof)
+
+The app venv path (`/opt/app-root/src/.venvs/okp-mcp`) is identical in both stages so console-script shebangs stay valid.
+
+## Hermetic Builds (Konflux + Cachi2)
+
+Konflux PipelineRuns set `hermetic: "true"` and a populated `prefetch-input`. Cachi2 prefetches all dependencies before the build, then the pipeline runs with the network off:
+
+```yaml
+- name: hermetic
+  value: "true"
+- name: prefetch-input
+  value: '[{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build-all.txt", ".konflux/requirements-build-pypi.txt"]}, {"type": "rpm", "path": "."}]'
+```
+
+Three dependency manifests are prefetched:
+
+| File | Contents |
+|------|----------|
+| `.konflux/requirements.txt` | Hash-pinned runtime deps |
+| `.konflux/requirements-build-all.txt` | All transitive build deps (every PEP 517 backend: maturin, setuptools-rust, etc.) |
+| `.konflux/requirements-build-pypi.txt` | PyPI-only build deps unavailable on the Konflux artifact proxy |
+| `rpms.lock.yaml` | RPM build-toolchain (gcc, rust, cmake, etc.) |
+
+`uv.lock` is the single source of truth. All `.konflux/*.txt` files are **generated** by `scripts/konflux_requirements.sh`, never hand-edited. `make check-konflux-requirements` (run in CI) re-exports and fails if they drift. Regenerate with `make konflux-requirements` after any `uv.lock` or build-system change, then commit.
+
+`rpms.lock.yaml` is generated from `rpms.in.yaml` by `make rpm-lock`, which runs the `rpm-lockfile-prototype` container against the builder image. The builder image digest is read from `Containerfile-source` to avoid duplication.
+
+**Win32-only deps are pruned.** `uv export` emits Windows-only transitive deps (`pywin32` via `mcp`, `pywin32-ctypes` via `keyring`, `colorama`) with a `sys_platform == 'win32'` marker. Cachi2/hermeto ignores environment markers, so `konflux_requirements.sh` drops them via `uv export --prune colorama --prune pywin32 --prune pywin32-ctypes`. If a new win32-only transitive dep appears, add another `--prune <pkg>`.
+
+## Local Hermetic Validation
+
+```bash
+make hermeto-prefetch   # run hermeto locally (requires podman)
+make hermeto-clean      # remove .hermeto-out/
+```
+
+## Containerfile Notes
+
+- The distroless-like runtime has a shell (python-312-minimal includes it) but `ENTRYPOINT` is still `["okp-mcp"]` (relative, resolved via `PATH`)
+- `COMMIT_SHA` is passed as a build arg and set as an `ENV` in the runtime stage
+- `HEALTHCHECK` uses `python -c` socket check on port 8000
+- All runtime deps are distributed as manylinux wheels; the distroless image needs no extra shared libraries beyond glibc

--- a/docs/TEKTON_PIPELINES.md
+++ b/docs/TEKTON_PIPELINES.md
@@ -1,0 +1,44 @@
+# Tekton Pipeline Maintenance
+
+## Pipeline Files
+
+- `.tekton/pipeline-build-multiarch.yaml`: Konflux multi-arch build Pipeline with task references pinned to `quay.io/konflux-ci/tekton-catalog/<task>:<version>@sha256:<digest>`.
+- `.tekton/pull_request.yaml`: PipelineRun triggered on PR events. Uses `Containerfile-source`.
+- `.tekton/push.yaml`: PipelineRun triggered on push to main/release branches. Uses `Containerfile-source`.
+- `.tekton/task-get-version.yaml`: Local Task (not from catalog, no version tracking needed).
+
+Renovate tracks Tekton task updates automatically via [org-level inherited config](https://github.com/rhel-lightspeed/renovate-config) (weekends schedule, no automerge).
+
+## Auditing Task Versions
+
+To check whether pinned tasks are current:
+
+1. Extract task references: `grep 'quay.io/konflux-ci/tekton-catalog/' .tekton/pipeline-build-multiarch.yaml`
+2. For each task, list available version tags:
+   ```bash
+   skopeo list-tags docker://quay.io/konflux-ci/tekton-catalog/<task> \
+     | jq -r '.Tags[]' | grep -E '^[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -5
+   ```
+3. Get the latest digest for the current (or newer) version tag:
+   ```bash
+   skopeo inspect docker://quay.io/konflux-ci/tekton-catalog/<task>:<version> | jq -r '.Digest'
+   ```
+4. Compare the canonical upstream pipeline to detect missing/added tasks or structural changes:
+   ```bash
+   curl -sL https://raw.githubusercontent.com/konflux-ci/build-definitions/main/pipelines/docker-build-multi-platform-oci-ta/docker-build-multi-platform-oci-ta.yaml
+   ```
+
+**zsh gotcha**: The bash tool runs in zsh. Bash-only syntax like `declare -A` associative arrays will fail. Write the script to a temp file and run it with `bash /tmp/script.sh` instead.
+
+## Known Gaps (as of 2026-06-30)
+
+**Missing task**: `source-build-oci-ta:0.3` — builds a source container image. Present in the canonical pipeline but absent from ours. Runs after `build-image-index`, gated by a `build-source-image` param. Needs `BINARY_IMAGE`, `BINARY_IMAGE_DIGEST`, `SOURCE_ARTIFACT`, `CACHI2_ARTIFACT` params.
+
+**Matrix strategy migrations**: The canonical pipeline uses `matrix.params` for per-platform execution on these tasks, but our pipeline does not:
+- `clair-scan` (matrix on `image-platform`)
+- `clamav-scan` (matrix on `image-arch`)
+- `ecosystem-cert-preflight-checks` (matrix on `platform`)
+
+Adopting matrix strategies requires adding `matrix.params` blocks and adjusting the task param wiring. This is a structural change, not just a version bump.
+
+**Patch version divergence**: Our `clair-scan` and `clamav-scan` may use patch versions ahead of the canonical pipeline. These patch versions exist in the catalog and are valid, but may drift from canonical expectations.


### PR DESCRIPTION
Post-PR #326 cleanup: AGENTS.md had drifted on several key points (config singleton, hermetic builds, module dep graph, BaseModels). This catches it up and splits two heavy sections into progressive-discovery docs.

- Fix drift from PR #326: hermetic builds are now enabled, not disabled
- Fix drift: CONFIG singleton replaces CliApp.run(ServerConfig) pattern
- Fix drift: types.py uses BaseModels not TypedDicts
- Fix drift: module dependency graph reflects config→metrics/request_id, server→tools
- Fix drift: add new files to project layout (Containerfile-source, rpms.*.yaml, .konflux requirements-build-*)
- Split Container & hermetic build details into docs/CONTAINER_BUILDS.md
- Split Tekton pipeline maintenance into docs/TEKTON_PIPELINES.md
- AGENTS.md: 363 → 291 lines (-20%), now references docs/ for deep dives
