### PR TITLE
Move manifests check to its own workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,6 @@ jobs:
             step_name: Check complexity
             command: make radon
 
-          - name: Manifests
-            step_name: Check hermetic manifests
-            command: make check-konflux-requirements
-
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -107,7 +103,6 @@ jobs:
       - name: Run tests
         run: make test
 
-
   build:
     name: Build - ${{ matrix.platform }}
 
@@ -151,3 +146,4 @@ jobs:
 
       - name: Test container startup
         run: scripts/test-container-startup.sh okp-mcp:test-${{ matrix.platform }}
+

--- a/.github/workflows/manifests.yml
+++ b/.github/workflows/manifests.yml
@@ -1,0 +1,51 @@
+name: Manifests
+
+on:
+  push:
+    branches:
+      - main
+      - release/**
+    paths:
+      - uv.lock
+      - .konflux/**
+
+  pull_request:
+    branches:
+      - main
+      - release/**
+    paths:
+      - uv.lock
+      - .konflux/**
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Check hermetic manifests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version-file: pyproject.toml
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@f98e06938123ccabd21905ea5d0069192241f9f1 # v8.3.1
+        with:
+          enable-cache: true
+          prune-cache: false
+
+      - name: Install dependencies
+        run: |
+          uv sync --locked
+          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
+
+      - name: Check hermetic manifests
+        run: make check-konflux-requirements

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,8 @@ rpms.lock.yaml                # resolved RPM dependency tree (generated from rpm
 .github/
   CODEOWNERS               # PR review assignment (@rhel-lightspeed/developers)
   workflows/
-    ci.yml                 # CI/CD: lint, typecheck, radon, pytest matrix, container build+push
+    ci.yml                 # CI: lint, typecheck, radon, pytest matrix, container build+push
+    manifests.yml          # Hermetic manifest drift check (runs only when uv.lock or .konflux/ change)
     functional.yml         # Functional tests against live Solr (triggered after ci.yml)
     scorecard.yml          # OpenSSF Scorecard: security posture, weekly + push-to-main
 docs/
@@ -165,7 +166,7 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Change RPM toolchain deps | `rpms.in.yaml`, `scripts/install-toolchain.sh` | Edit `rpms.in.yaml`, run `make rpm-lock`, update `install-toolchain.sh` if package list changed |
 | Change container install logic | `scripts/container-install.sh`, `Containerfile` | Build venv → wheel → app venv; branches on `BUILD_FROM_SOURCE` and `/cachi2/cachi2.env` |
 | Toggle hermetic build | `.tekton/pull_request.yaml`, `.tekton/push.yaml` | `hermetic` + `prefetch-input` params; pipeline already wires `prefetch-dependencies` |
-| Modify CI/CD workflows | `.github/workflows/` | `ci.yml` (test+container), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
+| Modify CI/CD workflows | `.github/workflows/` | `ci.yml` (test+container), `manifests.yml` (hermetic drift), `functional.yml` (Solr integration), `scorecard.yml` (OpenSSF) |
 | Solr schema reference | `docs/SOLR_EXPLORATION.md` | Historical: original redhat-okp container schema map |
 
 ## Tekton Pipeline Maintenance


### PR DESCRIPTION
Instead of running the manifests check on every CI run, only run it when the requirements files or lock file have changed. The task creates non-deterministic output so running it on every PR can cause the test to fail unrelated to the code change.