### PR TITLE
Harden GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,12 @@ jobs:
       - name: Test container startup
         run: scripts/test-container-startup.sh okp-mcp:test-${{ matrix.platform }}
 
+  functional:
+    name: Functional Tests
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    needs: build
+    uses: ./.github/workflows/functional.yml
+    secrets:
+      REGISTRY_REDHAT_IO_USERNAME: ${{ secrets.REGISTRY_REDHAT_IO_USERNAME }}
+      REGISTRY_REDHAT_IO_PASSWORD: ${{ secrets.REGISTRY_REDHAT_IO_PASSWORD }}
+      OKP_ACCESS_KEY: ${{ secrets.OKP_ACCESS_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          uv sync --locked
+          uv sync --locked --group dev
           echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: ${{ matrix.test.step_name }}
@@ -96,7 +96,9 @@ jobs:
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies
-        run: uv sync --locked --group dev
+        run: |
+          uv sync --locked --group dev
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run tests
         run: make test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,7 @@ jobs:
           python-version-file: pyproject.toml
 
       - name: Install uv
+        # zizmor: ignore[cache-poisoning] -- this job only runs linters and tests, never publishes artifacts
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies
@@ -93,6 +94,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
+        # zizmor: ignore[cache-poisoning] -- this job only runs tests, never publishes artifacts
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -82,6 +84,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -118,6 +122,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up QEMU
         uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Log in to registry.redhat.io
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -86,10 +86,12 @@ jobs:
           python-version: '3.12'
 
       - name: Install dependencies
-        run: uv sync
+        run: |
+          uv sync --locked --group dev
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
 
       - name: Run functional tests
-        run: uv run pytest -m functional -v
+        run: pytest -m functional -v
 
       - name: Dump Solr logs on failure
         if: failure()

--- a/.github/workflows/functional.yml
+++ b/.github/workflows/functional.yml
@@ -1,11 +1,14 @@
 name: Functional Tests
 
 on:
-  # Run after CI/CD passes on main (push only, not PRs)
-  workflow_run:
-    workflows: [CI/CD]
-    branches: [main]
-    types: [completed]
+  workflow_call:
+    secrets:
+      REGISTRY_REDHAT_IO_USERNAME:
+        required: true
+      REGISTRY_REDHAT_IO_PASSWORD:
+        required: true
+      OKP_ACCESS_KEY:
+        required: true
 
 permissions:
   contents: read
@@ -18,9 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    if: >-
-      github.event.workflow_run.conclusion == 'success'
-      && github.event.workflow_run.event == 'push'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -39,6 +39,7 @@ jobs:
           python-version-file: pyproject.toml
 
       - name: Install uv
+        # zizmor: ignore[cache-poisoning] -- this job never publishes artifacts
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Install dependencies

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Install Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/renovate-konflux.yml
+++ b/.github/workflows/renovate-konflux.yml
@@ -26,13 +26,11 @@ jobs:
           persist-credentials: false
 
       - name: Install Python
-        # v6.3.0
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version-file: pyproject.toml
 
       - name: Install uv
-        # v8.2.0
         uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Regenerate Konflux manifests

--- a/.github/workflows/renovate-konflux.yml
+++ b/.github/workflows/renovate-konflux.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.head_ref }}
+          persist-credentials: false
 
       - name: Install Python
         # v6.3.0


### PR DESCRIPTION
- Disable cache to avoid cache poisoning 
- Do not persistent credentials
- Switch to `workflow_call` instead of `workflow_run`