### PR TITLE
docs: extract container build process into dedicated doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ uv run okp-mcp --transport streamable-http --port 8000  # explicit HTTP mode
 ```bash
 make ci          # full suite: lint + typecheck + radon + drift check + test
 make setup       # install deps + pre-commit hooks
+make fix         # ruff check --fix + ruff format (auto-fix)
 make lint        # ruff check src/ tests/
 make format      # ruff format src/ tests/
 make typecheck   # ty check src/
@@ -30,6 +31,9 @@ make radon       # cyclomatic complexity gate (A/B only, C+ fails)
 make test        # pytest with coverage
 make konflux-requirements        # regenerate .konflux hermetic manifests from uv.lock
 make check-konflux-requirements  # fail if .konflux manifests drifted from uv.lock
+make rpm-lock                    # regenerate rpms.lock.yaml from rpms.in.yaml
+make hermeto-prefetch             # run Hermeto prefetch locally (requires podman)
+make hermeto-clean                # remove .hermeto-out/
 ```
 
 ## Pre-commit Hooks
@@ -100,18 +104,27 @@ tests/
   test_*.py            # unit test modules mirror src structure
 .pre-commit-config.yaml  # pre-commit hook definitions (ruff, gitleaks, whitespace, YAML/TOML checks)
 .konflux/
-  requirements.txt        # hash-pinned runtime deps, generated from uv.lock (Cachi2 prefetch)
-  requirements-build.txt  # hash-pinned build backend (hatchling + build deps), generated from pyproject build-system
+  requirements.txt            # hash-pinned runtime deps (generated from uv.lock)
+  requirements-build.txt      # hatchling + transitive build deps, prebuilt-wheel path only (generated)
+  requirements-build-all.txt  # full PEP 517 build tree for from-source path (generated)
+  requirements-build-pypi.txt # packages missing from Konflux artifact proxy (generated)
 scripts/
-  konflux_requirements.py # regenerates the .konflux manifests from uv.lock / pyproject.toml
+  konflux_requirements.py     # regenerates the .konflux manifests from uv.lock / pyproject.toml
+  container-install.sh        # shared container install logic (build venv → wheel → app venv)
+  install-toolchain.sh        # installs C/Rust build toolchain for from-source builds
+  test-container-startup.sh   # CI smoke test: start container, wait for healthcheck
+rpms.in.yaml                  # build-toolchain RPM packages for hermetic prefetch
+rpms.lock.yaml                # resolved RPM dependency tree (generated from rpms.in.yaml)
 .github/
   CODEOWNERS               # PR review assignment (@rhel-lightspeed/developers)
   workflows/
-    build.yml              # CI/CD: lint, typecheck, radon, pytest matrix, container build+push
-    functional.yml         # Functional tests against live Solr (triggered after build.yml)
+    ci.yml                 # CI/CD: lint, typecheck, radon, pytest matrix, container build+push
+    functional.yml         # Functional tests against live Solr (triggered after ci.yml)
     scorecard.yml          # OpenSSF Scorecard: security posture, weekly + push-to-main
 docs/
-  SOLR_EXPLORATION.md     # Historical: original redhat-okp container schema map
+  CONTAINER_BUILD.md     # Container build process, data flow diagrams, hermetic builds
+  RELEASE_BRANCHES.md    # Release branch workflow
+  SOLR_EXPLORATION.md    # Historical: original redhat-okp container schema map
 openshift/
   okp-mcp.yml                   # OpenShift deployment template (Deployment, Service, ServiceAccount)
   qe-gating-stage-trigger.yml   # OpenShift Job template that triggers the auto-qe-gating GitLab pipeline after staging deploys
@@ -145,8 +158,10 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Run locally with systemd | `quadlet/` | Rootless quadlet files: `.container`, `.network`, `.volume`; see `quadlet/README.md` |
 | Modify pre-commit hooks | `.pre-commit-config.yaml` | Runs on every commit: ruff, gitleaks, whitespace, YAML/TOML checks |
 | Change hermetic build deps | `scripts/konflux_requirements.py`, `.konflux/` | Regenerate with `make konflux-requirements` after a `uv.lock`/build-system change; CI gates drift |
