### PR TITLE
feat: add stateless_http, default enabled for session-free MCP transport

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,9 @@ uv sync                          # install all deps (including dev)
 uv run okp-mcp                   # run server (streamable-http, default)
 uv run okp-mcp --transport stdio                        # stdio mode
 uv run okp-mcp --transport streamable-http --port 8000  # explicit HTTP mode
-uv run okp-mcp --stateless-http                        # stateless mode (no session tracking)
+# Stateless mode is enabled by default for streamable-http.
+# Disable with: uv run okp-mcp --stateless-http false
+# or: MCP_STATELESS_HTTP=false uv run okp-mcp
 ```
 
 ## CI Commands (Makefile)
@@ -135,7 +137,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
-| Enable stateless mode | `src/okp_mcp/config.py` | `--stateless-http` flag or `MCP_STATELESS_HTTP=true` env var |
+| Enable stateless mode | `src/okp_mcp/config.py` | Enabled by default. `--stateless-http false` or `MCP_STATELESS_HTTP=false` to disable |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ uv sync                          # install all deps (including dev)
 uv run okp-mcp                   # run server (streamable-http, default)
 uv run okp-mcp --transport stdio                        # stdio mode
 uv run okp-mcp --transport streamable-http --port 8000  # explicit HTTP mode
+uv run okp-mcp --stateless-http                        # stateless mode (no session tracking)
 ```
 
 ## CI Commands (Makefile)
@@ -134,6 +135,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
+| Enable stateless mode | `src/okp_mcp/config.py` | `--stateless-http` flag or `MCP_STATELESS_HTTP=true` env var |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
 | Mock Solr responses | `tests/conftest.py` | `solr_mock` fixture uses respx |
 | Deploy to OpenShift | `openshift/okp-mcp.yml` | Template with params: IMAGE, IMAGE_TAG, REPLICAS, etc. |

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -161,6 +161,7 @@ class ServerConfig(BaseSettings):
 
     @property
     def transport_kwargs(self) -> dict[str, str | int | bool | list[StarletteMiddleware]]:
+        """Keyword arguments to pass to `mcp.run()` for the configured transport."""
         result: dict[str, str | int | bool | list[StarletteMiddleware]] = {}
         if self.transport in {Transport.streamable_http, Transport.sse}:
             result["host"] = self.host

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -146,6 +146,12 @@ class ServerConfig(BaseSettings):
         default=None,
         description="GlitchTip/Sentry DSN for exception reporting",
     )
+    stateless_http: bool = Field(
+        default=False,
+        description="Run in stateless mode (new transport per request, no session tracking). "
+        "Eliminates sticky session requirement when multiple clients share one endpoint. "
+        "Only applies to streamable-http transport.",
+    )
 
     @computed_field
     @property
@@ -154,8 +160,8 @@ class ServerConfig(BaseSettings):
         return f"{self.solr_url}/solr/portal/select"
 
     @property
-    def transport_kwargs(self) -> dict[str, str | int | list[StarletteMiddleware]]:
-        result = {}
+    def transport_kwargs(self) -> dict[str, str | int | bool | list[StarletteMiddleware]]:
+        result: dict[str, str | int | bool | list[StarletteMiddleware]] = {}
         if self.transport in {Transport.streamable_http, Transport.sse}:
             result["host"] = self.host
             result["port"] = self.port
@@ -163,6 +169,8 @@ class ServerConfig(BaseSettings):
                 StarletteMiddleware(PrometheusMiddleware),
                 StarletteMiddleware(RequestIDHeaderMiddleware),
             ]
