### PR TITLE
chore: expand Containerfile labels to match rhel-knowledge-bridge standard

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -30,11 +30,20 @@ RUN scripts/container-install.sh
 # Stage 2: Runtime - UBI 10 Python 3.12 Minimal (has shell, microdnf, python3.12).
 FROM registry.access.redhat.com/ubi10/python-312-minimal:latest@sha256:c060604f820e6aed184f2b61aeed8faddb5c60344b2cf6e4c6e4e478196d729e AS runtime
 
-LABEL com.redhat.component=okp-mcp
+LABEL com.redhat.application=rhel-knowledge-bridge
+LABEL com.redhat.component=rhel-knowledge-bridge
 LABEL description="MCP server for the RHEL Offline Knowledge Portal"
-LABEL name=okp-mcp
-LABEL summary="OKP MCP Server"
+LABEL distribution-scope=private
+LABEL io.k8s.description="MCP server for the RHEL Offline Knowledge Portal"
+LABEL io.k8s.display-name="RHEL Offline Knowledge Portal MCP server"
+LABEL io.openshift.tags="rhel,knowledge-portal,mcp"
+LABEL name="rhel-knowledge-bridge/rhel-knowledge-bridge-rhel10"
+LABEL cpe="cpe:/a:redhat:rhel_knowledge_bridge:1.0::el10"
+LABEL release="1.0"
+LABEL version=1.0
+LABEL url="https://github.com/rhel-lightspeed/okp-mcp"
 LABEL vendor="Red Hat, Inc."
+LABEL summary="MCP server for the RHEL Offline Knowledge Portal"
 
 # Copy the dependency venv from the builder stage. It keeps the SAME path it was
 # created at in the builder, so console-script shebangs stay valid without

--- a/Containerfile
+++ b/Containerfile
@@ -32,9 +32,9 @@ FROM registry.access.redhat.com/ubi10/python-312-minimal:latest@sha256:c060604f8
 
 LABEL com.redhat.application=rhel-knowledge-bridge
 LABEL com.redhat.component=rhel-knowledge-bridge
-LABEL description="MCP server for the RHEL Offline Knowledge Portal"
+LABEL description="Red Hat Offline Knowledge Portal"
 LABEL distribution-scope=private
-LABEL io.k8s.description="MCP server for the RHEL Offline Knowledge Portal"
+LABEL io.k8s.description="Red Hat Offline Knowledge Portal"
 LABEL io.k8s.display-name="RHEL Offline Knowledge Portal MCP server"
 LABEL io.openshift.tags="rhel,knowledge-portal,mcp"
 LABEL name="rhel-knowledge-bridge/rhel-knowledge-bridge-rhel10"
@@ -43,7 +43,7 @@ LABEL release="1.0"
 LABEL version=1.0
 LABEL url="https://github.com/rhel-lightspeed/okp-mcp"
 LABEL vendor="Red Hat, Inc."
-LABEL summary="MCP server for the RHEL Offline Knowledge Portal"
+LABEL summary="Red Hat Offline Knowledge Portal"
 
 # Copy the dependency venv from the builder stage. It keeps the SAME path it was
 # created at in the builder, so console-script shebangs stay valid without


### PR DESCRIPTION
Adds the full set of Red Hat container labels (com.redhat.application, distribution-scope, io.k8s.*, io.openshift.tags, name, cpe, release, version, url) to align with the labeling pattern used across the rhel-lightspeed portfolio.