### PR TITLE
style(scripts): use [[ instead of [ in shell conditionals

### DIFF
--- a/scripts/container-install.sh
+++ b/scripts/container-install.sh
@@ -25,7 +25,7 @@ set -euo pipefail
 # --- Determine pip binary-handling flags ---
 # Prebuilt-wheel builds use --only-binary=:all: (fast, uses manylinux wheels).
 # From-source builds use --no-binary=:all: (compiles every C/Rust extension).
-if [ "${BUILD_FROM_SOURCE:-0}" = "1" ]; then
+if [[ "${BUILD_FROM_SOURCE:-0}" = "1" ]]; then
     PIP_BINARY_FLAG="--no-binary=:all:"
     export CMAKE_BUILD_PARALLEL_LEVEL="$(nproc)"
     export MAX_JOBS="$(nproc)"
@@ -39,7 +39,7 @@ fi
 # environment so pip resolves from the prefetched offline mirror. Some prefetch
 # layouts also ship cachi2.env as a file; source it when present (harmless
 # otherwise). Local builds have neither and resolve from PyPI.
-if [ -f /cachi2/cachi2.env ]; then
+if [[ -f /cachi2/cachi2.env ]]; then
     # shellcheck source=/dev/null
     . /cachi2/cachi2.env
 fi
@@ -53,7 +53,7 @@ fi
 #    setuptools-rust, uv-build, etc.). Prebuilt-wheel builds only need
 #    hatchling — runtime deps install from manylinux wheels, not sdists.
 "${UV_PYTHON:-python3}" -m venv "${VENVS}/build"
-if [ "${BUILD_FROM_SOURCE:-0}" = "1" ]; then
+if [[ "${BUILD_FROM_SOURCE:-0}" = "1" ]]; then
     # Full build tree: every PEP 517 backend needed to compile every sdist
     # (maturin, setuptools-rust, etc.). Split across three files because some
     # packages are not available on the Konflux artifact proxy.

--- a/scripts/install-toolchain.sh
+++ b/scripts/install-toolchain.sh
@@ -18,17 +18,17 @@
 set -euo pipefail
 
 # Exit early for prebuilt-wheel builds that don't need a C/Rust toolchain.
-if [ "${BUILD_FROM_SOURCE:-1}" != "1" ]; then
+if [[ "${BUILD_FROM_SOURCE:-1}" != "1" ]]; then
     echo "install-toolchain.sh: BUILD_FROM_SOURCE=${BUILD_FROM_SOURCE:-1}, skipping toolchain install"
     exit 0
 fi
 
 dnf_args=(--allowerasing)
 
-if [ -f /cachi2/cachi2.env ]; then
+if [[ -f /cachi2/cachi2.env ]]; then
     # Find the Hermeto-injected repo (name varies); disable all others.
     hermeto_repo=$(grep -lm1 'file:///cachi2' /etc/yum.repos.d/*.repo 2>/dev/null | head -1)
-    if [ -n "$hermeto_repo" ]; then
+    if [[ -n "$hermeto_repo" ]]; then
         repo_id=$(sed -n 's/^\[\([^]]*\)\].*/\1/p' "$hermeto_repo" | head -1)
         dnf_args+=(--disablerepo='*' --enablerepo="$repo_id")
     fi

--- a/scripts/test-container-startup.sh
+++ b/scripts/test-container-startup.sh
@@ -3,11 +3,11 @@ docker run --rm -d -p 8000:8000 --name okp-mcp-test "$1"
 
 for _attempt in {1..30}; do
 STATUS=$(docker inspect -f '{{.State.Health.Status}}' okp-mcp-test 2>/dev/null || echo "missing")
-if [ "$STATUS" = "healthy" ]; then
+if [[ "$STATUS" = "healthy" ]]; then
   echo "Container is healthy!"
   docker stop okp-mcp-test
   exit 0
-elif [ "$STATUS" = "unhealthy" ]; then
+elif [[ "$STATUS" = "unhealthy" ]]; then
   echo "Container healthcheck failed!"
   break
 fi


### PR DESCRIPTION
## What

Replace all `[` single-bracket conditionals with `[[` double-bracket in shell scripts, as flagged by SonarCloud (shelldre:S7688). Double brackets are safer (no word splitting, no pathname expansion, better string comparison) and are already a bash-builtin in the shebang line.

## Changes

- `scripts/container-install.sh`: 3 conditionals
- `scripts/install-toolchain.sh`: 3 conditionals
- `scripts/test-container-startup.sh`: 2 conditionals

## Test notes

- All 402 pytest tests pass
- shellcheck shows no new warnings