+        if self.transport == Transport.streamable_http and self.stateless_http:
+            result["stateless_http"] = True
 
         return result
 

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -147,10 +147,10 @@ class ServerConfig(BaseSettings):
         description="GlitchTip/Sentry DSN for exception reporting",
     )
     stateless_http: bool = Field(
-        default=False,
+        default=True,
         description="Run in stateless mode (new transport per request, no session tracking). "
         "Eliminates sticky session requirement when multiple clients share one endpoint. "
-        "Only applies to streamable-http transport.",
+        "Only applies to streamable-http transport. Set to false to restore stateful sessions.",
     )
 
     @computed_field

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -171,3 +171,47 @@ def test_max_response_chars_rejects_non_positive(bad_value):
     """max_response_chars rejects zero and negative values at load time."""
     with pytest.raises(ValidationError, match="max_response_chars"):
         ServerConfig(max_response_chars=bad_value)
+
+
+# --- stateless_http tests ---
+
+
+def test_stateless_http_defaults_to_false():
+    """Stateless mode is disabled by default for backward compatibility."""
+    config = ServerConfig()
+    assert config.stateless_http is False
+
+
+def test_stateless_http_env_var():
+    """MCP_STATELESS_HTTP env var enables stateless mode."""
+    with patch.dict("os.environ", {"MCP_STATELESS_HTTP": "true"}):
+        config = ServerConfig()
+    assert config.stateless_http is True
+
+
+def test_stateless_http_from_cli():
+    """--stateless-http CLI flag enables stateless mode."""
+    config = CliApp.run(ServerConfig, cli_args=["--stateless-http", "true"])
+    assert config.stateless_http is True
+
+
+@pytest.mark.parametrize(
+    "transport,expected_in_kwargs",
+    [
+        ("streamable-http", True),
+        ("sse", False),
+        ("stdio", False),
+    ],
+)
+def test_stateless_http_in_transport_kwargs(transport, expected_in_kwargs):
+    """stateless_http only appears in transport_kwargs for streamable-http transport."""
+    config = ServerConfig(transport=transport, stateless_http=True)
+    kwargs = config.transport_kwargs
+    assert ("stateless_http" in kwargs) == expected_in_kwargs
+
+
+def test_stateless_http_not_in_kwargs_when_false():
+    """stateless_http is not included in transport_kwargs when disabled."""
+    config = ServerConfig(transport="streamable-http", stateless_http=False)
+    kwargs = config.transport_kwargs
+    assert "stateless_http" not in kwargs

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -130,7 +130,7 @@ def test_port_type_coercion():
 
 
 @pytest.mark.parametrize(
-    "solr_url, expected_endpoint",
+    ("solr_url", "expected_endpoint"),
     [
         ("http://localhost:8983", "http://localhost:8983/solr/portal/select"),
         ("http://rhel-okp:8983", "http://rhel-okp:8983/solr/portal/select"),
@@ -190,28 +190,23 @@ def test_stateless_http_disable_via_env_var():
 
 
 def test_stateless_http_from_cli():
-    """--stateless-http CLI flag controls stateless mode."""
+    """--stateless-http CLI argument controls stateless mode."""
     config = CliApp.run(ServerConfig, cli_args=["--stateless-http", "false"])
     assert config.stateless_http is False
 
 
 @pytest.mark.parametrize(
-    "transport,expected_in_kwargs",
+    ("transport", "stateless_http", "expected_in_kwargs"),
     [
-        ("streamable-http", True),
-        ("sse", False),
-        ("stdio", False),
+        ("streamable-http", True, True),
+        ("streamable-http", False, False),
+        ("http", True, False),
+        ("sse", True, False),
+        ("stdio", True, False),
     ],
 )
-def test_stateless_http_in_transport_kwargs(transport, expected_in_kwargs):
+def test_stateless_http_in_transport_kwargs(transport, stateless_http, expected_in_kwargs):
     """stateless_http only appears in transport_kwargs for streamable-http transport."""
-    config = ServerConfig(transport=transport, stateless_http=True)
+    config = ServerConfig(transport=transport, stateless_http=stateless_http)
     kwargs = config.transport_kwargs
     assert ("stateless_http" in kwargs) == expected_in_kwargs
-
-
-def test_stateless_http_not_in_kwargs_when_disabled():
-    """stateless_http is not included in transport_kwargs when explicitly disabled."""
-    config = ServerConfig(transport="streamable-http", stateless_http=False)
-    kwargs = config.transport_kwargs
-    assert "stateless_http" not in kwargs

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -176,23 +176,23 @@ def test_max_response_chars_rejects_non_positive(bad_value):
 # --- stateless_http tests ---
 
 
-def test_stateless_http_defaults_to_false():
-    """Stateless mode is disabled by default for backward compatibility."""
+def test_stateless_http_defaults_to_true():
+    """Stateless mode is enabled by default."""
     config = ServerConfig()
+    assert config.stateless_http is True
+
+
+def test_stateless_http_disable_via_env_var():
+    """MCP_STATELESS_HTTP=false env var disables stateless mode."""
+    with patch.dict("os.environ", {"MCP_STATELESS_HTTP": "false"}):
+        config = ServerConfig()
     assert config.stateless_http is False
 
 
-def test_stateless_http_env_var():
-    """MCP_STATELESS_HTTP env var enables stateless mode."""
-    with patch.dict("os.environ", {"MCP_STATELESS_HTTP": "true"}):
-        config = ServerConfig()
-    assert config.stateless_http is True
-
-
 def test_stateless_http_from_cli():
-    """--stateless-http CLI flag enables stateless mode."""
-    config = CliApp.run(ServerConfig, cli_args=["--stateless-http", "true"])
-    assert config.stateless_http is True
+    """--stateless-http CLI flag controls stateless mode."""
+    config = CliApp.run(ServerConfig, cli_args=["--stateless-http", "false"])
+    assert config.stateless_http is False
 
 
 @pytest.mark.parametrize(
@@ -210,8 +210,8 @@ def test_stateless_http_in_transport_kwargs(transport, expected_in_kwargs):
     assert ("stateless_http" in kwargs) == expected_in_kwargs
 
 
-def test_stateless_http_not_in_kwargs_when_false():
-    """stateless_http is not included in transport_kwargs when disabled."""
+def test_stateless_http_not_in_kwargs_when_disabled():
+    """stateless_http is not included in transport_kwargs when explicitly disabled."""
     config = ServerConfig(transport="streamable-http", stateless_http=False)
     kwargs = config.transport_kwargs
     assert "stateless_http" not in kwargs


### PR DESCRIPTION
Add `--stateless-http` flag and make it the default for streamable-http transport. In stateless mode each HTTP POST creates a fresh transport with no session tracking.

## Why

When multiple lightspeed-stack containers connect to the same okp-mcp endpoint, stateful MCP sessions clash — containers get errors and timeouts. The current workaround requires sticky sessions and a 1:1 pod ratio in OpenShift.

Stateless mode eliminates session tracking entirely. Each request is handled independently, so load balancers, multiple pods, and multiple clients all work naturally. No client-side changes needed — the llama-stack MCP client already handles stateless servers correctly.

## What changed

- `ServerConfig` gains `stateless_http: bool`, **defaulting to `True`**
- `transport_kwargs` wires it only for `streamable-http` transport (SSE doesn't support stateless mode, stdio is unaffected)
- To opt out: `--stateless-http false` or `MCP_STATELESS_HTTP=false`
- `AGENTS.md` updated with usage and reference

## Verified

- `make ci` passes (lint + typecheck + radon + 401 tests)
- End-to-end: `ServerConfig().transport_kwargs` includes `stateless_http: True` for streamable-http, excluded for SSE/stdio
- CodeRabbit: 0 findings

Fixes: RSPEED-3333


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to run the `streamable-http` transport in stateless mode by default, with support for disabling it via a CLI flag or environment variable.

* **Bug Fixes**
  * Improved transport behavior so session-state settings are only applied where relevant, keeping other transports unchanged.

* **Documentation**
  * Updated setup guidance to explain how to enable or disable stateless HTTP mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->