### PR TITLE
ci(workflows): use explicit permissions and avoid secret expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,8 @@ on:
       - main
       - release/**
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   sanity:

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -7,7 +7,8 @@ on:
     branches: [main]
     types: [completed]
 
-permissions: read-all
+permissions:
+  contents: read
 
 env:
   OKP_IMAGE_TAG: '1.1.9-1775158501'
@@ -49,10 +50,12 @@ jobs:
         run: docker load -i /tmp/okp-image.tar
 
       - name: Start OKP Solr
+        env:
+          ACCESS_KEY: ${{ secrets.OKP_ACCESS_KEY }}
         run: |
           docker run -d --name redhat-okp \
             -p 8983:8983 \
-            -e ACCESS_KEY="${{ secrets.OKP_ACCESS_KEY }}" \
+            -e ACCESS_KEY \
             -e SOLR_JETTY_HOST=0.0.0.0 \
             "registry.redhat.io/offline-knowledge-portal/rhokp-rhel9:${{ env.OKP_IMAGE_TAG }}"
 

--- a/.github/workflows/renovate-konflux.yml
+++ b/.github/workflows/renovate-konflux.yml
@@ -4,7 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize]
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   regenerate:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -6,12 +6,14 @@ on:
   schedule:
     - cron: "0 6 * * 1" # Weekly Monday 6am UTC (1am CT)
 
-permissions: read-all
+permissions:
+  contents: read
 
 jobs:
   scorecard:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       security-events: write
       id-token: write
     steps:


### PR DESCRIPTION
## What

Fix five SonarCloud issues in GitHub Actions workflow files:

- **`githubactions:S8234`** (4×): Replace `permissions: read-all` with explicit `permissions: contents: read` in `ci.yml`, `functional.yml`, `scorecard.yml`, and `renovate-konflux.yml`
- **`githubactions:S7636`** (1×): Move `OKP_ACCESS_KEY` from inline secret expansion to step-level `env:` with docker-run automatic environment inheritance in `functional.yml`

Also adds missing `contents: read` to the scorecard job's own permissions block (it overrides the workflow-level default with only `security-events` and `id-token`).

## Test notes

- All 402 pytest tests pass
- Pre-commit hooks clean (check-yaml, gitleaks, whitespace)
- `make ci` passes (lint, typecheck, radon, hermetic manifests)