+| Change RPM toolchain deps | `rpms.in.yaml`, `scripts/install-toolchain.sh` | Edit `rpms.in.yaml`, run `make rpm-lock`, update `install-toolchain.sh` if package list changed |
+| Change container install logic | `scripts/container-install.sh`, `Containerfile` | Build venv → wheel → app venv; branches on `BUILD_FROM_SOURCE` and `/cachi2/cachi2.env` |
 | Toggle hermetic build | `.tekton/pull_request.yaml`, `.tekton/push.yaml` | `hermetic` + `prefetch-input` params; pipeline already wires `prefetch-dependencies` |
-| Modify CI/CD workflows | `.github/workflows/` | `build.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
+| Modify CI/CD workflows | `.github/workflows/` | `ci.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 
 ## Tekton Pipeline Maintenance
@@ -318,33 +333,17 @@ Module-level constant `STOP_WORDS` lives in `config.py` outside the class to avo
 
 ## Container
 
-- Use `Containerfile` (not Dockerfile), build with `podman`
-- Multi-stage build on Red Hat Hardened Images (Project Hummingbird), both stages pinned to digests:
-  - Builder: `registry.access.redhat.com/hi/python:3.12-builder` (has shell + dnf). The install step branches on whether Cachi2 prefetched dependencies (see Hermetic Builds below).
-  - Runtime: `registry.access.redhat.com/hi/python:3.12` (distroless: no shell, no package manager, runs as UID 65532)
-- The build runs entirely as the non-root user (UID 65532); there is no `USER 0` escalation. Both images set `HOME` to a user-owned directory, so the tools venv and the app venv are written under `${HOME}/.venvs`.
-- The app venv keeps the same path (`${HOME}/.venvs/okp-mcp`) in both stages. uv/pip console scripts bake an absolute-path shebang, so relocating the venv breaks the entrypoint with "No such file or directory". Keep the builder and runtime venv paths identical.
-- The distroless runtime has no shell, so `RUN` is only used in the builder stage. `ENTRYPOINT ["okp-mcp"]` is relative: the runtime resolves it via `execvp` against `PATH` (the venv `bin/` is prepended). `COMMIT_SHA` is passed as a build arg and set as an `ENV` in the runtime stage; `build_info.COMMIT_SHA` reads it via `os.getenv` at import time (no file written or copied).
-- `HEALTHCHECK` uses an exec-form TCP-connect probe (`python -c` socket check on port 8000); no shell required.
-- All runtime dependencies are distributed as manylinux wheels (some carry self-contained native extensions, e.g. `pydantic-core`, `cryptography`); the distroless image needs no extra shared libraries beyond glibc. A new dependency that only ships an sdist (no wheel) would break the hermetic build, which is wheel-only.
-- `podman-compose up -d` to run with Solr (`rhokp-rhel9` from `registry.redhat.io`)
+Full build process documentation with data flow diagrams: **[docs/CONTAINER_BUILD.md](docs/CONTAINER_BUILD.md)**.
 
-### Hermetic Builds (Konflux + Cachi2)
+Quick reference:
 
