### PR TITLE
fix: remove user query content from INFO-level logs (CWE-532)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -312,6 +312,12 @@ No circular imports. `types.py`, `bm25.py`, and `formatting.py` have zero intern
       return "user-friendly message"
   ```
 
+### Query Content Logging (CWE-532)
+- **Never log user query content at INFO level or above.** Tool arguments derive from end-user prompts and may contain hostnames, internal IPs, or error messages. Log operational data only: query count, result counts, doc IDs (Red Hat paths), timing, error types.
+- Solr query parameters (`q`, `fq`) are logged at **DEBUG** only, since `q` carries the user's cleaned query for search calls.
+- The `doc_id` parameter (a Red Hat documentation path, not user-supplied PII) is safe to log at INFO.
+- Security audit: RSPEED-3365, CWE-532, FIND-005.
+
 ### Async
 - All MCP tool functions are `async`
 - Use `httpx.AsyncClient` as async context manager for HTTP calls

--- a/src/okp_mcp/portal.py
+++ b/src/okp_mcp/portal.py
@@ -583,8 +583,7 @@ async def _run_portal_search(
             SEARCH_DEPRECATION_DETECTED.inc()
 
     logger.info(
-        "Portal search: query=%r main=%d dep=%d merged=%d deduped=%d returned=%d",
-        query,
+        "Portal search: main=%d dep=%d merged=%d deduped=%d returned=%d",
         len(main_chunks),
         len(dep_chunks),
         len(merged),

--- a/src/okp_mcp/solr.py
+++ b/src/okp_mcp/solr.py
@@ -188,7 +188,8 @@ class SolrStatus(StrEnum):
 async def _solr_query(params: dict, client: httpx.AsyncClient, *, solr_endpoint: str) -> SolrResponse:
     """Execute a SOLR query and return the parsed JSON response."""
     merged = _SOLR_BASE_PARAMS | params
-    logger.info("SOLR query: q=%r, fq=%r", params.get("q"), params.get("fq"))
+    logger.debug("SOLR query: q=%r, fq=%r", params.get("q"), params.get("fq"))
+    logger.info("SOLR query: defType=%s rows=%s", params.get("defType", "edismax"), params.get("rows"))
     _start = time.monotonic()
     _status = SolrStatus.SUCCESS
     result = SolrResponse()

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -284,7 +284,7 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
     _start = time.monotonic()
 
     doc_id = _normalize_doc_id(doc_id)
-    logger.info("get_document: doc_id=%r query=%r", doc_id, query)
+    logger.info("get_document: doc_id=%r has_query=%s", doc_id, bool(query))
     try:
         app = get_app_context(ctx)
         if query:
@@ -301,10 +301,10 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
 
         return await _format_document(docs[0], data, doc_id, query, app.max_response_chars)
     except httpx.TimeoutException:
-        logger.warning("get_document timed out for doc_id=%r query=%r", doc_id, query, exc_info=True)
+        logger.warning("get_document timed out for doc_id=%r", doc_id, exc_info=True)
         return f"Unable to fetch document {doc_id} because the request timed out. Please try again."
     except (httpx.HTTPError, ValueError):
-        logger.exception("get_document failed for doc_id=%r query=%r", doc_id, query)
+        logger.exception("get_document failed for doc_id=%r", doc_id)
         return f"Unable to fetch document {doc_id}. The knowledge base may be temporarily unavailable."
     finally:
         TOOL_DURATION.labels(tool="get_document").observe(time.monotonic() - _start)

--- a/src/okp_mcp/tools/search.py
+++ b/src/okp_mcp/tools/search.py
@@ -115,7 +115,7 @@ async def search_portal(
         queries = normalized[:_MAX_QUERIES]
 
         max_results = max(1, min(max_results, 20))
-        logger.info("search_portal: queries=%r max_results=%d", queries, max_results)
+        logger.info("search_portal: query_count=%d max_results=%d", len(queries), max_results)
 
         app = get_app_context(ctx)
 
@@ -138,13 +138,13 @@ async def search_portal(
         # Use the first query for the "No results" message and budget selection.
         return _format_portal_results(chunks, has_deprecation, queries[0], app.max_response_chars)
     except httpx.TimeoutException:
-        logger.warning("Search timed out for queries: %r", queries, exc_info=True)
+        logger.warning("Search timed out (query_count=%d)", len(queries), exc_info=True)
         return "The search timed out. Please try again with a simpler query."
     except httpx.HTTPError:
-        logger.exception("Search failed for queries: %r", queries)
+        logger.exception("Search failed (query_count=%d)", len(queries))
         return "The knowledge base search is temporarily unavailable. Please try again shortly."
     except ValueError:
-        logger.exception("Search failed for queries: %r", queries)
+        logger.exception("Search failed (query_count=%d)", len(queries))
         return "The knowledge base search returned an unexpected response. Please try again."
     finally:
         TOOL_DURATION.labels(tool="search_portal").observe(time.monotonic() - _start)


### PR DESCRIPTION
## RSPEED-3365 / FIND-005: CWE-532 — Insertion of Sensitive Information into Log File

Security audit finding: okp-mcp logged LLM-reformulated search queries verbatim at INFO level. Tool arguments derive from end-user conversational prompts and may contain hostnames, internal IPs, or error messages with PII.

### Changes

| File | Before | After |
|------|--------|-------|
| `tools/search.py` | `queries=%r` at INFO + WARN/ERROR | `query_count=%d` — content removed |
| `portal.py` | `query=%r` in portal search summary | Removed — keeps result counts only |
| `solr.py` | `q=%r, fq=%r` at INFO | `q=%r` demoted to DEBUG; new INFO line logs `defType` and `rows` |
| `tools/document.py` | `query=%r` at INFO + WARN/ERROR | `has_query=True/False` — content removed; `doc_id` (Red Hat path) kept |
| `AGENTS.md` | No logging policy | Added "Query Content Logging (CWE-532)" section |

### What is preserved

- **DEBUG level**: Solr `q` and `fq` parameters remain at DEBUG for troubleshooting
- **doc_id**: Red Hat documentation paths (e.g. `/solutions/220513`) are not user-supplied PII
- **Operational counts**: query count, result counts, timing, error types

### AIA/ESS compliance context

lightspeed-stack independently logs the raw user question to **Splunk HEC** (`rlsapi_v1.py` → `observability/formats/rlsapi.py`, index `rh_rhls-002`) for EU AI Act (AIA) and Red Hat Enterprise Security Standard (ESS) compliance (RSPEED-2326). okp-mcp is an internal MCP sub-service with no user identity context (`org_id`, `x-rh-identity`); compliance logging belongs at the lightspeed-stack boundary.

If okp-mcp ever needs to log queries for compliance or agentic Q&A analysis, it should route them to Splunk (or equivalent structured telemetry) with appropriate access controls — not to uncontrolled pod stdout.

### Testing

- `make ci` equivalent: ruff ✅, ty ✅, radon A/B ✅, 415 tests passed ✅
- No functional test changes needed (tests verify search results, not log output)

Resolves: RSPEED-3365

_Written by Claude Opus 4.6_