### PR TITLE
Add make target to update lock file and generate requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,8 @@ make test        # pytest with coverage
 make konflux-requirements        # regenerate .konflux hermetic manifests from uv.lock
 make check-konflux-requirements  # fail if .konflux manifests drifted from uv.lock
 make rpm-lock                    # regenerate rpms.lock.yaml from rpms.in.yaml
+make lock                        # resolve deps and update uv.lock
+make freeze                      # lock + regenerate .konflux manifests (preferred workflow)
 make hermeto-prefetch             # run Hermeto prefetch locally (requires podman)
 make hermeto-clean                # remove .hermeto-out/
 ```
@@ -122,9 +124,10 @@ rpms.lock.yaml                # resolved RPM dependency tree (generated from rpm
     functional.yml         # Functional tests against live Solr (triggered after ci.yml)
     scorecard.yml          # OpenSSF Scorecard: security posture, weekly + push-to-main
 docs/
-  CONTAINER_BUILD.md     # Container build process, data flow diagrams, hermetic builds
-  RELEASE_BRANCHES.md    # Release branch workflow
-  SOLR_EXPLORATION.md    # Historical: original redhat-okp container schema map
+  CONTAINER_BUILD.md         # Container build process, data flow diagrams, hermetic builds
+  RELEASE_BRANCHES.md        # Release branch workflow
+  SOLR_EXPLORATION.md        # Historical: original redhat-okp container schema map
+  UPDATING_REQUIREMENTS.md   # Dependency update workflow: make freeze, lock, konflux-requirements
 openshift/
   okp-mcp.yml                   # OpenShift deployment template (Deployment, Service, ServiceAccount)
   qe-gating-stage-trigger.yml   # OpenShift Job template that triggers the auto-qe-gating GitLab pipeline after staging deploys
@@ -157,6 +160,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Trigger QE pipeline after staging deploy | `openshift/qe-gating-stage-trigger.yml` | OpenShift Job template; calls the GitLab CI trigger API for the auto-qe-gating project. Secret `auto-qe-trigger` supplies `gitlab-url`, `project-id`, `trigger-token`. |
 | Run locally with systemd | `quadlet/` | Rootless quadlet files: `.container`, `.network`, `.volume`; see `quadlet/README.md` |
 | Modify pre-commit hooks | `.pre-commit-config.yaml` | Runs on every commit: ruff, gitleaks, whitespace, YAML/TOML checks |
+| Update Python dependencies | `pyproject.toml`, `uv.lock`, `.konflux/` | See [docs/UPDATING_REQUIREMENTS.md](docs/UPDATING_REQUIREMENTS.md); `make freeze` is the preferred single command |
 | Change hermetic build deps | `scripts/konflux_requirements.py`, `.konflux/` | Regenerate with `make konflux-requirements` after a `uv.lock`/build-system change; CI gates drift |
 | Change RPM toolchain deps | `rpms.in.yaml`, `scripts/install-toolchain.sh` | Edit `rpms.in.yaml`, run `make rpm-lock`, update `install-toolchain.sh` if package list changed |
 | Change container install logic | `scripts/container-install.sh`, `Containerfile` | Build venv → wheel → app venv; branches on `BUILD_FROM_SOURCE` and `/cachi2/cachi2.env` |

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: fix lint format typecheck radon test ci setup konflux-requirements check-konflux-requirements rpm-lock hermeto-prefetch hermeto-clean
+.PHONY: check-konflux-requirements ci fix format freeze hermeto-clean hermeto-prefetch konflux-requirements lint lock radon rpm-lock setup test typecheck
 
 fix:
 	uv run --locked ruff check --fix
@@ -68,3 +68,9 @@ rpm-lock:
 	BUILDER=$$(awk '/^FROM /{print $$2; exit}' Containerfile) && \
 	podman run --rm -v "$$(pwd):/work:z" -w /work \
 	  $(RLP_IMAGE) --image "$$BUILDER" rpms.in.yaml
+
+
+lock:
+	uv lock
+
+freeze: lock konflux-requirements

--- a/docs/UPDATING_REQUIREMENTS.md
+++ b/docs/UPDATING_REQUIREMENTS.md
@@ -1,0 +1,32 @@
+# Updating Python Dependencies
+
+To update project dependencies and generate requirements files run `make freeze`.
+
+This resolves dependencies and regenerates the requirements files in a single step. Commit the resulting changes to `uv.lock` and `.konflux/` together.
+
+`make freeze` runs two targets in sequence:
+
+1. **`make lock`** -- Runs `uv lock` to resolve all dependency constraints in `pyproject.toml` and update `uv.lock`.
+2. **`make konflux-requirements`** -- Runs `scripts/konflux_requirements.py` to regenerate the requirements files in `.konflux/` from the updated `uv.lock`.
+
+These can be run independently if needed.
+
+## CI Verification
+
+CI runs `make check-konflux-requirements` to verify that the `.konflux/` manifests match `uv.lock`. If you update `uv.lock` without regenerating the manifests, CI will fail with:
+
+```
+FAIL: .konflux manifests are stale. Run 'make konflux-requirements' and commit.
+```
+
+Using `make freeze` avoids this by keeping both artifacts in sync.
+
+## RPM Dependencies
+
+If you are changing build-toolchain RPM packages (in `rpms.in.yaml`), that has a separate workflow:
+
+```bash
+make rpm-lock
+```
+
+This regenerates `rpms.lock.yaml` from `rpms.in.yaml` using the builder image. See [CONTAINER_BUILD.md](CONTAINER_BUILD.md) for details on the hermetic build process.


### PR DESCRIPTION
This makes it much easier to keep the requirements files in sync with the lock file. The lock file remains the source of truth.