### PR TITLE
chore: add SonarCloud project properties file

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,26 @@
+# SonarQube / SonarCloud project configuration
+# https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/analysis-parameters/
+
+sonar.projectKey=rhel-lightspeed_okp-mcp
+sonar.projectName=okp-mcp
+sonar.organization=rhel-lightspeed
+
+# Source and test locations
+sonar.sources=src
+sonar.tests=tests
+sonar.sourceEncoding=UTF-8
+
+# Python-specific
+sonar.python.version=3.12
+sonar.python.coverage.reportPaths=coverage/coverage.xml
+
+# Exclusions
+sonar.exclusions=\
+  **/__pycache__/**,\
+  **/.venv/**,\
+  **/.mypy_cache/**
+
+sonar.coverage.exclusions=\
+  tests/**,\
+  src/okp_mcp/build_info.py,\
+  src/okp_mcp/__init__.py


### PR DESCRIPTION
## What

Add a `sonar-project.properties` file so SonarCloud has explicit project configuration instead of relying on autodetection. The file was present on disk locally but never committed.

## What it configures

- **Project identity**: project key, name, organization
- **Python version**: pin to 3.12 for precise analysis instead of default "compatible with all versions"
- **Coverage**: points SonarCloud at `coverage/coverage.xml`
- **Exclusions**: skips caches, venvs, tests (coverage only), and build-info boilerplate

This resolves the SonarCloud warning about missing Python version configuration.
