### PR TITLE
feat: add MCP_EXCLUDE_KBASE config to filter kbase from search

### DIFF
--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -152,6 +152,12 @@ class ServerConfig(BaseSettings):
         "Eliminates sticky session requirement when multiple clients share one endpoint. "
         "Only applies to streamable-http transport. Set to false to restore stateful sessions.",
     )
+    exclude_kbase: bool = Field(
+        default=False,
+        description="Exclude kbase documents (solutions and articles) from search results. "
+        "Intended for disconnected (offline) deployments where kbase content is unavailable. "
+        "When enabled, adds fq=-documentKind:(solution OR article) to the main Solr query.",
+    )
 
     @computed_field
     @property

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -12,6 +12,7 @@ from dataclasses import replace
 
 import httpx
 
+from okp_mcp.config import CONFIG
 from okp_mcp.config import logger
 from okp_mcp.content import _select_within_budget
 from okp_mcp.content import doc_uri
@@ -95,10 +96,18 @@ def _build_main_query(cleaned_query: str) -> dict:
     Intent-specific boosts are applied by ``apply_main_boosts`` (from
     ``intent.py``) after construction.  See ``INTENT_RULES`` for the full
     list of detected intents and their boost parameters.
+
+    When ``CONFIG.exclude_kbase`` is enabled, a negated ``documentKind`` filter
+    is added to exclude kbase solutions and articles.  This is intended for
+    disconnected deployments where kbase content is unavailable.
     """
+    eol_fq = _build_eol_filter()
+    fq: str | list[str] = eol_fq
+    if CONFIG.exclude_kbase:
+        fq = [eol_fq, "-documentKind:(solution OR article)"]
     return {
         "q": cleaned_query,
-        "fq": _build_eol_filter(),
+        "fq": fq,
         "qf": _MAIN_QF,
         "fl": _MAIN_FL,
         # Token budget control: _deduplicate_by_parent keeps only the best

--- a/tests/test_portal.py
+++ b/tests/test_portal.py
@@ -1,5 +1,7 @@
 """Unit tests for the portal search module: query builders, chunk conversion, RRF, orchestrator, formatting."""
 
+from unittest.mock import patch
+
 import httpx
 import pytest
 import respx
@@ -353,6 +355,54 @@ class TestBuildMainQuery:
         """3 highlight snippets requested per document (enough for BM25 to pick good passages)."""
         params = _build_main_query("test")
         assert params["hl.snippets"] == "3"
+
+
+# ---------------------------------------------------------------------------
+# Main query builder — kbase exclusion filter
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMainQueryExcludeKbase:
+    """Verify the kbase exclusion filter in the main query builder."""
+
+    def test_exclude_kbase_disabled_by_default_fq_is_string(self):
+        """When exclude_kbase is False (default), fq is a plain EOL-filter string."""
+        params = _build_main_query("test query")
+        fq = params["fq"]
+        assert isinstance(fq, str)
+        assert "documentKind" not in fq
+
+    def test_exclude_kbase_enabled_fq_is_list(self):
+        """When exclude_kbase is True, fq becomes a list containing both filters."""
+        with patch("okp_mcp.portal.CONFIG") as mock_cfg:
+            mock_cfg.exclude_kbase = True
+            params = _build_main_query("test query")
+        fq = params["fq"]
+        assert isinstance(fq, list)
+
+    def test_exclude_kbase_enabled_contains_negated_document_kind_filter(self):
+        """When exclude_kbase is True, the kbase negation clause is present in fq."""
+        with patch("okp_mcp.portal.CONFIG") as mock_cfg:
+            mock_cfg.exclude_kbase = True
+            params = _build_main_query("test query")
+        assert "-documentKind:(solution OR article)" in params["fq"]
+
+    def test_exclude_kbase_enabled_preserves_eol_filter(self):
+        """When exclude_kbase is True, the EOL product exclusion filter is still present."""
+        with patch("okp_mcp.portal.CONFIG") as mock_cfg:
+            mock_cfg.exclude_kbase = True
+            params = _build_main_query("test query")
+        eol_fq = _build_eol_filter()
+        assert eol_fq in params["fq"]
+
+    def test_exclude_kbase_disabled_no_document_kind_filter(self):
+        """When exclude_kbase is False, no documentKind clause is added to fq."""
+        with patch("okp_mcp.portal.CONFIG") as mock_cfg:
+            mock_cfg.exclude_kbase = False
+            params = _build_main_query("test query")
+        fq = params["fq"]
+        assert isinstance(fq, str)
+        assert "documentKind" not in fq
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add a new boolean config option `exclude_kbase` (default: False, env var `MCP_EXCLUDE_KBASE`) that excludes kbase solutions and articles from the main Solr query. Intended for disconnected/offline deployments where kbase content is unavailable.

When enabled, `_build_main_query()` appends a negated documentKind filter `-documentKind:(solution OR article)` alongside the existing EOL product filter, matching the pattern already used by `_build_deprecation_query()`.

Adds 5 unit tests in `TestBuildMainQueryExcludeKbase` covering both the default (disabled) and enabled states.

Resolves: RSPEED-3328