### PR TITLE
fix: make get_document actually resolve doc_ids

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,9 +70,12 @@ Test scenarios live in `tests/functional_cases.py` as `FunctionalCase` dataclass
 
 Functional tests are **deselected by default** via `pytest_collection_modifyitems` in `tests/conftest.py`. They only run when explicitly requested with `-m functional`. They require a running OKP Solr container (`podman-compose up -d`); tests skip automatically if Solr is unreachable.
 
+A second functional module, `tests/test_functional_document.py`, exercises the `get_document` retrieval layer against live Solr. It seeds a real document via `_run_portal_search()`, then calls `_fetch_document_with_query()` / `_fetch_document_raw()` to prove the doc_id drives retrieval while the caller's query only selects highlights (it does not gate retrieval), and that a visible document URL round-trips through `_normalize_doc_id()` before the fetch layer.
+
 **Key files**:
 - `tests/functional_cases.py`: `FunctionalCase` dataclass + parametrized RSPEED test data
 - `tests/test_functional.py`: test runner calling `_run_portal_search()` with structured assertions
+- `tests/test_functional_document.py`: `get_document` retrieval tests (query-does-not-gate, highlight selection, URL normalization round-trip)
 
 ## Project Layout
 
@@ -102,6 +105,7 @@ tests/
   conftest.py          # shared fixtures (solr mocks, sample responses) + functional marker deselection
   functional_cases.py  # FunctionalCase dataclass + parametrized RSPEED test data
   test_functional.py   # functional test runner: calls _run_portal_search() against live Solr, asserts on PortalChunk results
+  test_functional_document.py  # functional get_document tests: query does not gate retrieval, highlight selection, URL normalization round-trip
   test_portal.py       # portal.py unit tests: query builders, chunk conversion, RRF, formatting, single/multi-query orchestrators
   test_*.py            # unit test modules mirror src structure
 .pre-commit-config.yaml  # pre-commit hook definitions (ruff, gitleaks, whitespace, YAML/TOML checks)
@@ -151,6 +155,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Add/modify intent detection | `src/okp_mcp/intent.py` | Append `IntentRule` to `INTENT_RULES` at the correct priority position |
 | Change portal search logic | `src/okp_mcp/portal.py` | Query builders, chunk conversion, RRF fusion, single/multi-query orchestrators, formatting |
 | Change Solr query logic | `src/okp_mcp/solr.py` | `_solr_query()` builds edismax params; `_clean_query()` for tokenization |