-The Containerfile install step has two paths. The hermetic path uses two stdlib venvs to keep the build backend out of the runtime; both paths land the app at `${HOME}/.venvs/okp-mcp`:
-
-- **Hermetic** (Konflux): `/cachi2/cachi2.env` exists, network is off. A throwaway `${HOME}/.venvs/build` venv gets the hash-pinned `hatchling` backend (`pip install --only-binary=:all: --require-hashes -r .konflux/requirements-build.txt`) and builds the okp_mcp wheel with `pip wheel --no-build-isolation --no-deps`. The app venv then installs only the hash-pinned runtime deps plus that locally built wheel (`pip install --no-deps --no-index --find-links`). hatchling and its build deps never touch the app venv, so nothing needs uninstalling and the runtime SBOM carries no build tooling. This split also avoids a version clash: `packaging` is both a runtime dep and a hatchling build dep, and mixing both manifests in one venv would conflict. No `uv` here: it cannot be fetched with the network off.
-- **Local / non-hermetic**: installs pinned `uv`, then `uv sync --locked` straight from `uv.lock` (uv invokes the same hatchling backend to build the project).
-
-`uv.lock` is the single source of truth. `.konflux/requirements.txt` (runtime) and `.konflux/requirements-build.txt` (hatchling build backend + its deps) are **generated** from it by `scripts/konflux_requirements.py`, never hand-edited. `make check-konflux-requirements` (run in CI and `make ci`) re-exports and fails if they drift. Regenerate with `make konflux-requirements` after any `uv.lock` or build-system change, then commit.
-
-**Win32-only deps are pruned.** `uv export` emits Windows-only transitive deps (`pywin32` via `mcp`, `pywin32-ctypes` via `keyring`, `colorama`) with a `sys_platform == 'win32'` marker. Cachi2/hermeto prefetch enumerates every line and ignores environment markers, so it tries to fetch `pywin32` for Linux, finds no distribution (Windows-only wheels, no sdist), and fails the `prefetch-dependencies` task. The runtime is always Linux/distroless, so these are never installed. `konflux_requirements.py` drops them via `uv export --prune colorama --prune pywin32 --prune pywin32-ctypes`. If a new win32-only transitive dep appears, add another `--prune <pkg>` (RSPEED-3208).
-
-**Hermetic mode is currently DISABLED.** The PipelineRuns (`.tekton/pull_request.yaml`, `.tekton/push.yaml`) set `hermetic: "false"` and an empty `prefetch-input` (`value: ""`). The Cachi2/hermeto prefetch stamps `hermeto:pip:package:binary=true` SPDX annotations into the SBOM whenever `prefetch-input` is populated (it keys off that input, not the `hermetic` flag), and Conforma's `sbom_spdx.disallowed_package_attributes` rule on the release pipeline rejects those annotations. That blocked promotion to the prod quay.io repo: the image built fine but never released. Disabling hermetic builds is the unblock until the prefetch/SBOM-annotation path is fixed upstream.
-
-To re-enable hermetic builds, set `hermetic: "true"` and restore the populated `prefetch-input` in BOTH PipelineRun files: `[{"type": "pip", "path": ".", "requirements_files": [".konflux/requirements.txt"], "requirements_build_files": [".konflux/requirements-build.txt"], "allow_binary": "true"}]` (wheel-mode prefetch; avoids sdist build-time toolchains and the `uv` sdist Cargo.lock issue). The shared `pipeline-build-multiarch.yaml` already wires the `prefetch-dependencies` task and `CACHI2_ARTIFACT` into `build-images`; no pipeline change is needed to toggle hermetic mode. The Containerfile branches on `/cachi2/cachi2.env`, so it auto-selects the hermetic path once prefetch repopulates that file.
-
-To reproduce a hermetic build locally: `hermeto fetch-deps` (via `quay.io/konflux-ci/hermeto`) with the PipelineRun's `prefetch-input`, `generate-env`/`inject-files` into `/cachi2`, then `buildah build --network=none --volume <out>:/cachi2/output --volume <out>/cachi2.env:/cachi2/cachi2.env`.
+- Single `Containerfile`, multi-stage on Hummingbird images (builder + distroless runtime), both pinned to digests
+- `BUILD_FROM_SOURCE=1` (default): compiles all wheels from source (Konflux production). `BUILD_FROM_SOURCE=0`: prebuilt manylinux wheels (GitHub Actions CI)
+- Build logic lives in `scripts/container-install.sh` and `scripts/install-toolchain.sh`
+- Hermetic builds are **enabled** — Hermeto prefetches pip sdists + RPMs; `container-install.sh` detects `/cachi2/cachi2.env` and resolves offline
+- `uv.lock` is the single source of truth; `.konflux/requirements*.txt` + `rpms.lock.yaml` are generated artifacts
+- Regenerate after dep changes: `make konflux-requirements` (Python), `make rpm-lock` (RPMs)
+- Reproduce hermetic prefetch locally: `make hermeto-prefetch`
 
 ## Complexity
 

