### PR TITLE
Add token to task used to update freeze files

### DIFF
--- a/.github/workflows/renovate-konflux.yml
+++ b/.github/workflows/renovate-konflux.yml
@@ -37,6 +37,8 @@ jobs:
         run: make konflux-requirements
 
       - name: Commit and push if changed
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -48,4 +50,5 @@ jobs:
 
           git add .konflux/
           git commit -m "chore: auto-regenerate Konflux manifests"
+          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
           git push


### PR DESCRIPTION
By setting `persist-credentials: false` in #371, it had the side effect of removing the token needed to authenticate and push changes. Add the token just to the task where it is needed.