+| Change document retrieval query | `src/okp_mcp/tools/document.py` | `_fetch_document_with_query()` selects the doc via `q` under `defType=lucene` and passes the caller's query as `hl.q` (highlights only) so `mm` never gates retrieval; `_doc_id_filter()` normalizes ID suffix forms |
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -203,6 +203,13 @@ async def _fetch_document_with_query(
     document happens to share too few terms with the query would match zero
     rows and be reported as "Document not found". Returns the Solr response.
     """
+    # defType=lucene overrides the edismax default from _SOLR_BASE_PARAMS. The
+    # base edismax boost params (qf/pf/mm/ps) still ride along in the merged
+    # request and appear in the SOLR query log, but Solr silently ignores them
+    # under the lucene parser -- they are inert here, not a bug. They are left
+    # in place rather than filtered out because _solr_query is shared with
+    # search_portal, which needs them; stripping them would risk that path for a
+    # purely cosmetic log cleanup.
     return await _solr_query(
         {
             "q": _doc_id_filter(doc_id),

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -65,12 +65,22 @@ def _escape_solr_phrase(value: str) -> str:
 def _doc_id_filter(doc_id: str) -> str:
     """Build a Solr filter that matches a document by ``id`` or ``view_uri``.
 
-    Solr ``id`` may carry an ``/index.html`` suffix that ``view_uri`` omits,
-    so checking both fields ensures a match regardless of which form the
-    caller provides. The value is escaped to prevent Lucene query injection.
+    Both fields are checked in both suffix forms, because the corpus uses
+    three different conventions and callers legitimately supply any of them:
+
+    - solutions/articles/documentation carry ``id`` with an ``/index.html``
+      suffix and no ``view_uri`` at all, yet search_portal renders their URL
+      with the suffix stripped -- so the visible URL round-trips only if the
+      suffix is restored here.
+    - errata carry ``id`` as the bare advisory ID (``RHSA-2026:29976``) and
+      ``view_uri`` as ``/errata/RHSA-2026:29976/``; appending ``/index.html``
+      to an erratum matches neither field.
+    - CVEs carry both forms.
+
+    The value is escaped to prevent Lucene query injection.
     """
-    safe = _escape_solr_phrase(doc_id)
-    return f'id:"{safe}" OR view_uri:"{safe}"'
+    safe = _escape_solr_phrase(doc_id.removesuffix("/index.html").removesuffix("/"))
+    return f'id:"{safe}" OR id:"{safe}/index.html" OR view_uri:"{safe}" OR view_uri:"{safe}/"'
 
 
 def _uses_document_passages(doc: SolrDoc) -> bool:
@@ -181,15 +191,24 @@ async def _fetch_document_with_query(
     *,
     solr_endpoint: str,
 ) -> SolrResponse:
-    """Fetch a document by ID using edismax query mode with highlighting.
+    """Fetch a document by ID, using the caller's query only to pick highlights.
 
-    Uses _solr_query so edismax and highlight parameters are applied.
-    Returns the raw Solr response dict.
+    Identity and relevance are kept in separate parameters on purpose. The
+    document is selected by ``q`` under the lucene parser, and the caller's
+    query is passed as ``hl.q`` so it chooses which passages come back
+    without deciding whether the document is returned at all.
+
+    Putting the caller's query in ``q`` instead would subject retrieval to
+    the edismax ``mm`` in _SOLR_BASE_PARAMS: a perfectly valid doc_id whose
+    document happens to share too few terms with the query would match zero
+    rows and be reported as "Document not found". Returns the Solr response.
     """
     return await _solr_query(
         {
-            "q": _clean_query(query),
-            "fq": _doc_id_filter(doc_id),
+            "q": _doc_id_filter(doc_id),
+            "defType": "lucene",
+            "hl.q": _clean_query(query),
+            "hl.qparser": "edismax",
             "fl": DOCUMENT_FL,
             "rows": 1,
             "hl.snippets": "10",
@@ -207,7 +226,12 @@ async def _fetch_document_raw(
 
     Uses httpx directly rather than _solr_query to avoid injecting edismax
     and highlight parameters that are not appropriate for raw document retrieval.
-    Returns the raw Solr response dict.
+
+    ``defType`` is pinned to lucene because bypassing _solr_query does not
+    bypass the Solr request handler's own defaults, which select edismax.
+    Under edismax the field-qualified OR in _doc_id_filter is treated as a
+    set of optional clauses governed by the handler's ``mm``, so every
+    lookup matched zero documents. Returns the Solr response.
     """
     close_client = client is None
     if client is None:
@@ -217,6 +241,7 @@ async def _fetch_document_raw(
             solr_endpoint,
             params={
                 "q": _doc_id_filter(doc_id),
+                "defType": "lucene",
                 "wt": "json",
                 "fl": DOCUMENT_FL,
                 "rows": 1,

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,9 +11,13 @@ from prometheus_client import REGISTRY
 
 from okp_mcp import tools
 from okp_mcp.config import ServerConfig
+from okp_mcp.solr import _clean_query
+from okp_mcp.tools.document import _doc_id_filter
 from okp_mcp.tools.document import _DOCUMENTATION_MAX_CHARS
 from okp_mcp.tools.document import _DOCUMENTATION_MAX_SECTIONS
 from okp_mcp.tools.document import _DOCUMENTATION_PER_SECTION
+from okp_mcp.tools.document import _fetch_document_raw
+from okp_mcp.tools.document import _fetch_document_with_query
 from okp_mcp.tools.document import _format_document_content
 from okp_mcp.tools.document import _format_document_passages
 from okp_mcp.tools.document import _format_metadata
@@ -460,3 +464,80 @@ async def test_not_found_counter_not_incremented_when_doc_exists():
         await tools.get_document(mock_ctx, "/solutions/12345")
 
     assert _get_counter("okp_document_not_found") == before
+
+
+# ---------------------------------------------------------------------------
+# Solr request construction
+#
+# These assert the parameters actually sent to Solr. The rest of this module
+# mocks _fetch_document_raw / _solr_query out, so a lookup that never matches
+# anything still passes every other test here.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "doc_id,expected_clause",
+    [
+        # solutions/articles/documentation: id carries /index.html, no view_uri,
+        # and search_portal renders the URL with the suffix stripped.
+        ("/solutions/5372961", 'id:"/solutions/5372961/index.html"'),
+        ("/solutions/5372961/index.html", 'id:"/solutions/5372961/index.html"'),
+        ("/articles/67521", 'id:"/articles/67521/index.html"'),
+        # errata: id is the bare advisory ID, view_uri is the path form.
+        ("RHSA-2026:29976", 'id:"RHSA-2026:29976"'),
+        ("/errata/RHSA-2026:29976/", 'view_uri:"/errata/RHSA-2026:29976/"'),
+        # CVE: both forms are indexed.
+        ("/security/cve/CVE-2024-1086/", 'view_uri:"/security/cve/CVE-2024-1086/"'),
+        ("/security/cve/CVE-2024-1086/index.html", 'id:"/security/cve/CVE-2024-1086/index.html"'),
+    ],
+)
+def test_doc_id_filter_covers_corpus_conventions(doc_id, expected_clause):
+    """Every doc_id form a caller can hold resolves to a matching clause."""
+    assert expected_clause in _doc_id_filter(doc_id)
+
+
+def test_doc_id_filter_escapes_quotes():
+    """Injection attempts stay inside the quoted phrase."""
+    assert '\\"' in _doc_id_filter('/solutions/1" OR id:*')
+
+
+async def test_fetch_document_raw_pins_lucene_parser():
+    """The raw lookup must not inherit the request handler's edismax default.
+
+    Under edismax the field-qualified OR is scored as optional clauses
+    governed by the handler's mm, which matches zero documents.
+    """
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = Mock(
+        json=Mock(return_value={"response": {"numFound": 0, "docs": []}}),
+        raise_for_status=Mock(),
+    )
+
+    await _fetch_document_raw("/solutions/5372961", client=mock_client, solr_endpoint=_SOLR_ENDPOINT)
+
+    params = mock_client.get.call_args.kwargs["params"]
+    assert params["defType"] == "lucene"
+    assert params["q"] == _doc_id_filter("/solutions/5372961")
+
+
+async def test_fetch_document_with_query_keeps_caller_query_out_of_q():
+    """Identity goes in q; the caller's query only picks highlights.
+
+    With the query in q, edismax mm decides whether the document comes back
+    at all, so a valid doc_id whose text shares too few terms with the query
+    is reported as "Document not found".
+    """
+    with patch("okp_mcp.tools.document._solr_query", new_callable=AsyncMock) as mock_query:
+        mock_query.return_value = SolrResponse()
+        await _fetch_document_with_query(
+            "/solutions/5372961",
+            "some unrelated question",
+            client=AsyncMock(spec=httpx.AsyncClient),
+            solr_endpoint=_SOLR_ENDPOINT,
+        )
+
+    params = mock_query.call_args.args[0]
+    assert params["q"] == _doc_id_filter("/solutions/5372961")
+    assert params["defType"] == "lucene"
+    assert params["hl.q"] == _clean_query("some unrelated question")
+    assert "fq" not in params

--- a/tests/test_functional_document.py
+++ b/tests/test_functional_document.py
@@ -1,0 +1,174 @@
+"""Functional tests for get_document retrieval against live Solr.
+
+These tests prove the two behaviors that unit tests (which mock Solr) cannot:
+
+1. The caller's query never gates retrieval. A document fetched by ID is
+   returned even when the query shares few or no terms with the document
+   text, because the query only drives highlighting (``hl.q``) and not the
+   main ``q`` under edismax ``mm``. This is the regression behind
+   GitHub issue #377 / the "Document not found" reports.
+2. The visible search-result URL round-trips back into get_document. The URL
+   search_portal renders (``/index.html`` stripped) resolves to the same
+   document whether or not the suffix is present.
+
+Tests seed a real document by running a portal search first, then feed the
+resulting URL back into the document-fetch helpers. This keeps them robust to
+index churn: whatever the live index currently returns for a stable query is
+what we round-trip.
+
+The visible URL is passed through ``_normalize_doc_id`` before the fetch, exactly
+as the ``get_document`` tool does: normalization (stripping the
+``access.redhat.com`` prefix to a bare path) is a required precondition of the
+fetch layer, since the corpus stores path-based IDs. ``test_visible_url_...``
+also asserts that the *un-normalized* URL returns zero documents, pinning down
+why that normalization step matters.
+
+Run with::
+
+    uv run pytest -m functional -v
+
+Requires: OKP Solr container running (``podman-compose up -d``). Tests skip
+automatically if Solr is unreachable.
+"""
+
+import httpx
+import pytest
+
+from okp_mcp.config import ServerConfig
+from okp_mcp.portal import _run_portal_search
+from okp_mcp.portal import PortalChunk
+from okp_mcp.tools.document import _fetch_document_raw
+from okp_mcp.tools.document import _fetch_document_with_query
+from okp_mcp.tools.document import _normalize_doc_id
+from okp_mcp.types import SolrResponse
+
+
+# Gibberish tokens that match no real document, proving the query cannot gate
+# retrieval: a lookup by ID must still return the document.
+_UNRELATED_QUERY = "qwxyz nonexistent gibberish token zzxq"
+
+
+async def _seed_document() -> tuple[str, str, str]:
+    """Return (visible_url, doc_id, parent_id) for a real document, skipping if Solr is down.
+
+    Runs a stable portal search and takes the top result. ``visible_url`` is the
+    ``online_source_url`` an LLM copies from search results; ``doc_id`` is that
+    URL after ``_normalize_doc_id`` (the required precondition the get_document
+    tool applies before any fetch); ``parent_id`` is the underlying Solr id used
+    to look up highlight snippets.
+    """
+    config = ServerConfig()
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        try:
+            chunks, _ = await _run_portal_search(
+                "How do I recreate the grub configuration file",
+                client=client,
+                solr_endpoint=config.solr_endpoint,
+                max_results=7,
+            )
+        except (httpx.ConnectError, httpx.TimeoutException):
+            pytest.skip(f"Solr not reachable at {config.solr_url}")
+            raise  # unreachable, satisfies type checker
+
+    top: PortalChunk | None = next((c for c in chunks if c.online_source_url), None)
+    if top is None:
+        pytest.skip("No seed document with a URL returned by portal search")
+    return top.online_source_url, _normalize_doc_id(top.online_source_url), top.parent_id or ""
+
+
+def _returned_docs(response: SolrResponse) -> int:
+    """Return the number of documents in a Solr response body."""
+    return len(response.response.docs)
+
+
+@pytest.mark.functional
+async def test_query_does_not_gate_document_retrieval() -> None:
+    """A document fetched by ID is returned even when the query matches nothing.
+
+    Proves the fix for the retrieval-gating bug: the caller's query drives
+    highlighting only, so a poorly-overlapping (here, deliberately unrelated)
+    query cannot turn a valid document lookup into "Document not found".
+    """
+    _, doc_id, _ = await _seed_document()
+    config = ServerConfig()
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        with_unrelated = await _fetch_document_with_query(
+            doc_id, _UNRELATED_QUERY, client, solr_endpoint=config.solr_endpoint
+        )
+
+    assert _returned_docs(with_unrelated) == 1, (
+        "Document lookup was gated by the query: an unrelated query returned "
+        f"zero documents for {doc_id!r}. The query must only drive highlighting."
+    )
+
+
+@pytest.mark.functional
+async def test_highlight_query_selects_passages_without_gating() -> None:
+    """A relevant query yields highlights; an unrelated query still returns the doc.
+
+    Contrasts the two query behaviors on the same document: both retrieve the
+    document (retrieval is not gated), but only the relevant query is expected
+    to produce highlight snippets keyed to that document.
+    """
+    _, doc_id, parent_id = await _seed_document()
+    config = ServerConfig()
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        relevant = await _fetch_document_with_query(
+            doc_id, "recreate grub configuration file", client, solr_endpoint=config.solr_endpoint
+        )
+        unrelated = await _fetch_document_with_query(
+            doc_id, _UNRELATED_QUERY, client, solr_endpoint=config.solr_endpoint
+        )
+
+    assert _returned_docs(relevant) == 1, f"Relevant query failed to retrieve {doc_id!r}"
+    assert _returned_docs(unrelated) == 1, f"Unrelated query failed to retrieve {doc_id!r}"
+
+    relevant_snippets = _highlight_snippets(relevant, parent_id)
+    assert relevant_snippets, (
+        f"Relevant query produced no highlight snippets; hl.q is not selecting passages for {doc_id!r}."
+    )
+
+
+@pytest.mark.functional
+async def test_visible_url_round_trips_through_raw_fetch() -> None:
+    """The search-result URL resolves back to the document via the raw path.
+
+    Proves the fix for the ID-suffix bug: the URL search_portal renders
+    (with ``/index.html`` stripped) resolves to the same document through the
+    no-query raw fetch, which is the fallback path when the LLM omits a query.
+    """
+    visible_url, doc_id, _ = await _seed_document()
+    config = ServerConfig()
+
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        raw = await _fetch_document_raw(doc_id, client, solr_endpoint=config.solr_endpoint)
+        raw_unnormalized = await _fetch_document_raw(visible_url, client, solr_endpoint=config.solr_endpoint)
+
+    assert _returned_docs(raw) == 1, (
+        f"Raw fetch could not resolve the normalized id {doc_id!r}. The id/view_uri "
+        "suffix normalization is not round-tripping."
+    )
+    assert _returned_docs(raw_unnormalized) == 0, (
+        f"The un-normalized URL {visible_url!r} unexpectedly resolved. This test "
+        "pins down why get_document must call _normalize_doc_id before fetching: "
+        "the corpus stores path-based ids, so the full URL matches nothing."
+    )
+
+
+def _highlight_snippets(response: SolrResponse, parent_id: str) -> list[str]:
+    """Return highlight snippets for the parent doc, tolerant of key form.
+
+    Solr keys highlighting by document id. The seed's parent_id should match,
+    but if the index keys differ (suffix form), fall back to any non-empty
+    main_content snippets present in the response.
+    """
+    keyed = response.highlighting.get(parent_id, {}).get("main_content", [])
+    if keyed:
+        return keyed
+    for hit in response.highlighting.values():
+        snippets = hit.get("main_content", [])
+        if snippets:
+            return snippets
+    return []


### PR DESCRIPTION
Fixes #377

`get_document` was failing to resolve doc_ids through three independent defects
in how the Solr request was built. #377 identified the third one.

### 1. `_fetch_document_raw` was still getting edismax

It bypassed `_solr_query` to avoid edismax, but bypassing the helper does not
bypass the request handler's own defaults, which select edismax with `mm`. The
field-qualified OR in `_doc_id_filter` was scored as optional clauses under that
`mm`, so it required a document matching **both** `id` and `view_uri` — a
document that does not exist. Every query-less lookup returned nothing.

Fixed by pinning `defType=lucene`.

### 2. `_fetch_document_with_query` let the query gate retrieval

It put the caller's query in `q` and the doc_id in `fq`, so `mm` decided whether
the document came back at all. A valid doc_id whose text shared too few terms
with the query was reported as not found:

| doc_id | query | result |
|---|---|---|
| `/security/cve/CVE-2017-7801/` | `Firefox memory safety vulnerability` | not found |
| `/security/cve/CVE-2017-7801/` | `CVE-2017-7801` | found |

Identity now stays in `q` under the lucene parser and the caller's query moves to
`hl.q`, which selects passages without gating retrieval.

### 3. `_doc_id_filter` matched only the exact string supplied (#377)

The corpus uses three conventions:

| kind | `id` | `view_uri` |
|---|---|---|
| solution / article / documentation | path + `/index.html` | absent |
| errata | bare advisory ID | path |
| CVE | path | path |

Since `search_portal` renders URLs with `/index.html` stripped, feeding a search
result straight back into `get_document` — what the tool docstring tells callers
to do — failed for every solution, article and documentation page.

The filter now tries both suffix forms of both fields. Compared to the
retry-on-zero-results approach suggested in the issue, this resolves in the same
query, so there is no extra round-trip.

## Verification

Against a live 496,982-document index: all 11 doc_id forms across the five
document kinds resolve with no query, with an on-target query, and with a wholly
unrelated query. Highlights still track the caller's query.

Includes tests asserting the Solr parameters themselves — the existing suite
mocks out the functions that build the request, so none of these three defects
were observable by it.