--- a/docs/CONTAINER_BUILD.md
+++ b/docs/CONTAINER_BUILD.md
@@ -1,0 +1,187 @@
+# Container Build Process
+
+Single `Containerfile`, multi-stage build on Red Hat Hardened Images (Project Hummingbird). Both stages pinned to digests.
+
+## Images
+
+| Stage | Image | Capabilities |
+|-------|-------|-------------|
+| Builder | `registry.access.redhat.com/hi/python:3.12-builder` | bash, dnf, pip, shadow-utils |
+| Runtime | `registry.access.redhat.com/hi/python:3.12` | distroless, ~39 MB compressed, UID 65532 |
+
+## Build Modes
+
+The `BUILD_FROM_SOURCE` build arg (default `1`) selects the mode:
+
+| Mode | Value | What it does | Used by |
+|------|-------|-------------|---------|
+| From-source | `1` | Installs C/Rust toolchain via `install-toolchain.sh`, compiles all wheels from sdist (`--no-binary`) | Konflux production |
+| Prebuilt-wheel | `0` | Uses manylinux wheels (`--only-binary`), no toolchain install | GitHub Actions CI (`--build-arg BUILD_FROM_SOURCE=0`) |
+
+## Data Flow
+
+### Non-hermetic (local / GitHub Actions CI)
+
+```text
+uv.lock (single source of truth)
+  │
+  ├─ scripts/konflux_requirements.py
+  │    ├─ uv export ──────────────────→ .konflux/requirements.txt        (runtime deps)
+  │    ├─ uv pip compile ─────────────→ .konflux/requirements-build.txt  (hatchling only)
+  │    └─ uvx pybuild-deps compile
+  │         ├─ uv-build pin (rustc compat) ──→ .konflux/requirements-build-all.txt  (full build tree)
+  │         └─ proxy-missing split ──────────→ .konflux/requirements-build-pypi.txt (direct PyPI)
+  │
+  ├─ Containerfile
+  │    ├─ COPY .konflux/ + src/ + scripts/
+  │    ├─ [if BUILD_FROM_SOURCE=1] scripts/install-toolchain.sh
+  │    │    └─ dnf install gcc rust cargo ... (from image repos, network on)
+  │    └─ scripts/container-install.sh
+  │         ├─ venv /opt/.venvs/build  ← pip install build backends
+  │         ├─ pip wheel (okp_mcp)
+  │         ├─ venv /opt/.venvs/okp-mcp ← pip install runtime deps + wheel
+  │         └─ smoke-test: python -c "import okp_mcp"
+  │
+  └─ Runtime stage
+       └─ COPY --from=builder /opt/.venvs/okp-mcp → same path
+```
+
+### Hermetic (Konflux + Hermeto)
+
+```text
+.tekton/pull_request.yaml / push.yaml
+  │  hermetic: "true"
+  │  prefetch-input:
+  │    ├─ type: pip  → requirements.txt + requirements-build-all.txt + requirements-build-pypi.txt
+  │    └─ type: rpm  → rpms.lock.yaml
+  │
+  ▼
+Hermeto prefetch-dependencies task
+  │  Downloads all pip sdists + RPMs into /cachi2/output/
+  │  Writes /cachi2/cachi2.env (sets PIP_FIND_LINKS, PIP_NO_INDEX)
+  │  Injects file:// yum repo into /etc/yum.repos.d/
+  │
+  ▼
+Containerfile (--network none)
+  ├─ scripts/install-toolchain.sh
+  │    └─ Detects Hermeto-injected repo, runs dnf --disablerepo='*' --enablerepo=<hermeto-repo>
+  └─ scripts/container-install.sh
+       ├─ Sources /cachi2/cachi2.env → pip resolves from offline mirror
+       ├─ venv /opt/.venvs/build  ← pip install --no-binary=:all: --require-hashes
+       │    └─ -r requirements-build-all.txt -r requirements-build-pypi.txt
+       ├─ pip wheel --no-build-isolation --no-deps . (builds okp_mcp from source)
+       ├─ venv /opt/.venvs/okp-mcp ← pip install --no-binary=:all: --require-hashes -r requirements.txt
+       ├─ pip install --no-deps --no-index okp_mcp (from local wheel)
+       └─ smoke-test
+```
+
+## Key Containerfile Details
+
+- Builder runs as `USER 0` (root) to create `/opt` and install packages. Ephemeral — only the venv is copied out.
+- App venv path is `/opt/.venvs/okp-mcp` in both stages. pip bakes absolute-path shebangs, so this path **must match** between builder and runtime.
+- `ENTRYPOINT ["okp-mcp"]` is relative — resolved via `execvp` against `PATH` (venv `bin/` is prepended).
+- `COMMIT_SHA` is a build arg, set as `ENV` in runtime. `build_info.py` reads it via `os.getenv`.
+- `HEALTHCHECK` uses exec-form TCP-connect probe (`python3.12 -c` socket check on port 8000). No shell required.
+
+## Manifest Generation
+
+`uv.lock` is the single source of truth. The `.konflux/` manifests are **generated** artifacts:
+
+| File | Contents | Generator |
+|------|----------|-----------|
+| `requirements.txt` | Hash-pinned runtime deps | `uv export` |
+| `requirements-build.txt` | Hatchling + transitive deps (prebuilt-wheel path only) | `uv pip compile` |
+| `requirements-build-all.txt` | Full PEP 517 build tree for every sdist (from-source path) | `uvx pybuild-deps compile` |
+| `requirements-build-pypi.txt` | Packages missing from Konflux artifact proxy (direct PyPI) | Split from `requirements-build-all.txt` |
+
+Regenerate after any `uv.lock` or `pyproject.toml` build-system change:
+
+```bash
+make konflux-requirements   # regenerates all four .konflux/ files
+make check-konflux-requirements  # CI gate: fails if manifests drifted from uv.lock
+```
+
+### Win32-only dep pruning
+
+`uv export` emits Windows-only transitive deps (`pywin32`, `pywin32-ctypes`, `colorama`) with `sys_platform == 'win32'` markers. Hermeto ignores environment markers and fails on packages with no Linux distribution. `konflux_requirements.py` prunes them via `uv export --prune`. If a new win32-only transitive dep appears, add another `--prune <pkg>` flag.
+
+### uv-build version pin
+
+`pybuild-deps` resolves the latest `uv-build`, but `uv-build >=0.11.8` requires rustc ≥1.93. The Hummingbird builder image ships rustc 1.92, so `konflux_requirements.py` pins `uv-build==0.11.7` (MSRV 1.92). Remove this pin when the builder image ships rustc ≥1.93.
+
+### Proxy-missing package split
+
+Some build-dep packages are not available on the Konflux artifact registry proxy. `konflux_requirements.py` splits them into `requirements-build-pypi.txt` with `--index-url https://pypi.org/simple/` so they resolve directly from PyPI. The current proxy-missing packages are `setuptools-rust` and `vcs-versioning`. Add new package names to the `PROXY_MISSING` regex as failures are discovered.
+
+## RPM Toolchain Deps
+
+From-source builds need a C/Rust toolchain not shipped in the builder image. In hermetic mode, RPMs must be prefetched.
+
+| File | Purpose |
+|------|---------|
+| `rpms.in.yaml` | Declares required packages + content origin repos + target arches |
+| `rpms.lock.yaml` | Resolved RPM dependency tree (generated, never hand-edited) |
+
+The `contentOrigin.repos[].repoid` in `rpms.in.yaml` must match a valid Hummingbird Pulp repo ID. The allowed repo IDs are defined in the [RHTAP EC policy](https://github.com/release-engineering/rhtap-ec-policy) — getting these wrong causes Hermeto RPM prefetch to fail silently or resolve the wrong packages.
+
+Regenerate after editing `rpms.in.yaml`:
+
+```bash
+make rpm-lock   # resolves RPM tree against builder image, writes rpms.lock.yaml
+```
+
+`install-toolchain.sh` installs these RPMs. In hermetic mode it detects the Hermeto-injected `file://` repo and restricts `dnf` to it; in non-hermetic mode it resolves from the image's network repos.
+
+## Build Script Reference
+
+| Script | Purpose |
+|--------|---------|
+| `scripts/container-install.sh` | Shared install logic: build venv → wheel → app venv → smoke test. Branches on `BUILD_FROM_SOURCE` and `/cachi2/cachi2.env`. |
+| `scripts/install-toolchain.sh` | Installs gcc, rust, cargo, openssl-devel, etc. Skipped when `BUILD_FROM_SOURCE=0`. Handles hermetic vs network RPM repos. |
+| `scripts/konflux_requirements.py` | Regenerates all `.konflux/requirements*.txt` from `uv.lock`. Handles win32 pruning, uv-build pin, proxy-missing split. |
+| `scripts/test-container-startup.sh` | CI smoke test: starts container, waits for healthcheck, stops. |
+
+## Local Reproduction
+
+### Build the container
+
+```bash
+# Prebuilt-wheel (fast, for development)
+podman build -t okp-mcp --build-arg BUILD_FROM_SOURCE=0 .
+
+# From-source (matches Konflux production)
+podman build -t okp-mcp .
+```
+
+### Run with Solr
+
+```bash
+podman-compose up -d   # starts okp-mcp + Solr (rhokp-rhel9)
+```
+
+### Reproduce hermetic prefetch locally
+
+```bash
+make hermeto-prefetch   # runs Hermeto in podman, output in .hermeto-out/
+make hermeto-clean      # removes .hermeto-out/
+```
+
+The full hermetic build (network-off container build against prefetched deps) can be reproduced with:
+
+```bash
+make hermeto-prefetch
+buildah build --network=none \
+  --volume .hermeto-out:/cachi2/output:z \
+  --volume .hermeto-out/cachi2.env:/cachi2/cachi2.env:z \
+  .
+```
+
+## Makefile Targets
+
+| Target | Purpose |
+|--------|---------|
+| `make konflux-requirements` | Regenerate `.konflux/` manifests from `uv.lock` |
+| `make check-konflux-requirements` | CI gate: fail if manifests drifted |
+| `make rpm-lock` | Regenerate `rpms.lock.yaml` from `rpms.in.yaml` |
+| `make hermeto-prefetch` | Run Hermeto prefetch locally (requires podman) |
+| `make hermeto-clean` | Remove `.hermeto-out/` |


### PR DESCRIPTION
Stacked on #337.

Extracts the detailed container build documentation from AGENTS.md into `docs/CONTAINER_BUILD.md` and fixes all stale references in AGENTS.md.

## What changed

**New file: `docs/CONTAINER_BUILD.md`**
- Containerfile stages, build modes, and key details
- Data flow diagrams for non-hermetic and hermetic (Konflux + Hermeto) builds
- Manifest generation pipeline (requirements files, win32 pruning, uv-build pin, proxy-missing split)
- RPM toolchain deps with RHTAP EC policy reference for repo IDs
- Build script reference table
- Local reproduction commands

**AGENTS.md fixes**
- `build.yml` → `ci.yml` (renamed months ago, never updated)
- Missing `.konflux/` files: `requirements-build-all.txt`, `requirements-build-pypi.txt`
- Missing scripts: `container-install.sh`, `install-toolchain.sh`, `test-container-startup.sh`
- Missing root files: `rpms.in.yaml`, `rpms.lock.yaml`
- Missing Makefile targets: `fix`, `rpm-lock`, `hermeto-prefetch`, `hermeto-clean`
- Missing docs in Project Layout: `CONTAINER_BUILD.md`, `RELEASE_BRANCHES.md`
- New Where to Look rows for RPM toolchain deps and container install scripts
- Container section replaced with concise summary + link to the extracted doc
