### PR TITLE
ci: ignore generated Konflux manifests in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>rhel-lightspeed/renovate-config"],
+  "ignorePaths": [".konflux/requirements*.txt"],
   "tekton": {
     "enabled": false
   }


### PR DESCRIPTION
## Summary

- Ignore generated Konflux requirements manifests in Renovate scans
- Keep dependency update source of truth in uv.lock / pyproject.toml

## Testing

- python -m json.tool renovate.json

CodeRabbit skipped by request.
