### PR TITLE
Change make target to upgrade dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,8 +69,7 @@ rpm-lock:
 	podman run --rm -v "$$(pwd):/work:z" -w /work \
 	  $(RLP_IMAGE) --image "$$BUILDER" rpms.in.yaml
 
+upgrade:
+	uv lock --upgrade
 
-lock:
-	uv lock
-
-freeze: lock konflux-requirements
+freeze: upgrade konflux-requirements


### PR DESCRIPTION
`uv lock` by itself only updates the lock file if requirements in `pyproject.toml` have changed. It does not upgrade package dependencies.