### PR TITLE
get_document: return real section anchors for documentation

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -12,7 +12,10 @@
                 "--reload",
                 "--reload-dir",
                 "src/"
-            ]
+            ],
+            "env": {
+                "MCP_OKP_HTML_URL": "http://localhost:8085"
+            }
         }
     }
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,10 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 
 ## Section Anchors (get_document outlines)
 
-`get_document` called on a documentation page without a query returns the page's section
-outline instead of content. Each entry carries the real URL fragment, so callers can link
-straight to a section rather than to the whole guide.
+`get_document` puts real URL fragments on both documentation paths: without a query it
+returns the page's section outline instead of content, and with a query it labels each
+returned passage with the section it came from. Either way the caller can link straight to
+a section rather than to the whole guide.
 
 The anchors cannot come from Solr. Red Hat assigns them in the AsciiDoc source -- "Kafka
 tuning overview" is published at `#con-config-tuning-intro-str` -- and no indexed field
@@ -173,6 +174,26 @@ matched the public docs.redhat.com fragments 45 of 45.
   avoided because it is heavily contended -- pointing the mirror at an unrelated local
   service yields an outline with no anchors rather than wrong ones, but it is still a
   wasted request per lookup.
+- Passages are placed by locating their text in the mirror's body via
+  `DocumentOutline.locate()`. Solr's `main_content` cannot be used for this: it leads with
+  the page's table of contents, which repeats most headings, so offsets computed against it
+  attribute passages to whichever heading the ToC listed. Measured over 146 highlight
+  passages from 33 guides: all 104 drawn from real prose were placed correctly and the 42
+  misses were every one a ToC fragment -- so `locate()` returning None means "not body
+  text", and those passages keep a bare `Passage N:` label rather than borrowing a
+  neighbour's anchor. (That also makes an unplaceable passage a reliable ToC detector, if
+  filtering them out is ever wanted.)
+- Passages that `locate()` cannot place are dropped as ToC noise, but only when prose
+  remains: an unavailable mirror makes everything look unplaceable, and a reference manual
+  can legitimately highlight nothing but heading runs. Measured over 39 guide+query pairs,
+  9 (23%) shed a ToC passage for -17% passage characters; 13 returned nothing but ToC and
+  were left alone. Filtering is a subset in Solr's own order, so relevance cannot regress.
+- Do NOT raise `hl.snippets` to compensate for the dropped passages. It was tried:
+  `hl.snippets` re-fragments the field rather than extending the list, and going from 10 to
+  24 pushed the three relevant admission passages out of the top three in favour of the
+  glossary. Aggregate passage and character counts improved while the answer got worse.
+- Anchoring covers Solr highlight passages. The BM25 fallback path
+  (`_extract_relevant_section`) is not anchored yet.
 - Outlines are trimmed to `_MAX_OUTLINE_CHARS` (15K) by dropping the deepest nesting
   levels, not by truncating the list. Mirror outlines run to a median of 22 sections but
   a p90 of 181 and a max of 460 (~37KB), and the sections a reader wants are as often in
@@ -196,7 +217,7 @@ matched the public docs.redhat.com fragments 45 of 45.
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Change the section outline | `src/okp_mcp/content.py` | `format_sections()` renders anchors from `outline.py` when present, else falls back to `heading_h1`/`heading_h2` titles. `_fit_to_budget()` trims to `_MAX_OUTLINE_CHARS` by shedding the deepest nesting levels first, never by cutting the tail; `clean_heading()` normalizes the NBSP numbering separators |
-| Change section anchor lookup | `src/okp_mcp/outline.py` | `parse_outline()` extracts `<section id>` pairs with stdlib `html.parser`; `OutlineFetcher` fetches and LRU-caches them from the HTML mirror. Every failure degrades to an empty list — never raise |
+| Change section anchor lookup | `src/okp_mcp/outline.py` | `parse_document()` extracts `<section id>` sections plus locatable body text with stdlib `html.parser`; `DocumentOutline.locate()` maps a passage to its section; `OutlineFetcher` fetches and LRU-caches parses from the HTML mirror. Every failure degrades to `NO_OUTLINE` — never raise |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
 | Enable stateless mode | `src/okp_mcp/config.py` | Enabled by default. `--stateless-http false` or `MCP_STATELESS_HTTP=false` to disable |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,8 @@ src/okp_mcp/
     shared.py    # shared tool constants
   solr.py        # Solr query builder, BM25 paragraph extraction, RHV filtering
   bm25.py        # Pure-Python BM25Plus scorer (drop-in for rank_bm25, no numpy)
-  content.py     # Boilerplate stripping, content truncation, text cleaning
+  content.py     # Boilerplate stripping, content truncation, text cleaning, section outline
+  outline.py     # Section anchors parsed from the OKP HTML mirror (fetch + LRU cache)
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
   types.py       # Shared TypedDicts: SolrDoc, SolrHighlighting, SolrResponseBody, SolrResponse
 tests/
@@ -145,6 +146,42 @@ quadlet/
 SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 ```
 
+## Section Anchors (get_document outlines)
+
+`get_document` called on a documentation page without a query returns the page's section
+outline instead of content. Each entry carries the real URL fragment, so callers can link
+straight to a section rather than to the whole guide.
+
+The anchors cannot come from Solr. Red Hat assigns them in the AsciiDoc source -- "Kafka
+tuning overview" is published at `#con-config-tuning-intro-str` -- and no indexed field
+carries them; deriving slugs from heading text matched 1 heading in 44 when measured
+against a live guide.
+
+They come from the OKP appliance instead, which serves the rendered HTML over httpd on
+port 8080 alongside Solr on 8983. Solr document ids *are* the mirror's paths, so
+`outline.py` fetches `{html_mirror_url}{id}` and parses the `<section id>` elements.
+Measured on a 250-document sample: all reachable, 236 expose `<section id>`, and the
+remaining 14 are single-topic pages with no subsections. Anchors produced for one guide
+matched the public docs.redhat.com fragments 45 of 45.
+
+- Configure with `MCP_OKP_HTML_URL`; it defaults to the `solr_url` host on port 8080.
+  Set it to `-` to disable the lookup.
+- In-container deployments need no configuration: the mcp container shares the pod
+  network, so the derived `http://<solr-host>:8080` already resolves to the mirror.
+- `podman-compose.yml` publishes the mirror as `8085:8080` for running the server from
+  source on the host; `.mcp.json` sets `MCP_OKP_HTML_URL` to match. Host port 8080 is
+  avoided because it is heavily contended -- pointing the mirror at an unrelated local
+  service yields an outline with no anchors rather than wrong ones, but it is still a
+  wasted request per lookup.
+- Outlines are trimmed to `_MAX_OUTLINE_CHARS` (15K) by dropping the deepest nesting
+  levels, not by truncating the list. Mirror outlines run to a median of 22 sections but
+  a p90 of 181 and a max of 460 (~37KB), and the sections a reader wants are as often in
+  the last chapter as the first -- a flat count cap dropped OpenShift's Chapter 9
+  entirely. The 460-section worst case degrades to its top three levels at ~11KB.
+- Every failure (mirror down, document absent, page without sections) falls back to a
+  title-only outline built from `heading_h1`/`heading_h2`. The lookup must never turn a
+  working `get_document` call into an error.
+
 ## Where to Look
 
 | Task | Location | Notes |
@@ -158,6 +195,8 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Change document retrieval query | `src/okp_mcp/tools/document.py` | `_fetch_document_with_query()` selects the doc via `q` under `defType=lucene` and passes the caller's query as `hl.q` (highlights only) so `mm` never gates retrieval; `_doc_id_filter()` normalizes ID suffix forms |
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
+| Change the section outline | `src/okp_mcp/content.py` | `format_sections()` renders anchors from `outline.py` when present, else falls back to `heading_h1`/`heading_h2` titles. `_fit_to_budget()` trims to `_MAX_OUTLINE_CHARS` by shedding the deepest nesting levels first, never by cutting the tail; `clean_heading()` normalizes the NBSP numbering separators |
+| Change section anchor lookup | `src/okp_mcp/outline.py` | `parse_outline()` extracts `<section id>` pairs with stdlib `html.parser`; `OutlineFetcher` fetches and LRU-caches them from the HTML mirror. Every failure degrades to an empty list — never raise |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
 | Enable stateless mode | `src/okp_mcp/config.py` | Enabled by default. `--stateless-http false` or `MCP_STATELESS_HTTP=false` to disable |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
@@ -242,7 +281,7 @@ __init__.py → build_info, config, metrics (side-effect import), request_id, se
 build_info.py → (standalone; reads COMMIT_SHA env var, APP_ROOT/COMMIT_SHA file, or local `git rev-parse`)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
 tools/search.py → config, metrics, portal, server
-tools/document.py → content, metrics, server, solr, tools/shared.py, types
+tools/document.py → content, metrics, outline, server, solr, tools/shared.py, types
 tools/run_code.py → config, server
 metrics.py  → server (imports mcp for custom_route)
 request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starlette
@@ -251,9 +290,10 @@ portal.py   → config, content, formatting, intent, solr, types
 formatting.py → (standalone)
 solr.py     → bm25, config, metrics, types
 bm25.py     → (standalone)
-server.py   → config
+server.py   → config, outline
 telemetry.py → build_info, config, sentry_sdk
-content.py  → types
+content.py  → outline, types
+outline.py  → (standalone; stdlib html.parser + httpx)
 types.py    → (standalone)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,7 +98,8 @@ src/okp_mcp/
     shared.py    # shared tool constants
   solr.py        # Solr query builder, BM25 paragraph extraction, RHV filtering
   bm25.py        # Pure-Python BM25Plus scorer (drop-in for rank_bm25, no numpy)
-  content.py     # Boilerplate stripping, content truncation, text cleaning
+  content.py     # Boilerplate stripping, content truncation, text cleaning, section outline
+  outline.py     # Section anchors parsed from the OKP HTML mirror (fetch + LRU cache)
   formatting.py  # Result annotation, deprecation/replacement detection, sort keys
   types.py       # Shared TypedDicts: SolrDoc, SolrHighlighting, SolrResponseBody, SolrResponse
 tests/
@@ -145,6 +146,47 @@ quadlet/
 SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 ```
 
+## Section Anchors (get_document outlines)
+
+`get_document` called on a documentation page without a query returns the page's section
+outline instead of content. Each entry carries the real URL fragment, so callers can link
+straight to a section rather than to the whole guide.
+
+The anchors cannot come from Solr. Red Hat assigns them in the AsciiDoc source -- "Kafka
+tuning overview" is published at `#con-config-tuning-intro-str` -- and no indexed field
+carries them; deriving slugs from heading text matched 1 heading in 44 when measured
+against a live guide.
+
+They come from the OKP appliance instead, which serves the rendered HTML over httpd on
+port 8080 alongside Solr on 8983. Solr document ids *are* the mirror's paths, so
+`outline.py` fetches `{html_mirror_url}{id}` and parses the `<section id>` elements.
+Measured on a 250-document sample: all reachable, 236 expose `<section id>`, and the
+remaining 14 are single-topic pages with no subsections. Anchors produced for one guide
+matched the public docs.redhat.com fragments 45 of 45.
+
+- Configure with `MCP_OKP_HTML_URL`; it defaults to the `solr_url` host on port 8080.
+  Set it to `-` to disable the lookup.
+- In-container deployments need no configuration: the mcp container shares the pod
+  network, so the derived `http://<solr-host>:8080` already resolves to the mirror.
+- `podman-compose.yml` publishes the mirror as `8085:8080` for running the server from
+  source on the host; `.mcp.json` sets `MCP_OKP_HTML_URL` to match. Host port 8080 is
+  avoided because it is heavily contended -- pointing the mirror at an unrelated local
+  service yields an outline with no anchors rather than wrong ones, but it is still a
+  wasted request per lookup.
+- Do NOT log the mirror URL. `MCP_OKP_HTML_URL` can carry credentials and the derived
+  default names an internal host, so startup logs the status only and a failed fetch logs
+  the document path with a status code or exception type. `str(httpx.HTTPStatusError)`
+  embeds the request URL, which is why the exception is summarised rather than formatted
+  into the message.
+- Outlines are trimmed to `_MAX_OUTLINE_CHARS` (15K) by dropping the deepest nesting
+  levels, not by truncating the list. Mirror outlines run to a median of 22 sections but
+  a p90 of 181 and a max of 460 (~37KB), and the sections a reader wants are as often in
+  the last chapter as the first -- a flat count cap dropped OpenShift's Chapter 9
+  entirely. The 460-section worst case degrades to its top three levels at ~11KB.
+- Every failure (mirror down, document absent, page without sections) falls back to a
+  title-only outline built from `heading_h1`/`heading_h2`. The lookup must never turn a
+  working `get_document` call into an error.
+
 ## Where to Look
 
 | Task | Location | Notes |
@@ -158,6 +200,8 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 | Change document retrieval query | `src/okp_mcp/tools/document.py` | `_fetch_document_with_query()` selects the doc via `q` under `defType=lucene` and passes the caller's query as `hl.q` (highlights only) so `mm` never gates retrieval; `_doc_id_filter()` normalizes ID suffix forms |
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
+| Change the section outline | `src/okp_mcp/content.py` | `format_sections()` renders anchors from `outline.py` when present, else falls back to `heading_h1`/`heading_h2` titles. `_fit_to_budget()` trims to `_MAX_OUTLINE_CHARS` by shedding the deepest nesting levels first, never by cutting the tail; `clean_heading()` normalizes the NBSP numbering separators |
+| Change section anchor lookup | `src/okp_mcp/outline.py` | `parse_outline()` extracts `<section id>` pairs with stdlib `html.parser`; `OutlineFetcher` fetches and LRU-caches them from the HTML mirror. Every failure degrades to an empty list — never raise |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
 | Enable stateless mode | `src/okp_mcp/config.py` | Enabled by default. `--stateless-http false` or `MCP_STATELESS_HTTP=false` to disable |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |
@@ -242,7 +286,7 @@ __init__.py → build_info, config, metrics (side-effect import), request_id, se
 build_info.py → (standalone; reads COMMIT_SHA env var, APP_ROOT/COMMIT_SHA file, or local `git rev-parse`)
 tools/__init__.py → tools/search.py, tools/document.py, tools/run_code.py
 tools/search.py → config, metrics, portal, server
-tools/document.py → content, metrics, server, solr, tools/shared.py, types
+tools/document.py → content, metrics, outline, server, solr, tools/shared.py, types
 tools/run_code.py → config, server
 metrics.py  → server (imports mcp for custom_route)
 request_id.py → fastmcp.server.dependencies, fastmcp.server.middleware, starlette
@@ -251,9 +295,10 @@ portal.py   → config, content, formatting, intent, solr, types
 formatting.py → (standalone)
 solr.py     → bm25, config, metrics, types
 bm25.py     → (standalone)
-server.py   → config
+server.py   → config, outline
 telemetry.py → build_info, config, sentry_sdk
-content.py  → types
+content.py  → outline, types
+outline.py  → (standalone; stdlib html.parser + httpx)
 types.py    → (standalone)
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,9 +148,10 @@ SECURITY.md            # Vulnerability reporting via GitHub Security Advisories
 
 ## Section Anchors (get_document outlines)
 
-`get_document` called on a documentation page without a query returns the page's section
-outline instead of content. Each entry carries the real URL fragment, so callers can link
-straight to a section rather than to the whole guide.
+`get_document` puts real URL fragments on both documentation paths: without a query it
+returns the page's section outline instead of content, and with a query it labels each
+returned passage with the section it came from. Either way the caller can link straight to
+a section rather than to the whole guide.
 
 The anchors cannot come from Solr. Red Hat assigns them in the AsciiDoc source -- "Kafka
 tuning overview" is published at `#con-config-tuning-intro-str` -- and no indexed field
@@ -173,11 +174,39 @@ matched the public docs.redhat.com fragments 45 of 45.
   avoided because it is heavily contended -- pointing the mirror at an unrelated local
   service yields an outline with no anchors rather than wrong ones, but it is still a
   wasted request per lookup.
+- Passages are placed by locating their text in the mirror's body via
+  `DocumentOutline.locate()`. Solr's `main_content` cannot be used for this: it leads with
+  the page's table of contents, which repeats most headings, so offsets computed against it
+  attribute passages to whichever heading the ToC listed. Measured over 146 highlight
+  passages from 33 guides: all 104 drawn from real prose were placed correctly and the 42
+  misses were every one a ToC fragment -- so `locate()` returning None means "not body
+  text", and those passages keep a bare `Passage N:` label rather than borrowing a
+  neighbour's anchor. (That also makes an unplaceable passage a reliable ToC detector, if
+  filtering them out is ever wanted.)
+- Passages shorter than `_MIN_PROBE_CHARS` are placed only when their text occurs exactly
+  once in the body. Probing needs 25 characters, and RHV sentence filtering can leave a
+  genuine prose highlight shorter than that; calling it unplaceable would hand it to the
+  ToC filter, while an unconditional `find()` would give repeated text like "Note" the
+  first section that happens to contain it.
+- The located section is resolved once per passage and carried through to the label.
+  `locate()` scans a ~150KB body up to four times, so re-deriving it while formatting
+  costs a second full pass per passage for an answer already computed.
 - Do NOT log the mirror URL. `MCP_OKP_HTML_URL` can carry credentials and the derived
   default names an internal host, so startup logs the status only and a failed fetch logs
   the document path with a status code or exception type. `str(httpx.HTTPStatusError)`
   embeds the request URL, which is why the exception is summarised rather than formatted
   into the message.
+- Passages that `locate()` cannot place are dropped as ToC noise, but only when prose
+  remains: an unavailable mirror makes everything look unplaceable, and a reference manual
+  can legitimately highlight nothing but heading runs. Measured over 39 guide+query pairs,
+  9 (23%) shed a ToC passage for -17% passage characters; 13 returned nothing but ToC and
+  were left alone. Filtering is a subset in Solr's own order, so relevance cannot regress.
+- Do NOT raise `hl.snippets` to compensate for the dropped passages. It was tried:
+  `hl.snippets` re-fragments the field rather than extending the list, and going from 10 to
+  24 pushed the three relevant admission passages out of the top three in favour of the
+  glossary. Aggregate passage and character counts improved while the answer got worse.
+- Anchoring covers Solr highlight passages. The BM25 fallback path
+  (`_extract_relevant_section`) is not anchored yet.
 - Outlines are trimmed to `_MAX_OUTLINE_CHARS` (15K) by dropping the deepest nesting
   levels, not by truncating the list. Mirror outlines run to a median of 22 sections but
   a p90 of 181 and a max of 460 (~37KB), and the sections a reader wants are as often in
@@ -201,7 +230,7 @@ matched the public docs.redhat.com fragments 45 of 45.
 | Modify result formatting | `src/okp_mcp/formatting.py` | `annotate_result()` for deprecation/EOL (used by portal.py) |
 | Change content cleaning | `src/okp_mcp/content.py` | `strip_boilerplate()` regex, `truncate_content()` |
 | Change the section outline | `src/okp_mcp/content.py` | `format_sections()` renders anchors from `outline.py` when present, else falls back to `heading_h1`/`heading_h2` titles. `_fit_to_budget()` trims to `_MAX_OUTLINE_CHARS` by shedding the deepest nesting levels first, never by cutting the tail; `clean_heading()` normalizes the NBSP numbering separators |
-| Change section anchor lookup | `src/okp_mcp/outline.py` | `parse_outline()` extracts `<section id>` pairs with stdlib `html.parser`; `OutlineFetcher` fetches and LRU-caches them from the HTML mirror. Every failure degrades to an empty list — never raise |
+| Change section anchor lookup | `src/okp_mcp/outline.py` | `parse_document()` extracts `<section id>` sections plus locatable body text with stdlib `html.parser`; `DocumentOutline.locate()` maps a passage to its section; `OutlineFetcher` fetches and LRU-caches parses from the HTML mirror. Every failure degrades to `NO_OUTLINE` — never raise |
 | Modify config/CLI args | `src/okp_mcp/config.py` | Add field to `ServerConfig`; auto-generates CLI arg and `MCP_`-prefixed env var |
 | Enable stateless mode | `src/okp_mcp/config.py` | Enabled by default. `--stateless-http false` or `MCP_STATELESS_HTTP=false` to disable |
 | Add functional test case | `tests/functional_cases.py` | Add `FunctionalCase` to `FUNCTIONAL_TEST_CASES` list |

--- a/podman-compose.yml
+++ b/podman-compose.yml
@@ -7,6 +7,12 @@ services:
     container_name: redhat-okp
     ports:
       - "8983:8983"
+      # httpd serving the rendered documentation, where get_document reads the
+      # real section anchors. The okp-mcp container below reaches it over the
+      # pod network without this; publishing is for running the server from
+      # source on the host, which then needs MCP_OKP_HTML_URL=http://localhost:8085.
+      # Mapped off 8080 because that port is heavily contended on dev machines.
+      - "8085:8080"
     environment:
       ACCESS_KEY: ${OKP_ACCESS_KEY}
       SOLR_JETTY_HOST: "0.0.0.0"

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -4,6 +4,7 @@ import logging
 import sys
 
 from enum import StrEnum
+from urllib.parse import urlsplit
 
 from pydantic import computed_field
 from pydantic import Field
@@ -137,6 +138,13 @@ class ServerConfig(BaseSettings):
         default="http://localhost:8983",
         description="Base URL of the Solr instance",
     )
+    okp_html_url: str = Field(
+        default="",
+        description="Base URL of the OKP HTML mirror, used to read real section anchors for "
+        "get_document outlines. Defaults to the solr_url host on port 8080, which is where the "
+        "OKP appliance serves it. Set to a bare '-' to disable the lookup and fall back to a "
+        "title-only outline.",
+    )
     max_response_chars: int = Field(
         default=30_000,
         ge=1,
@@ -164,6 +172,26 @@ class ServerConfig(BaseSettings):
     def solr_endpoint(self) -> str:
         """Solr select endpoint derived from solr_url."""
         return f"{self.solr_url}/solr/portal/select"
+
+    @computed_field
+    @property
+    def html_mirror_url(self) -> str:
+        """Base URL of the OKP HTML mirror, or empty when the lookup is disabled.
+
+        The OKP appliance serves the rendered documentation over httpd on 8080
+        from the same host as Solr, so the default is derived rather than
+        configured. ``okp_html_url='-'`` opts out, and an unreachable mirror
+        degrades to a title-only outline rather than failing the tool call.
+        """
+        if self.okp_html_url == "-":
+            return ""
+        if self.okp_html_url:
+            return self.okp_html_url.rstrip("/")
+
+        parsed = urlsplit(self.solr_url)
+        if not parsed.hostname:
+            return ""
+        return f"{parsed.scheme or 'http'}://{parsed.hostname}:8080"
 
     @property
     def transport_kwargs(self) -> dict[str, str | int | bool | list[StarletteMiddleware]]:

--- a/src/okp_mcp/config.py
+++ b/src/okp_mcp/config.py
@@ -4,6 +4,7 @@ import logging
 import sys
 
 from enum import StrEnum
+from urllib.parse import urlsplit
 
 from pydantic import computed_field
 from pydantic import Field
@@ -137,6 +138,13 @@ class ServerConfig(BaseSettings):
         default="http://localhost:8983",
         description="Base URL of the Solr instance",
     )
+    okp_html_url: str = Field(
+        default="",
+        description="Base URL of the OKP HTML mirror, used to read real section anchors for "
+        "get_document outlines. Defaults to the solr_url host on port 8080, which is where the "
+        "OKP appliance serves it. Set to a bare '-' to disable the lookup and fall back to a "
+        "title-only outline.",
+    )
     max_response_chars: int = Field(
         default=30_000,
         ge=1,
@@ -164,6 +172,30 @@ class ServerConfig(BaseSettings):
     def solr_endpoint(self) -> str:
         """Solr select endpoint derived from solr_url."""
         return f"{self.solr_url}/solr/portal/select"
+
+    @computed_field
+    @property
+    def html_mirror_url(self) -> str:
+        """Base URL of the OKP HTML mirror, or empty when the lookup is disabled.
+
+        The OKP appliance serves the rendered documentation over httpd on 8080
+        from the same host as Solr, so the default is derived rather than
+        configured. ``okp_html_url='-'`` opts out, and an unreachable mirror
+        degrades to a title-only outline rather than failing the tool call.
+        """
+        if self.okp_html_url == "-":
+            return ""
+        if self.okp_html_url:
+            return self.okp_html_url.rstrip("/")
+
+        parsed = urlsplit(self.solr_url)
+        if not parsed.hostname:
+            return ""
+        # urlsplit strips the brackets an IPv6 literal needs back before a port
+        # can be appended, so restore them rather than emitting a URL httpx
+        # cannot parse.
+        host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+        return f"{parsed.scheme or 'http'}://{host}:8080"
 
     @property
     def transport_kwargs(self) -> dict[str, str | int | bool | list[StarletteMiddleware]]:

--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -2,8 +2,20 @@
 
 import re
 
+from collections.abc import Iterable
+from collections.abc import Sequence
+
+from okp_mcp.outline import Section
 from okp_mcp.types import SolrDoc
 
+
+# Character budget for the outline format_sections renders. Sampled over the
+# HTML mirror, a page's full outline runs to ~13KB at the p90 and 37KB at the
+# worst case (460 sections), against a 30K default response budget -- so the
+# large tail has to be trimmed. The budget is on characters rather than entry
+# count because entry counts vary by two orders of magnitude (median 22, p90
+# 181) and a count that suits a guide starves a reference manual.
+_MAX_OUTLINE_CHARS = 15_000
 
 # Solr content uses a Unicode right single quotation mark (U+2019, a.k.a.
 # "smart apostrophe") in "Red Hat\u2019s", not the ASCII apostrophe (U+0027).
@@ -104,6 +116,144 @@ def strip_boilerplate(text: str) -> str:
     text = _FAST_TRACK_PATTERN.sub("", text)
     text = _NOT_INCLUDED_PATTERN.sub("", text)
     return text
+
+
+def clean_heading(title: str) -> str:
+    """Normalise a Solr heading for display.
+
+    Solr stores documentation headings with non-breaking spaces around the
+    numbering, e.g. ``"Chapter\\u00a09.\\u00a0Admission plugins"``; 91% of the
+    indexed documentation pages carry at least one.  Left as-is they render as
+    an odd glyph and break naive whitespace matching, so collapse every run of
+    whitespace (NBSP included) into a single ASCII space.
+    """
+    return re.sub(r"\s+", " ", title).strip()
+
+
+def _dedup_headings(titles: Iterable[str], seen: set[str]) -> list[str]:
+    """Clean, drop empties, and drop repeats, preserving document order.
+
+    ``seen`` is updated in place so a title that appears as both an h1 and an
+    h2 is listed once, under the first level it occurs in.
+    """
+    kept: list[str] = []
+    for title in titles:
+        cleaned = clean_heading(title)
+        if not cleaned or cleaned in seen:
+            continue
+        seen.add(cleaned)
+        kept.append(cleaned)
+    return kept
+
+
+def _outline_width(lines: list[str]) -> int:
+    """Rendered length of outline lines, counting the indent and newline."""
+    return sum(len(line) + 3 for line in lines)
+
+
+def _shed_depth(entries: list[tuple[int, str]], max_chars: int) -> tuple[list[str], bool]:
+    """Drop the deepest nesting levels until the outline fits the budget.
+
+    Returns the surviving lines and whether any level was dropped.
+    """
+    full_depth = max((level for level, _ in entries), default=1)
+    depth = full_depth
+    kept = [line for level, line in entries if level <= depth]
+
+    while _outline_width(kept) > max_chars and depth > 1:
+        depth -= 1
+        kept = [line for level, line in entries if level <= depth]
+
+    return kept, depth < full_depth
+
+
+def _trim_note(kept: int, total: int, shed: bool, truncated: bool) -> str:
+    """Describe what the budget left out, or nothing when the outline is whole."""
+    reasons = []
+    if shed:
+        reasons.append("deeper subsections omitted")
+    if truncated:
+        reasons.append("list truncated")
+    if not reasons:
+        return ""
+    return f"\n  [showing {kept} of {total} sections, {' and '.join(reasons)}]"
+
+
+def _fit_to_budget(entries: list[tuple[int, str]], max_chars: int) -> tuple[list[str], str]:
+    """Trim an outline to ``max_chars``, shedding the deepest levels first.
+
+    A flat "first N entries" cap truncates the tail, which is where the later
+    chapters live -- exactly the sections a reader scrolls to. Dropping whole
+    nesting levels instead keeps the document's shape: a 460-section reference
+    degrades to its top levels spanning the whole guide rather than to its
+    first 60 subsections.
+
+    Returns the lines to render and a note describing what was left out.
+    """
+    kept, shed = _shed_depth(entries, max_chars)
+
+    # The top level alone can still overflow -- a reference manual whose every
+    # entry is a chapter -- so count truncation backstops the depth shedding.
+    truncated = False
+    while kept and _outline_width(kept) > max_chars:
+        kept.pop()
+        truncated = True
+
+    return kept, _trim_note(len(kept), len(entries), shed, truncated)
+
+
+def _format_outline(entries: list[tuple[int, str]], url: str, linkable: bool, max_chars: int) -> str:
+    """Render an outline block, noting what was trimmed and how to cite a section."""
+    lines, note = _fit_to_budget(entries, max_chars)
+    if not lines:
+        return ""
+
+    body = "\n".join(f"  {line}" for line in lines)
+    result = f"\n\nSections in this document:\n{body}{note}"
+
+    if linkable:
+        guidance = f"Link to a section by appending its fragment to the URL, e.g. {url}{lines[0].split(' ', 1)[0]}"
+    else:
+        guidance = (
+            "Cite a section by the title above. This page has no per-section "
+            "anchors — link to the document URL and do not invent a #fragment."
+        )
+    return f"{result}\n{guidance}"
+
+
+def format_sections(
+    doc: SolrDoc,
+    sections: Sequence[Section] = (),
+    url: str = "",
+    max_chars: int = _MAX_OUTLINE_CHARS,
+) -> str:
+    """Return the section outline of a documentation page.
+
+    When ``sections`` carries anchors read from the HTML mirror, each entry is
+    rendered as a ``#fragment`` plus its title, so the caller can build a link
+    that resolves on docs.redhat.com.  Anchors cannot come from Solr: they are
+    author-assigned AsciiDoc IDs ("Kafka tuning overview" lives at
+    ``#con-config-tuning-intro-str``) and no indexed field carries them.
+
+    Falls back to listing ``heading_h1`` then ``heading_h2`` by title alone
+    when no anchors are available -- an unreachable mirror, or one of the
+    single-topic pages that has no subsections. Returns an empty string when
+    the document has no headings at all (solutions, errata, CVEs).
+    """
+    if sections:
+        entries = [(s.level, f"#{s.anchor} — {s.title}") for s in sections]
+        return _format_outline(entries, url, linkable=True, max_chars=max_chars)
+
+    seen: set[str] = set()
+    chapters = _dedup_headings(doc.heading_h1, seen)
+    headings = _dedup_headings(doc.heading_h2, seen)
+    if not chapters and not headings:
+        return ""
+
+    # h1 is the chapter level and h2 the section level, so the same depth
+    # shedding applies to the Solr fallback.
+    entries = [(1, title) for title in chapters] + [(2, title) for title in headings]
+    return _format_outline(entries, url, linkable=False, max_chars=max_chars)
 
 
 def doc_uri(doc: SolrDoc) -> str:

--- a/src/okp_mcp/content.py
+++ b/src/okp_mcp/content.py
@@ -241,7 +241,7 @@ def format_sections(
     the document has no headings at all (solutions, errata, CVEs).
     """
     if sections:
-        entries = [(s.level, f"#{s.anchor} — {s.title}") for s in sections]
+        entries = [(section.level, f"#{section.anchor} — {section.title}") for section in sections]
         return _format_outline(entries, url, linkable=True, max_chars=max_chars)
 
     seen: set[str] = set()

--- a/src/okp_mcp/metrics.py
+++ b/src/okp_mcp/metrics.py
@@ -163,6 +163,15 @@ DOCUMENT_HIGHLIGHT_FALLBACK = Counter(
     "Document retrievals that fell back to BM25 extraction (no highlights)",
 )
 
+# Solr highlights main_content, which leads with the page's table of contents,
+# so some passages are runs of headings rather than prose. They are dropped
+# when the mirror can identify them. A share far from the measured ~26% of
+# passages (~59% of characters) means the highlighter or the mirror changed.
+DOCUMENT_TOC_PASSAGES_DROPPED = Counter(
+    "okp_document_toc_passages_dropped_total",
+    "Highlight passages discarded as table-of-contents fragments",
+)
+
 
 class PrometheusMiddleware:
     """ASGI middleware that records HTTP request count and duration."""

--- a/src/okp_mcp/outline.py
+++ b/src/okp_mcp/outline.py
@@ -1,0 +1,181 @@
+"""Section anchors read from the OKP appliance's HTML mirror.
+
+Solr indexes documentation as plain text: ``heading_h1``/``heading_h2`` carry
+the section titles but nothing carries the URL fragment each section lives at,
+and the fragments cannot be derived from the titles.  Red Hat assigns them in
+the AsciiDoc source, so "Kafka tuning overview" is published under
+``#con-config-tuning-intro-str``; deriving slugs from heading text was measured
+against a live guide and matched 1 heading in 44.
+
+The same appliance that serves Solr also ships the rendered HTML behind its own
+httpd, and there each section is a ``<section id="...">`` carrying exactly the
+id docs.redhat.com uses as its fragment.  Reading the outline from there keeps
+the server offline while still producing links that resolve on the public site:
+sampled against the live docs, 45 of a guide's 46 anchors matched byte for byte
+(the odd one out is the document wrapper, which is not a section).
+
+Coverage over a 250-document sample of the indexed corpus: every document was
+reachable, 236 expose ``<section id>``, and the remaining 14 are single-topic
+pages that have no subsections to link to.  Callers fall back to the
+title-only outline when this module returns nothing.
+"""
+
+import logging
+
+from collections import OrderedDict
+from html.parser import HTMLParser
+from typing import NamedTuple
+
+import httpx
+
+
+logger = logging.getLogger("okp_mcp.outline")
+
+# Headings render as <h1 class="title">, <h2 class="title">, ... inside the
+# section they name. Anything deeper than h4 is a formatting heading rather
+# than a linkable section.
+_HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4"})
+
+# Wrapper element around the whole document; it carries an id but is the page
+# itself rather than a section within it, so linking to it is a no-op.
+_WRAPPER_ID_PREFIX = "mimir-doc--"
+
+# Outlines are small (a list of short string pairs) but each one costs a
+# ~200KB fetch, so keep recently used documents around. Sized to hold a
+# working set of guides without pinning the whole corpus.
+_CACHE_SIZE = 128
+
+
+class Section(NamedTuple):
+    """A linkable section: the URL fragment and the heading it belongs to.
+
+    ``level`` is the nesting depth (1 for a chapter, 2 for a section within
+    it, ...), which lets callers shed the deepest levels first when an
+    outline is too large to render whole.
+    """
+
+    anchor: str
+    title: str
+    level: int = 1
+
+
+class _OutlineParser(HTMLParser):
+    """Collect ``(section id, heading text)`` pairs from a rendered guide.
+
+    Sections nest, so the parser keeps a stack and attributes a heading to the
+    innermost section open when it starts.  Sections without an ``id`` still
+    push onto the stack -- dropping them would misattribute their headings to
+    the enclosing section, which would produce a link to the wrong place.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._open_sections: list[str | None] = []
+        self._collecting: str | None = None
+        self._level = 1
+        self._buffer: list[str] = []
+        self.sections: list[Section] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "section":
+            self._open_sections.append(dict(attrs).get("id"))
+            return
+        if tag in _HEADING_TAGS and self._open_sections:
+            anchor = self._open_sections[-1]
+            # One heading per section: a nested formatting heading inside an
+            # already-titled section must not overwrite the section's title.
+            if anchor and not any(existing.anchor == anchor for existing in self.sections):
+                self._collecting = anchor
+                self._level = len(self._open_sections)
+                self._buffer = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "section":
+            if self._open_sections:
+                self._open_sections.pop()
+            return
+        if tag in _HEADING_TAGS and self._collecting:
+            title = " ".join("".join(self._buffer).split())
+            if title:
+                self.sections.append(Section(self._collecting, title, self._level))
+            self._collecting = None
+
+    def handle_data(self, data: str) -> None:
+        if self._collecting:
+            self._buffer.append(data)
+
+
+def parse_outline(html: str) -> list[Section]:
+    """Extract the linkable sections from a rendered documentation page.
+
+    Levels are normalised so the shallowest section returned is level 1,
+    because the dropped document wrapper otherwise pushes every real chapter
+    down a level on the pages that have one.
+    """
+    parser = _OutlineParser()
+    parser.feed(html)
+    sections = [section for section in parser.sections if not section.anchor.startswith(_WRAPPER_ID_PREFIX)]
+    if not sections:
+        return []
+
+    offset = min(section.level for section in sections) - 1
+    return [section._replace(level=section.level - offset) for section in sections]
+
+
+def _html_path(doc_id: str) -> str:
+    """Map a Solr document id onto its path in the HTML mirror.
+
+    Solr ids are the crawled file paths, so the mapping is the identity apart
+    from the ``/index.html`` suffix that ``doc_uri`` strips for display.
+    """
+    path = doc_id if doc_id.startswith("/") else f"/{doc_id}"
+    return path if path.endswith(".html") else f"{path.removesuffix('/')}/index.html"
+
+
+class OutlineFetcher:
+    """Fetches and caches section outlines from the HTML mirror.
+
+    Every failure mode -- no mirror configured, mirror unreachable, document
+    absent, page carrying no sections -- resolves to an empty list.  The
+    outline is a navigational extra, so it must never turn a working
+    ``get_document`` call into an error.
+    """
+
+    def __init__(self, base_url: str, client: httpx.AsyncClient) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = client
+        self._cache: OrderedDict[str, list[Section]] = OrderedDict()
+
+    async def get(self, doc_id: str) -> list[Section]:
+        """Return the sections of a document, or an empty list if unavailable."""
+        if not self._base_url:
+            return []
+
+        if doc_id in self._cache:
+            self._cache.move_to_end(doc_id)
+            return self._cache[doc_id]
+
+        sections = await self._fetch(doc_id)
+
+        self._cache[doc_id] = sections
+        self._cache.move_to_end(doc_id)
+        if len(self._cache) > _CACHE_SIZE:
+            self._cache.popitem(last=False)
+        return sections
+
+    async def _fetch(self, doc_id: str) -> list[Section]:
+        url = f"{self._base_url}{_html_path(doc_id)}"
+        try:
+            response = await self._client.get(url)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            # Debug, not warning: a deployment that exposes only Solr hits this
+            # on every documentation fetch and the fallback is well defined.
+            logger.debug("outline fetch failed for %s: %s", url, exc)
+            return []
+
+        try:
+            return parse_outline(response.text)
+        except (ValueError, AssertionError) as exc:
+            logger.debug("outline parse failed for %s: %s", url, exc)
+            return []

--- a/src/okp_mcp/outline.py
+++ b/src/okp_mcp/outline.py
@@ -21,8 +21,10 @@ title-only outline when this module returns nothing.
 """
 
 import logging
+import re
 
 from collections import OrderedDict
+from html import unescape
 from html.parser import HTMLParser
 from typing import NamedTuple
 
@@ -30,6 +32,14 @@ import httpx
 
 
 logger = logging.getLogger("okp_mcp.outline")
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalise(text: str) -> str:
+    """Collapse every whitespace run to a single space and trim."""
+    return _WHITESPACE.sub(" ", text).strip()
+
 
 # Headings render as <h1 class="title">, <h2 class="title">, ... inside the
 # section they name. Anything deeper than h4 is a formatting heading rather
@@ -40,10 +50,21 @@ _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4"})
 # itself rather than a section within it, so linking to it is a no-op.
 _WRAPPER_ID_PREFIX = "mimir-doc--"
 
-# Outlines are small (a list of short string pairs) but each one costs a
-# ~200KB fetch, so keep recently used documents around. Sized to hold a
-# working set of guides without pinning the whole corpus.
-_CACHE_SIZE = 128
+# Script, style, and navigation carry no prose, and the nav in particular
+# repeats the whole table of contents -- exactly the text a passage must not
+# be matched against.
+_NON_PROSE_TAGS = frozenset({"script", "style", "nav"})
+
+# Probe window used to find a passage in the body. Long enough to be unique in
+# a 150KB guide, short enough to survive a snippet boundary.
+_PROBE_CHARS = 60
+_MIN_PROBE_CHARS = 25
+
+# Each entry holds the page's body text (~150KB for the largest guides) and
+# costs a ~200KB fetch to build, so the cache trades memory for both. Sized to
+# keep a working set of guides resident while bounding the process at a few
+# tens of MB.
+_CACHE_SIZE = 64
 
 
 class Section(NamedTuple):
@@ -59,13 +80,75 @@ class Section(NamedTuple):
     level: int = 1
 
 
+class DocumentOutline(NamedTuple):
+    """A page's sections plus the body text needed to place a passage in one."""
+
+    sections: tuple[Section, ...] = ()
+    # Whitespace-collapsed text of every section, in document order. Solr's
+    # main_content cannot stand in for it: that field leads with the page's
+    # table of contents, which repeats most headings, so offsets computed
+    # against it attribute passages to whichever heading the ToC listed.
+    body: str = ""
+    # (offset into body, anchor) at each section start, ascending.
+    starts: tuple[tuple[int, str], ...] = ()
+
+    def locate(self, passage: str) -> Section | None:
+        """Return the section a passage came from, or None if it has no home.
+
+        Solr highlights ``main_content``, which includes the table of contents,
+        so a passage can legitimately be a run of headings that exists nowhere
+        in the body. Measured over 146 highlight passages from 33 guides, every
+        one of the 104 drawn from real prose was placed correctly and all 42
+        misses were ToC fragments -- so None means "not body text", not
+        "lookup failed".
+        """
+        offset = self._find(passage)
+        if offset < 0:
+            return None
+
+        found = None
+        for start, anchor in self.starts:
+            if start > offset:
+                break
+            found = anchor
+        if found is None:
+            return None
+        return next((s for s in self.sections if s.anchor == found), None)
+
+    def _find(self, passage: str) -> int:
+        """Locate a passage in the body, probing a few points along it.
+
+        A single leading probe is not enough: highlight snippets have had RHV
+        sentences filtered out of them, so the head of a snippet is not always
+        contiguous in the source.  Probing further in recovers those.
+        """
+        text = _normalise(unescape(passage))
+        for fraction in (0.0, 0.35, 0.6, 0.8):
+            probe = text[int(len(text) * fraction) :][:_PROBE_CHARS]
+            if len(probe) < _MIN_PROBE_CHARS:
+                continue
+            offset = self.body.find(probe)
+            if offset >= 0:
+                return offset
+        return -1
+
+
+# Shared empty outline for every "no anchors available" path: an unconfigured
+# or unreachable mirror, a non-documentation document, a page with no sections.
+NO_OUTLINE = DocumentOutline()
+
+
 class _OutlineParser(HTMLParser):
-    """Collect ``(section id, heading text)`` pairs from a rendered guide.
+    """Collect sections, their titles, and their body text from a guide.
 
     Sections nest, so the parser keeps a stack and attributes a heading to the
     innermost section open when it starts.  Sections without an ``id`` still
     push onto the stack -- dropping them would misattribute their headings to
     the enclosing section, which would produce a link to the wrong place.
+
+    Body text is accumulated whitespace-collapsed as it arrives so that section
+    offsets are recorded against the final string, rather than normalising
+    afterwards and having to re-derive every offset.
     """
 
     def __init__(self) -> None:
@@ -74,11 +157,21 @@ class _OutlineParser(HTMLParser):
         self._collecting: str | None = None
         self._level = 1
         self._buffer: list[str] = []
+        self._skip = 0
+        self._words: list[str] = []
+        self._length = 0
         self.sections: list[Section] = []
+        self.starts: list[tuple[int, str]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _NON_PROSE_TAGS:
+            self._skip += 1
+            return
         if tag == "section":
-            self._open_sections.append(dict(attrs).get("id"))
+            anchor = dict(attrs).get("id")
+            self._open_sections.append(anchor)
+            if anchor:
+                self.starts.append((self._length, anchor))
             return
         if tag in _HEADING_TAGS and self._open_sections:
             anchor = self._open_sections[-1]
@@ -90,12 +183,15 @@ class _OutlineParser(HTMLParser):
                 self._buffer = []
 
     def handle_endtag(self, tag: str) -> None:
+        if tag in _NON_PROSE_TAGS:
+            self._skip = max(0, self._skip - 1)
+            return
         if tag == "section":
             if self._open_sections:
                 self._open_sections.pop()
             return
         if tag in _HEADING_TAGS and self._collecting:
-            title = " ".join("".join(self._buffer).split())
+            title = _normalise("".join(self._buffer))
             if title:
                 self.sections.append(Section(self._collecting, title, self._level))
             self._collecting = None
@@ -103,10 +199,21 @@ class _OutlineParser(HTMLParser):
     def handle_data(self, data: str) -> None:
         if self._collecting:
             self._buffer.append(data)
+        if self._skip or not self._open_sections:
+            return
+        for word in data.split():
+            if self._words:
+                self._words.append(" ")
+                self._length += 1
+            self._words.append(word)
+            self._length += len(word)
+
+    def body(self) -> str:
+        return "".join(self._words)
 
 
-def parse_outline(html: str) -> list[Section]:
-    """Extract the linkable sections from a rendered documentation page.
+def parse_document(html: str) -> DocumentOutline:
+    """Parse a rendered documentation page into sections and locatable body text.
 
     Levels are normalised so the shallowest section returned is level 1,
     because the dropped document wrapper otherwise pushes every real chapter
@@ -114,12 +221,23 @@ def parse_outline(html: str) -> list[Section]:
     """
     parser = _OutlineParser()
     parser.feed(html)
+
     sections = [section for section in parser.sections if not section.anchor.startswith(_WRAPPER_ID_PREFIX)]
     if not sections:
-        return []
+        return NO_OUTLINE
 
     offset = min(section.level for section in sections) - 1
-    return [section._replace(level=section.level - offset) for section in sections]
+    kept = {section.anchor for section in sections}
+    return DocumentOutline(
+        sections=tuple(section._replace(level=section.level - offset) for section in sections),
+        body=parser.body(),
+        starts=tuple((start, anchor) for start, anchor in parser.starts if anchor in kept),
+    )
+
+
+def parse_outline(html: str) -> list[Section]:
+    """Extract just the linkable sections from a rendered documentation page."""
+    return list(parse_document(html).sections)
 
 
 def _html_path(doc_id: str) -> str:
@@ -136,7 +254,7 @@ class OutlineFetcher:
     """Fetches and caches section outlines from the HTML mirror.
 
     Every failure mode -- no mirror configured, mirror unreachable, document
-    absent, page carrying no sections -- resolves to an empty list.  The
+    absent, page carrying no sections -- resolves to an empty outline.  The
     outline is a navigational extra, so it must never turn a working
     ``get_document`` call into an error.
     """
@@ -144,26 +262,26 @@ class OutlineFetcher:
     def __init__(self, base_url: str, client: httpx.AsyncClient) -> None:
         self._base_url = base_url.rstrip("/")
         self._client = client
-        self._cache: OrderedDict[str, list[Section]] = OrderedDict()
+        self._cache: OrderedDict[str, DocumentOutline] = OrderedDict()
 
-    async def get(self, doc_id: str) -> list[Section]:
-        """Return the sections of a document, or an empty list if unavailable."""
+    async def get(self, doc_id: str) -> DocumentOutline:
+        """Return a document's outline, or an empty one if unavailable."""
         if not self._base_url:
-            return []
+            return NO_OUTLINE
 
         if doc_id in self._cache:
             self._cache.move_to_end(doc_id)
             return self._cache[doc_id]
 
-        sections = await self._fetch(doc_id)
+        outline = await self._fetch(doc_id)
 
-        self._cache[doc_id] = sections
+        self._cache[doc_id] = outline
         self._cache.move_to_end(doc_id)
         if len(self._cache) > _CACHE_SIZE:
             self._cache.popitem(last=False)
-        return sections
+        return outline
 
-    async def _fetch(self, doc_id: str) -> list[Section]:
+    async def _fetch(self, doc_id: str) -> DocumentOutline:
         url = f"{self._base_url}{_html_path(doc_id)}"
         try:
             response = await self._client.get(url)
@@ -172,10 +290,10 @@ class OutlineFetcher:
             # Debug, not warning: a deployment that exposes only Solr hits this
             # on every documentation fetch and the fallback is well defined.
             logger.debug("outline fetch failed for %s: %s", url, exc)
-            return []
+            return NO_OUTLINE
 
         try:
-            return parse_outline(response.text)
+            return parse_document(response.text)
         except (ValueError, AssertionError) as exc:
             logger.debug("outline parse failed for %s: %s", url, exc)
-            return []
+            return NO_OUTLINE

--- a/src/okp_mcp/outline.py
+++ b/src/okp_mcp/outline.py
@@ -21,8 +21,10 @@ title-only outline when this module returns nothing.
 """
 
 import logging
+import re
 
 from collections import OrderedDict
+from html import unescape
 from html.parser import HTMLParser
 from typing import NamedTuple
 
@@ -30,6 +32,14 @@ import httpx
 
 
 logger = logging.getLogger("okp_mcp.outline")
+
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalise(text: str) -> str:
+    """Collapse every whitespace run to a single space and trim."""
+    return _WHITESPACE.sub(" ", text).strip()
+
 
 # Headings render as <h1 class="title">, <h2 class="title">, ... inside the
 # section they name. Anything deeper than h4 is a formatting heading rather
@@ -40,10 +50,21 @@ _HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4"})
 # itself rather than a section within it, so linking to it is a no-op.
 _WRAPPER_ID_PREFIX = "mimir-doc--"
 
-# Outlines are small (a list of short string pairs) but each one costs a
-# ~200KB fetch, so keep recently used documents around. Sized to hold a
-# working set of guides without pinning the whole corpus.
-_CACHE_SIZE = 128
+# Script, style, and navigation carry no prose, and the nav in particular
+# repeats the whole table of contents -- exactly the text a passage must not
+# be matched against.
+_NON_PROSE_TAGS = frozenset({"script", "style", "nav"})
+
+# Probe window used to find a passage in the body. Long enough to be unique in
+# a 150KB guide, short enough to survive a snippet boundary.
+_PROBE_CHARS = 60
+_MIN_PROBE_CHARS = 25
+
+# Each entry holds the page's body text (~150KB for the largest guides) and
+# costs a ~200KB fetch to build, so the cache trades memory for both. Sized to
+# keep a working set of guides resident while bounding the process at a few
+# tens of MB.
+_CACHE_SIZE = 64
 
 
 class Section(NamedTuple):
@@ -59,13 +80,87 @@ class Section(NamedTuple):
     level: int = 1
 
 
+class DocumentOutline(NamedTuple):
+    """A page's sections plus the body text needed to place a passage in one."""
+
+    sections: tuple[Section, ...] = ()
+    # Whitespace-collapsed text of every section, in document order. Solr's
+    # main_content cannot stand in for it: that field leads with the page's
+    # table of contents, which repeats most headings, so offsets computed
+    # against it attribute passages to whichever heading the ToC listed.
+    body: str = ""
+    # (offset into body, anchor) at each section start, ascending.
+    starts: tuple[tuple[int, str], ...] = ()
+
+    def locate(self, passage: str) -> Section | None:
+        """Return the section a passage came from, or None if it has no home.
+
+        Solr highlights ``main_content``, which includes the table of contents,
+        so a passage can legitimately be a run of headings that exists nowhere
+        in the body. Measured over 146 highlight passages from 33 guides, every
+        one of the 104 drawn from real prose was placed correctly and all 42
+        misses were ToC fragments -- so None means "not body text", not
+        "lookup failed".
+        """
+        offset = self._find(passage)
+        if offset < 0:
+            return None
+
+        found = None
+        for start, anchor in self.starts:
+            if start > offset:
+                break
+            found = anchor
+        if found is None:
+            return None
+        return next((s for s in self.sections if s.anchor == found), None)
+
+    def _find(self, passage: str) -> int:
+        """Locate a passage in the body, probing a few points along it.
+
+        A single leading probe is not enough: highlight snippets have had RHV
+        sentences filtered out of them, so the head of a snippet is not always
+        contiguous in the source.  Probing further in recovers those.
+        """
+        text = _normalise(unescape(passage))
+        if len(text) < _MIN_PROBE_CHARS:
+            # Too short to probe, but RHV sentence filtering can leave a
+            # genuine prose highlight this small, and returning -1 would let
+            # _place_passages discard it as a ToC run. A short passage is
+            # only placeable when it occurs exactly once: "Note" appears in
+            # every second section and must not be attributed to the first.
+            if not text:
+                return -1
+            offset = self.body.find(text)
+            if offset < 0 or self.body.find(text, offset + 1) >= 0:
+                return -1
+            return offset
+        for fraction in (0.0, 0.35, 0.6, 0.8):
+            probe = text[int(len(text) * fraction) :][:_PROBE_CHARS]
+            if len(probe) < _MIN_PROBE_CHARS:
+                continue
+            offset = self.body.find(probe)
+            if offset >= 0:
+                return offset
+        return -1
+
+
+# Shared empty outline for every "no anchors available" path: an unconfigured
+# or unreachable mirror, a non-documentation document, a page with no sections.
+NO_OUTLINE = DocumentOutline()
+
+
 class _OutlineParser(HTMLParser):
-    """Collect ``(section id, heading text)`` pairs from a rendered guide.
+    """Collect sections, their titles, and their body text from a guide.
 
     Sections nest, so the parser keeps a stack and attributes a heading to the
     innermost section open when it starts.  Sections without an ``id`` still
     push onto the stack -- dropping them would misattribute their headings to
     the enclosing section, which would produce a link to the wrong place.
+
+    Body text is accumulated whitespace-collapsed as it arrives so that section
+    offsets are recorded against the final string, rather than normalising
+    afterwards and having to re-derive every offset.
     """
 
     def __init__(self) -> None:
@@ -74,11 +169,21 @@ class _OutlineParser(HTMLParser):
         self._collecting: str | None = None
         self._level = 1
         self._buffer: list[str] = []
+        self._skip = 0
+        self._words: list[str] = []
+        self._length = 0
         self.sections: list[Section] = []
+        self.starts: list[tuple[int, str]] = []
 
     def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag in _NON_PROSE_TAGS:
+            self._skip += 1
+            return
         if tag == "section":
-            self._open_sections.append(dict(attrs).get("id"))
+            anchor = dict(attrs).get("id")
+            self._open_sections.append(anchor)
+            if anchor:
+                self.starts.append((self._length, anchor))
             return
         if tag in _HEADING_TAGS and self._open_sections:
             anchor = self._open_sections[-1]
@@ -90,12 +195,15 @@ class _OutlineParser(HTMLParser):
                 self._buffer = []
 
     def handle_endtag(self, tag: str) -> None:
+        if tag in _NON_PROSE_TAGS:
+            self._skip = max(0, self._skip - 1)
+            return
         if tag == "section":
             if self._open_sections:
                 self._open_sections.pop()
             return
         if tag in _HEADING_TAGS and self._collecting:
-            title = " ".join("".join(self._buffer).split())
+            title = _normalise("".join(self._buffer))
             if title:
                 self.sections.append(Section(self._collecting, title, self._level))
             self._collecting = None
@@ -103,10 +211,21 @@ class _OutlineParser(HTMLParser):
     def handle_data(self, data: str) -> None:
         if self._collecting:
             self._buffer.append(data)
+        if self._skip or not self._open_sections:
+            return
+        for word in data.split():
+            if self._words:
+                self._words.append(" ")
+                self._length += 1
+            self._words.append(word)
+            self._length += len(word)
+
+    def body(self) -> str:
+        return "".join(self._words)
 
 
-def parse_outline(html: str) -> list[Section]:
-    """Extract the linkable sections from a rendered documentation page.
+def parse_document(html: str) -> DocumentOutline:
+    """Parse a rendered documentation page into sections and locatable body text.
 
     Levels are normalised so the shallowest section returned is level 1,
     because the dropped document wrapper otherwise pushes every real chapter
@@ -114,12 +233,23 @@ def parse_outline(html: str) -> list[Section]:
     """
     parser = _OutlineParser()
     parser.feed(html)
+
     sections = [section for section in parser.sections if not section.anchor.startswith(_WRAPPER_ID_PREFIX)]
     if not sections:
-        return []
+        return NO_OUTLINE
 
     offset = min(section.level for section in sections) - 1
-    return [section._replace(level=section.level - offset) for section in sections]
+    kept = {section.anchor for section in sections}
+    return DocumentOutline(
+        sections=tuple(section._replace(level=section.level - offset) for section in sections),
+        body=parser.body(),
+        starts=tuple((start, anchor) for start, anchor in parser.starts if anchor in kept),
+    )
+
+
+def parse_outline(html: str) -> list[Section]:
+    """Extract just the linkable sections from a rendered documentation page."""
+    return list(parse_document(html).sections)
 
 
 def _html_path(doc_id: str) -> str:
@@ -147,7 +277,7 @@ class OutlineFetcher:
     """Fetches and caches section outlines from the HTML mirror.
 
     Every failure mode -- no mirror configured, mirror unreachable, document
-    absent, page carrying no sections -- resolves to an empty list.  The
+    absent, page carrying no sections -- resolves to an empty outline.  The
     outline is a navigational extra, so it must never turn a working
     ``get_document`` call into an error.
     """
@@ -155,26 +285,26 @@ class OutlineFetcher:
     def __init__(self, base_url: str, client: httpx.AsyncClient) -> None:
         self._base_url = base_url.rstrip("/")
         self._client = client
-        self._cache: OrderedDict[str, list[Section]] = OrderedDict()
+        self._cache: OrderedDict[str, DocumentOutline] = OrderedDict()
 
-    async def get(self, doc_id: str) -> list[Section]:
-        """Return the sections of a document, or an empty list if unavailable."""
+    async def get(self, doc_id: str) -> DocumentOutline:
+        """Return a document's outline, or an empty one if unavailable."""
         if not self._base_url:
-            return []
+            return NO_OUTLINE
 
         if doc_id in self._cache:
             self._cache.move_to_end(doc_id)
             return self._cache[doc_id]
 
-        sections = await self._fetch(doc_id)
+        outline = await self._fetch(doc_id)
 
-        self._cache[doc_id] = sections
+        self._cache[doc_id] = outline
         self._cache.move_to_end(doc_id)
         if len(self._cache) > _CACHE_SIZE:
             self._cache.popitem(last=False)
-        return sections
+        return outline
 
-    async def _fetch(self, doc_id: str) -> list[Section]:
+    async def _fetch(self, doc_id: str) -> DocumentOutline:
         path = _html_path(doc_id)
         try:
             response = await self._client.get(f"{self._base_url}{path}")
@@ -186,10 +316,10 @@ class OutlineFetcher:
             # deployment configuration and httpx repeats it inside the
             # exception, so neither is logged.
             logger.debug("outline fetch failed for %s: %s", path, _describe(exc))
-            return []
+            return NO_OUTLINE
 
         try:
-            return parse_outline(response.text)
+            return parse_document(response.text)
         except (ValueError, AssertionError) as exc:
             logger.debug("outline parse failed for %s: %s", path, exc)
-            return []
+            return NO_OUTLINE

--- a/src/okp_mcp/outline.py
+++ b/src/okp_mcp/outline.py
@@ -1,0 +1,195 @@
+"""Section anchors read from the OKP appliance's HTML mirror.
+
+Solr indexes documentation as plain text: ``heading_h1``/``heading_h2`` carry
+the section titles but nothing carries the URL fragment each section lives at,
+and the fragments cannot be derived from the titles.  Red Hat assigns them in
+the AsciiDoc source, so "Kafka tuning overview" is published under
+``#con-config-tuning-intro-str``; deriving slugs from heading text was measured
+against a live guide and matched 1 heading in 44.
+
+The same appliance that serves Solr also ships the rendered HTML behind its own
+httpd, and there each section is a ``<section id="...">`` carrying exactly the
+id docs.redhat.com uses as its fragment.  Reading the outline from there keeps
+the server offline while still producing links that resolve on the public site:
+sampled against the live docs, 45 of a guide's 46 anchors matched byte for byte
+(the odd one out is the document wrapper, which is not a section).
+
+Coverage over a 250-document sample of the indexed corpus: every document was
+reachable, 236 expose ``<section id>``, and the remaining 14 are single-topic
+pages that have no subsections to link to.  Callers fall back to the
+title-only outline when this module returns nothing.
+"""
+
+import logging
+
+from collections import OrderedDict
+from html.parser import HTMLParser
+from typing import NamedTuple
+
+import httpx
+
+
+logger = logging.getLogger("okp_mcp.outline")
+
+# Headings render as <h1 class="title">, <h2 class="title">, ... inside the
+# section they name. Anything deeper than h4 is a formatting heading rather
+# than a linkable section.
+_HEADING_TAGS = frozenset({"h1", "h2", "h3", "h4"})
+
+# Wrapper element around the whole document; it carries an id but is the page
+# itself rather than a section within it, so linking to it is a no-op.
+_WRAPPER_ID_PREFIX = "mimir-doc--"
+
+# Outlines are small (a list of short string pairs) but each one costs a
+# ~200KB fetch, so keep recently used documents around. Sized to hold a
+# working set of guides without pinning the whole corpus.
+_CACHE_SIZE = 128
+
+
+class Section(NamedTuple):
+    """A linkable section: the URL fragment and the heading it belongs to.
+
+    ``level`` is the nesting depth (1 for a chapter, 2 for a section within
+    it, ...), which lets callers shed the deepest levels first when an
+    outline is too large to render whole.
+    """
+
+    anchor: str
+    title: str
+    level: int = 1
+
+
+class _OutlineParser(HTMLParser):
+    """Collect ``(section id, heading text)`` pairs from a rendered guide.
+
+    Sections nest, so the parser keeps a stack and attributes a heading to the
+    innermost section open when it starts.  Sections without an ``id`` still
+    push onto the stack -- dropping them would misattribute their headings to
+    the enclosing section, which would produce a link to the wrong place.
+    """
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self._open_sections: list[str | None] = []
+        self._collecting: str | None = None
+        self._level = 1
+        self._buffer: list[str] = []
+        self.sections: list[Section] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag == "section":
+            self._open_sections.append(dict(attrs).get("id"))
+            return
+        if tag in _HEADING_TAGS and self._open_sections:
+            anchor = self._open_sections[-1]
+            # One heading per section: a nested formatting heading inside an
+            # already-titled section must not overwrite the section's title.
+            if anchor and not any(existing.anchor == anchor for existing in self.sections):
+                self._collecting = anchor
+                self._level = len(self._open_sections)
+                self._buffer = []
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "section":
+            if self._open_sections:
+                self._open_sections.pop()
+            return
+        if tag in _HEADING_TAGS and self._collecting:
+            title = " ".join("".join(self._buffer).split())
+            if title:
+                self.sections.append(Section(self._collecting, title, self._level))
+            self._collecting = None
+
+    def handle_data(self, data: str) -> None:
+        if self._collecting:
+            self._buffer.append(data)
+
+
+def parse_outline(html: str) -> list[Section]:
+    """Extract the linkable sections from a rendered documentation page.
+
+    Levels are normalised so the shallowest section returned is level 1,
+    because the dropped document wrapper otherwise pushes every real chapter
+    down a level on the pages that have one.
+    """
+    parser = _OutlineParser()
+    parser.feed(html)
+    sections = [section for section in parser.sections if not section.anchor.startswith(_WRAPPER_ID_PREFIX)]
+    if not sections:
+        return []
+
+    offset = min(section.level for section in sections) - 1
+    return [section._replace(level=section.level - offset) for section in sections]
+
+
+def _html_path(doc_id: str) -> str:
+    """Map a Solr document id onto its path in the HTML mirror.
+
+    Solr ids are the crawled file paths, so the mapping is the identity apart
+    from the ``/index.html`` suffix that ``doc_uri`` strips for display.
+    """
+    path = doc_id if doc_id.startswith("/") else f"/{doc_id}"
+    return path if path.endswith(".html") else f"{path.removesuffix('/')}/index.html"
+
+
+def _describe(exc: httpx.HTTPError) -> str:
+    """Summarise a fetch failure without repeating the URL it was made against.
+
+    ``str(HTTPStatusError)`` embeds the full request URL, which carries the
+    mirror host and any credentials configured with it.
+    """
+    if isinstance(exc, httpx.HTTPStatusError):
+        return f"HTTP {exc.response.status_code}"
+    return type(exc).__name__
+
+
+class OutlineFetcher:
+    """Fetches and caches section outlines from the HTML mirror.
+
+    Every failure mode -- no mirror configured, mirror unreachable, document
+    absent, page carrying no sections -- resolves to an empty list.  The
+    outline is a navigational extra, so it must never turn a working
+    ``get_document`` call into an error.
+    """
+
+    def __init__(self, base_url: str, client: httpx.AsyncClient) -> None:
+        self._base_url = base_url.rstrip("/")
+        self._client = client
+        self._cache: OrderedDict[str, list[Section]] = OrderedDict()
+
+    async def get(self, doc_id: str) -> list[Section]:
+        """Return the sections of a document, or an empty list if unavailable."""
+        if not self._base_url:
+            return []
+
+        if doc_id in self._cache:
+            self._cache.move_to_end(doc_id)
+            return self._cache[doc_id]
+
+        sections = await self._fetch(doc_id)
+
+        self._cache[doc_id] = sections
+        self._cache.move_to_end(doc_id)
+        if len(self._cache) > _CACHE_SIZE:
+            self._cache.popitem(last=False)
+        return sections
+
+    async def _fetch(self, doc_id: str) -> list[Section]:
+        path = _html_path(doc_id)
+        try:
+            response = await self._client.get(f"{self._base_url}{path}")
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            # Debug, not warning: a deployment that exposes only Solr hits this
+            # on every documentation fetch and the fallback is well defined.
+            # The document path identifies the failure; the mirror URL is
+            # deployment configuration and httpx repeats it inside the
+            # exception, so neither is logged.
+            logger.debug("outline fetch failed for %s: %s", path, _describe(exc))
+            return []
+
+        try:
+            return parse_outline(response.text)
+        except (ValueError, AssertionError) as exc:
+            logger.debug("outline parse failed for %s: %s", path, exc)
+            return []

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -18,6 +18,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from okp_mcp.config import CONFIG
+from okp_mcp.outline import OutlineFetcher
 from okp_mcp.request_id import RequestIDContextMiddleware
 
 
@@ -31,6 +32,7 @@ class AppContext:
     http_client: httpx.AsyncClient
     solr_endpoint: str
     max_response_chars: int
+    outline_fetcher: OutlineFetcher | None = None
 
 
 @asynccontextmanager
@@ -38,7 +40,9 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
     """Manage app lifecycle resources for tool execution."""
     solr_endpoint = CONFIG.solr_endpoint
     max_response_chars = CONFIG.max_response_chars
+    html_mirror_url = CONFIG.html_mirror_url
     logger.info("SOLR endpoint: %s", solr_endpoint)
+    logger.info("HTML mirror: %s", html_mirror_url or "disabled (outlines will omit section anchors)")
     client = httpx.AsyncClient(timeout=30.0)
     try:
         yield {
@@ -46,6 +50,7 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
                 http_client=client,
                 solr_endpoint=solr_endpoint,
                 max_response_chars=max_response_chars,
+                outline_fetcher=OutlineFetcher(html_mirror_url, client) if html_mirror_url else None,
             )
         }
     finally:

--- a/src/okp_mcp/server.py
+++ b/src/okp_mcp/server.py
@@ -18,6 +18,7 @@ from starlette.requests import Request
 from starlette.responses import Response
 
 from okp_mcp.config import CONFIG
+from okp_mcp.outline import OutlineFetcher
 from okp_mcp.request_id import RequestIDContextMiddleware
 
 
@@ -31,6 +32,7 @@ class AppContext:
     http_client: httpx.AsyncClient
     solr_endpoint: str
     max_response_chars: int
+    outline_fetcher: OutlineFetcher | None = None
 
 
 @asynccontextmanager
@@ -38,7 +40,15 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
     """Manage app lifecycle resources for tool execution."""
     solr_endpoint = CONFIG.solr_endpoint
     max_response_chars = CONFIG.max_response_chars
+    html_mirror_url = CONFIG.html_mirror_url
     logger.info("SOLR endpoint: %s", solr_endpoint)
+    # Status only: the mirror URL is an internal host, and an explicit
+    # MCP_OKP_HTML_URL can carry credentials, so it must not reach the log at
+    # the default INFO level.
+    logger.info(
+        "HTML mirror: %s",
+        "enabled" if html_mirror_url else "disabled (outlines will omit section anchors)",
+    )
     client = httpx.AsyncClient(timeout=30.0)
     try:
         yield {
@@ -46,6 +56,7 @@ async def _app_lifespan(server: FastMCP) -> AsyncIterator[dict[str, AppContext]]
                 http_client=client,
                 solr_endpoint=solr_endpoint,
                 max_response_chars=max_response_chars,
+                outline_fetcher=OutlineFetcher(html_mirror_url, client) if html_mirror_url else None,
             )
         }
     finally:

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -3,7 +3,6 @@
 import logging
 import time
 
-from collections.abc import Sequence
 from urllib.parse import urlsplit
 
 import httpx
@@ -19,9 +18,11 @@ from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_FALLBACK
 from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_USED
 from okp_mcp.metrics import DOCUMENT_NOT_FOUND
 from okp_mcp.metrics import DOCUMENT_NUDGE
+from okp_mcp.metrics import DOCUMENT_TOC_PASSAGES_DROPPED
 from okp_mcp.metrics import TOOL_CALLS
 from okp_mcp.metrics import TOOL_DURATION
-from okp_mcp.outline import Section
+from okp_mcp.outline import DocumentOutline
+from okp_mcp.outline import NO_OUTLINE
 from okp_mcp.server import get_app_context
 from okp_mcp.server import mcp
 from okp_mcp.solr import _clean_query
@@ -39,6 +40,17 @@ logger = logging.getLogger("okp_mcp.tools.get_document")
 # Tighter budgets here prevent token-heavy responses while still surfacing
 # the most relevant passages via Solr highlights or local BM25 extraction.
 _DOCUMENTATION_MAX_CHARS = 10_000
+
+# Highlights asked of Solr, and the most rendered per document.
+#
+# Asking for more to compensate for the table-of-contents runs that get dropped
+# was tried and rejected: hl.snippets does not return a longer list of the same
+# fragments, it re-fragments the field. Raising the ask from 10 to 24 on
+# "what are webhook admission plugins" pushed the three admission passages out
+# of the top three and filled those slots with the glossary and Ignition
+# instead. Aggregate passage and character counts improved while the answer got
+# worse, so this number stays where Solr's own selection is best.
+_MAX_PASSAGES = 10
 _DOCUMENTATION_MAX_SECTIONS = 3
 _DOCUMENTATION_PER_SECTION = 1000
 
@@ -112,15 +124,67 @@ def _format_metadata(doc: SolrDoc) -> str:
     return result
 
 
-def _format_document_passages(highlight_snippets: list[str], query: str, max_chars: int, current_result: str) -> str:
+def _drop_toc_passages(snippets: list[str], outline: DocumentOutline) -> list[str]:
+    """Drop highlights that are table-of-contents runs rather than prose.
+
+    Solr highlights ``main_content``, which leads with the page's ToC, so a
+    quarter of the passages come back as strings of headings. They are also the
+    long ones -- measured at 26% of passages but 59% of the characters -- so
+    they crowd real prose out of the passage budget rather than merely sitting
+    beside it. Dropping them leaves exactly the prose Solr already chose, in
+    Solr's order, and returns the budget they were occupying.
+
+    Filtering needs the mirror: without it every passage looks unplaceable, so
+    an unavailable mirror must leave the list alone rather than empty it. The
+    same guard covers a page whose passages are all classified as ToC, where
+    returning nothing would be worse than returning the headings.
+    """
+    if not outline.starts:
+        return snippets
+
+    prose = [snippet for snippet in snippets if outline.locate(snippet) is not None]
+    if not prose:
+        return snippets
+
+    DOCUMENT_TOC_PASSAGES_DROPPED.inc(len(snippets) - len(prose))
+    return prose
+
+
+def _passage_label(index: int, snippet: str, outline: DocumentOutline) -> str:
+    """Label a passage, naming the section it came from when that is known.
+
+    A passage with no home section is a table-of-contents fragment: Solr
+    highlights ``main_content``, which leads with the page's ToC, so those
+    runs of headings match no body text. They keep the bare label rather than
+    borrowing a neighbouring section's anchor.
+    """
+    section = outline.locate(snippet)
+    if section is None:
+        return f"Passage {index}:"
+    return f"Passage {index} [#{section.anchor} — {section.title}]:"
+
+
+def _format_document_passages(
+    highlight_snippets: list[str],
+    query: str,
+    max_chars: int,
+    current_result: str,
+    outline: DocumentOutline = NO_OUTLINE,
+) -> str:
     """Format highlight snippets as numbered passages within the remaining budget."""
-    remaining_budget = max_chars - len(current_result) - len("\n\nRelevant passages:\n")
+    header = "\n\nRelevant passages:\n"
+    if outline.starts:
+        header = "\n\nRelevant passages (append a passage's fragment to the URL above to link to its section):\n"
+
+    remaining_budget = max_chars - len(current_result) - len(header)
     if remaining_budget <= 0:
         return ""
 
-    formatted_passages = [f"Passage {index + 1}:\n{snippet}" for index, snippet in enumerate(highlight_snippets)]
+    formatted_passages = [
+        f"{_passage_label(index + 1, snippet, outline)}\n{snippet}" for index, snippet in enumerate(highlight_snippets)
+    ]
     passages = _select_within_budget(formatted_passages, remaining_budget, query)
-    return f"\n\nRelevant passages:\n{passages}"
+    return f"{header}{passages}"
 
 
 def _format_document_content(
@@ -130,7 +194,7 @@ def _format_document_content(
     query: str,
     max_chars: int,
     current_result: str,
-    sections: Sequence[Section] = (),
+    outline: DocumentOutline = NO_OUTLINE,
 ) -> str:
     """Build the content section for a fetched document.
 
@@ -163,8 +227,8 @@ def _format_document_content(
     # from the real title rather than guessing at what the guide covers.
     if is_documentation and not query:
         DOCUMENT_NUDGE.inc()
-        outline = format_sections(doc, sections, url=f"https://access.redhat.com{doc_uri(doc)}")
-        return outline + (
+        listing = format_sections(doc, outline.sections, url=f"https://access.redhat.com{doc_uri(doc)}")
+        return listing + (
             "\n\nThis is a large documentation page. "
             "Pass a query to get_document to extract the most relevant passages."
         )
@@ -183,7 +247,8 @@ def _format_document_content(
         if highlight_snippets:
             DOCUMENT_HIGHLIGHT_USED.inc()
             doc_budget = min(max_chars, _DOCUMENTATION_MAX_CHARS)
-            return _format_document_passages(highlight_snippets, query, doc_budget, current_result)
+            passages = _drop_toc_passages(highlight_snippets, outline)[:_MAX_PASSAGES]
+            return _format_document_passages(passages, query, doc_budget, current_result, outline)
         DOCUMENT_HIGHLIGHT_FALLBACK.inc()
         extracted = _extract_relevant_section(
             content, query, per_section=_DOCUMENTATION_PER_SECTION, max_sections=_DOCUMENTATION_MAX_SECTIONS
@@ -194,7 +259,9 @@ def _format_document_content(
         DOCUMENT_HIGHLIGHT_FALLBACK.inc()
         return f"\n\nContent:\n{_extract_relevant_section(content, query, max_sections=8)}"
     DOCUMENT_HIGHLIGHT_USED.inc()
-    return f"\n\nContent:\n{' ... '.join(highlight_snippets)}"
+    # Non-documentation kinds render every snippet inline, so they keep the
+    # pre-overfetch count rather than growing with the larger Solr ask.
+    return f"\n\nContent:\n{' ... '.join(highlight_snippets[:_MAX_PASSAGES])}"
 
 
 async def _fetch_document_with_query(
@@ -231,7 +298,7 @@ async def _fetch_document_with_query(
             "hl.qparser": "edismax",
             "fl": DOCUMENT_FL,
             "rows": 1,
-            "hl.snippets": "10",
+            "hl.snippets": str(_MAX_PASSAGES),
             "hl.fragsize": "600",
         },
         client=client,
@@ -280,7 +347,7 @@ async def _format_document(
     doc_id: str,
     query: str,
     max_chars: int,
-    sections: Sequence[Section] = (),
+    outline: DocumentOutline = NO_OUTLINE,
 ) -> str:
     """Format a fetched document into a readable string.
 
@@ -289,7 +356,7 @@ async def _format_document(
     Truncates final output to max_chars as a safety net.
     """
     result = _format_metadata(doc)
-    result += _format_document_content(doc, data, doc_id, query, max_chars, result, sections)
+    result += _format_document_content(doc, data, doc_id, query, max_chars, result, outline)
     return truncate_content(result, max_chars)
 
 
@@ -320,13 +387,14 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
             return f"Document not found: {doc_id}"
 
         doc = docs[0]
-        # Only the outline path renders anchors, and it is the only path that
-        # justifies the mirror's ~200KB fetch, so gate the lookup on it.
-        sections: Sequence[Section] = ()
-        if _uses_document_passages(doc) and not query and app.outline_fetcher is not None:
-            sections = await app.outline_fetcher.get(doc.id or doc_id)
+        # Both documentation paths spend the anchors: the no-query path lists
+        # them, the query path attaches them to passages. Other document kinds
+        # have no mirror page, so they never pay the ~200KB fetch.
+        outline = NO_OUTLINE
+        if _uses_document_passages(doc) and app.outline_fetcher is not None:
+            outline = await app.outline_fetcher.get(doc.id or doc_id)
 
-        return await _format_document(doc, data, doc_id, query, app.max_response_chars, sections)
+        return await _format_document(doc, data, doc_id, query, app.max_response_chars, outline)
     except httpx.TimeoutException:
         logger.warning("get_document timed out for doc_id=%r", doc_id, exc_info=True)
         return f"Unable to fetch document {doc_id} because the request timed out. Please try again."

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -3,6 +3,7 @@
 import logging
 import time
 
+from collections.abc import Sequence
 from urllib.parse import urlsplit
 
 import httpx
@@ -11,6 +12,7 @@ from fastmcp import Context
 
 from okp_mcp.content import _select_within_budget
 from okp_mcp.content import doc_uri
+from okp_mcp.content import format_sections
 from okp_mcp.content import strip_boilerplate
 from okp_mcp.content import truncate_content
 from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_FALLBACK
@@ -19,6 +21,7 @@ from okp_mcp.metrics import DOCUMENT_NOT_FOUND
 from okp_mcp.metrics import DOCUMENT_NUDGE
 from okp_mcp.metrics import TOOL_CALLS
 from okp_mcp.metrics import TOOL_DURATION
+from okp_mcp.outline import Section
 from okp_mcp.server import get_app_context
 from okp_mcp.server import mcp
 from okp_mcp.solr import _clean_query
@@ -121,7 +124,13 @@ def _format_document_passages(highlight_snippets: list[str], query: str, max_cha
 
 
 def _format_document_content(
-    doc: SolrDoc, data: SolrResponse, doc_id: str, query: str, max_chars: int, current_result: str
+    doc: SolrDoc,
+    data: SolrResponse,
+    doc_id: str,
+    query: str,
+    max_chars: int,
+    current_result: str,
+    sections: Sequence[Section] = (),
 ) -> str:
     """Build the content section for a fetched document.
 
@@ -137,7 +146,7 @@ def _format_document_content(
         YES
          |
         query provided?
-         +--NO--> metadata + "pass a query" nudge (~500 chars)
+         +--NO--> metadata + section outline + "pass a query" nudge
          |
         YES
          |
@@ -148,10 +157,14 @@ def _format_document_content(
     is_documentation = _uses_document_passages(doc)
 
     # Documentation without a query is almost always useless (first 1500 chars
-    # is typically a table of contents). Nudge the caller to be specific.
+    # is typically a table of contents). Nudge the caller to be specific, and
+    # list the sections so the nudge is actionable: the caller can pick the
+    # section it wants, link straight to it, and phrase the follow-up query
+    # from the real title rather than guessing at what the guide covers.
     if is_documentation and not query:
         DOCUMENT_NUDGE.inc()
-        return (
+        outline = format_sections(doc, sections, url=f"https://access.redhat.com{doc_uri(doc)}")
+        return outline + (
             "\n\nThis is a large documentation page. "
             "Pass a query to get_document to extract the most relevant passages."
         )
@@ -261,7 +274,14 @@ async def _fetch_document_raw(
             await client.aclose()
 
 
-async def _format_document(doc: SolrDoc, data: SolrResponse, doc_id: str, query: str, max_chars: int) -> str:
+async def _format_document(
+    doc: SolrDoc,
+    data: SolrResponse,
+    doc_id: str,
+    query: str,
+    max_chars: int,
+    sections: Sequence[Section] = (),
+) -> str:
     """Format a fetched document into a readable string.
 
     Renders title, type, product/version, URL, synopsis/summary/CVE details,
@@ -269,7 +289,7 @@ async def _format_document(doc: SolrDoc, data: SolrResponse, doc_id: str, query:
     Truncates final output to max_chars as a safety net.
     """
     result = _format_metadata(doc)
-    result += _format_document_content(doc, data, doc_id, query, max_chars, result)
+    result += _format_document_content(doc, data, doc_id, query, max_chars, result, sections)
     return truncate_content(result, max_chars)
 
 
@@ -299,7 +319,14 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
             DOCUMENT_NOT_FOUND.inc()
             return f"Document not found: {doc_id}"
 
-        return await _format_document(docs[0], data, doc_id, query, app.max_response_chars)
+        doc = docs[0]
+        # Only the outline path renders anchors, and it is the only path that
+        # justifies the mirror's ~200KB fetch, so gate the lookup on it.
+        sections: Sequence[Section] = ()
+        if _uses_document_passages(doc) and not query and app.outline_fetcher is not None:
+            sections = await app.outline_fetcher.get(doc.id or doc_id)
+
+        return await _format_document(doc, data, doc_id, query, app.max_response_chars, sections)
     except httpx.TimeoutException:
         logger.warning("get_document timed out for doc_id=%r", doc_id, exc_info=True)
         return f"Unable to fetch document {doc_id} because the request timed out. Please try again."

--- a/src/okp_mcp/tools/document.py
+++ b/src/okp_mcp/tools/document.py
@@ -3,7 +3,6 @@
 import logging
 import time
 
-from collections.abc import Sequence
 from urllib.parse import urlsplit
 
 import httpx
@@ -19,8 +18,11 @@ from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_FALLBACK
 from okp_mcp.metrics import DOCUMENT_HIGHLIGHT_USED
 from okp_mcp.metrics import DOCUMENT_NOT_FOUND
 from okp_mcp.metrics import DOCUMENT_NUDGE
+from okp_mcp.metrics import DOCUMENT_TOC_PASSAGES_DROPPED
 from okp_mcp.metrics import TOOL_CALLS
 from okp_mcp.metrics import TOOL_DURATION
+from okp_mcp.outline import DocumentOutline
+from okp_mcp.outline import NO_OUTLINE
 from okp_mcp.outline import Section
 from okp_mcp.server import get_app_context
 from okp_mcp.server import mcp
@@ -39,6 +41,17 @@ logger = logging.getLogger("okp_mcp.tools.get_document")
 # Tighter budgets here prevent token-heavy responses while still surfacing
 # the most relevant passages via Solr highlights or local BM25 extraction.
 _DOCUMENTATION_MAX_CHARS = 10_000
+
+# Highlights asked of Solr, and the most rendered per document.
+#
+# Asking for more to compensate for the table-of-contents runs that get dropped
+# was tried and rejected: hl.snippets does not return a longer list of the same
+# fragments, it re-fragments the field. Raising the ask from 10 to 24 on
+# "what are webhook admission plugins" pushed the three admission passages out
+# of the top three and filled those slots with the glossary and Ignition
+# instead. Aggregate passage and character counts improved while the answer got
+# worse, so this number stays where Solr's own selection is best.
+_MAX_PASSAGES = 10
 _DOCUMENTATION_MAX_SECTIONS = 3
 _DOCUMENTATION_PER_SECTION = 1000
 
@@ -112,15 +125,70 @@ def _format_metadata(doc: SolrDoc) -> str:
     return result
 
 
-def _format_document_passages(highlight_snippets: list[str], query: str, max_chars: int, current_result: str) -> str:
-    """Format highlight snippets as numbered passages within the remaining budget."""
-    remaining_budget = max_chars - len(current_result) - len("\n\nRelevant passages:\n")
+def _place_passages(snippets: list[str], outline: DocumentOutline) -> list[tuple[str, Section | None]]:
+    """Pair each highlight with its section, dropping table-of-contents runs.
+
+    Solr highlights ``main_content``, which leads with the page's ToC, so a
+    quarter of the passages come back as strings of headings. They are also the
+    long ones -- measured at 26% of passages but 59% of the characters -- so
+    they crowd real prose out of the passage budget rather than merely sitting
+    beside it. Dropping them leaves exactly the prose Solr already chose, in
+    Solr's order, and returns the budget they were occupying.
+
+    Placing every passage once and carrying the result is what keeps this
+    cheap: ``locate`` scans a body of ~150KB, and labelling later would
+    otherwise repeat that scan for each of the ten passages.
+
+    Filtering needs the mirror: without it every passage looks unplaceable, so
+    an unavailable mirror must leave the list alone rather than empty it. The
+    same guard covers a page whose passages are all classified as ToC, where
+    returning nothing would be worse than returning the headings.
+    """
+    if not outline.starts:
+        return [(snippet, None) for snippet in snippets]
+
+    placed = [(snippet, outline.locate(snippet)) for snippet in snippets]
+    prose = [entry for entry in placed if entry[1] is not None]
+    if not prose:
+        return [(snippet, None) for snippet, _ in placed]
+
+    DOCUMENT_TOC_PASSAGES_DROPPED.inc(len(placed) - len(prose))
+    return prose
+
+
+def _passage_label(index: int, section: Section | None) -> str:
+    """Label a passage, naming the section it came from when that is known.
+
+    A passage with no home section is a table-of-contents fragment: Solr
+    highlights ``main_content``, which leads with the page's ToC, so those
+    runs of headings match no body text. They keep the bare label rather than
+    borrowing a neighbouring section's anchor.
+    """
+    if section is None:
+        return f"Passage {index}:"
+    return f"Passage {index} [#{section.anchor} — {section.title}]:"
+
+
+def _format_document_passages(
+    passages: list[tuple[str, Section | None]],
+    query: str,
+    max_chars: int,
+    current_result: str,
+) -> str:
+    """Format placed passages as numbered entries within the remaining budget."""
+    header = "\n\nRelevant passages:\n"
+    if any(section is not None for _, section in passages):
+        header = "\n\nRelevant passages (append a passage's fragment to the URL above to link to its section):\n"
+
+    remaining_budget = max_chars - len(current_result) - len(header)
     if remaining_budget <= 0:
         return ""
 
-    formatted_passages = [f"Passage {index + 1}:\n{snippet}" for index, snippet in enumerate(highlight_snippets)]
-    passages = _select_within_budget(formatted_passages, remaining_budget, query)
-    return f"\n\nRelevant passages:\n{passages}"
+    formatted_passages = [
+        f"{_passage_label(index + 1, section)}\n{snippet}" for index, (snippet, section) in enumerate(passages)
+    ]
+    selected = _select_within_budget(formatted_passages, remaining_budget, query)
+    return f"{header}{selected}"
 
 
 def _format_document_content(
@@ -130,7 +198,7 @@ def _format_document_content(
     query: str,
     max_chars: int,
     current_result: str,
-    sections: Sequence[Section] = (),
+    outline: DocumentOutline = NO_OUTLINE,
 ) -> str:
     """Build the content section for a fetched document.
 
@@ -163,8 +231,8 @@ def _format_document_content(
     # from the real title rather than guessing at what the guide covers.
     if is_documentation and not query:
         DOCUMENT_NUDGE.inc()
-        outline = format_sections(doc, sections, url=f"https://access.redhat.com{doc_uri(doc)}")
-        return outline + (
+        listing = format_sections(doc, outline.sections, url=f"https://access.redhat.com{doc_uri(doc)}")
+        return listing + (
             "\n\nThis is a large documentation page. "
             "Pass a query to get_document to extract the most relevant passages."
         )
@@ -183,7 +251,8 @@ def _format_document_content(
         if highlight_snippets:
             DOCUMENT_HIGHLIGHT_USED.inc()
             doc_budget = min(max_chars, _DOCUMENTATION_MAX_CHARS)
-            return _format_document_passages(highlight_snippets, query, doc_budget, current_result)
+            passages = _place_passages(highlight_snippets, outline)[:_MAX_PASSAGES]
+            return _format_document_passages(passages, query, doc_budget, current_result)
         DOCUMENT_HIGHLIGHT_FALLBACK.inc()
         extracted = _extract_relevant_section(
             content, query, per_section=_DOCUMENTATION_PER_SECTION, max_sections=_DOCUMENTATION_MAX_SECTIONS
@@ -194,7 +263,9 @@ def _format_document_content(
         DOCUMENT_HIGHLIGHT_FALLBACK.inc()
         return f"\n\nContent:\n{_extract_relevant_section(content, query, max_sections=8)}"
     DOCUMENT_HIGHLIGHT_USED.inc()
-    return f"\n\nContent:\n{' ... '.join(highlight_snippets)}"
+    # Non-documentation kinds render every snippet inline, so they keep the
+    # pre-overfetch count rather than growing with the larger Solr ask.
+    return f"\n\nContent:\n{' ... '.join(highlight_snippets[:_MAX_PASSAGES])}"
 
 
 async def _fetch_document_with_query(
@@ -231,7 +302,7 @@ async def _fetch_document_with_query(
             "hl.qparser": "edismax",
             "fl": DOCUMENT_FL,
             "rows": 1,
-            "hl.snippets": "10",
+            "hl.snippets": str(_MAX_PASSAGES),
             "hl.fragsize": "600",
         },
         client=client,
@@ -280,7 +351,7 @@ async def _format_document(
     doc_id: str,
     query: str,
     max_chars: int,
-    sections: Sequence[Section] = (),
+    outline: DocumentOutline = NO_OUTLINE,
 ) -> str:
     """Format a fetched document into a readable string.
 
@@ -289,7 +360,7 @@ async def _format_document(
     Truncates final output to max_chars as a safety net.
     """
     result = _format_metadata(doc)
-    result += _format_document_content(doc, data, doc_id, query, max_chars, result, sections)
+    result += _format_document_content(doc, data, doc_id, query, max_chars, result, outline)
     return truncate_content(result, max_chars)
 
 
@@ -320,13 +391,14 @@ async def get_document(ctx: Context, doc_id: str, query: str = "") -> str:
             return f"Document not found: {doc_id}"
 
         doc = docs[0]
-        # Only the outline path renders anchors, and it is the only path that
-        # justifies the mirror's ~200KB fetch, so gate the lookup on it.
-        sections: Sequence[Section] = ()
-        if _uses_document_passages(doc) and not query and app.outline_fetcher is not None:
-            sections = await app.outline_fetcher.get(doc.id or doc_id)
+        # Both documentation paths spend the anchors: the no-query path lists
+        # them, the query path attaches them to passages. Other document kinds
+        # have no mirror page, so they never pay the ~200KB fetch.
+        outline = NO_OUTLINE
+        if _uses_document_passages(doc) and app.outline_fetcher is not None:
+            outline = await app.outline_fetcher.get(doc.id or doc_id)
 
-        return await _format_document(doc, data, doc_id, query, app.max_response_chars, sections)
+        return await _format_document(doc, data, doc_id, query, app.max_response_chars, outline)
     except httpx.TimeoutException:
         logger.warning("get_document timed out for doc_id=%r", doc_id, exc_info=True)
         return f"Unable to fetch document {doc_id} because the request timed out. Please try again."

--- a/src/okp_mcp/tools/shared.py
+++ b/src/okp_mcp/tools/shared.py
@@ -1,7 +1,7 @@
 """Shared constants and helpers for MCP tool modules."""
 
 DOCUMENT_FL = (
-    "id,allTitle,title,heading_h1,main_content,view_uri,documentKind,"
+    "id,allTitle,title,heading_h1,heading_h2,main_content,view_uri,documentKind,"
     "product,documentation_version,lastModifiedDate,"
     "cve_details,portal_synopsis,portal_summary"
 )

--- a/src/okp_mcp/types.py
+++ b/src/okp_mcp/types.py
@@ -12,6 +12,7 @@ class SolrDoc(BaseModel):
     allTitle: str = ""
     title: str = ""
     heading_h1: list[str] = Field(default_factory=list)
+    heading_h2: list[str] = Field(default_factory=list)
     view_uri: str = ""
     url_slug: str = ""
     documentKind: str = ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,3 +210,28 @@ def test_stateless_http_in_transport_kwargs(transport, stateless_http, expected_
     config = ServerConfig(transport=transport, stateless_http=stateless_http)
     kwargs = config.transport_kwargs
     assert ("stateless_http" in kwargs) == expected_in_kwargs
+
+
+# --- html_mirror_url ---
+
+
+def test_html_mirror_url_derived_from_solr_host():
+    """The OKP appliance serves the mirror on 8080 beside Solr, so derive it."""
+    config = ServerConfig(solr_url="http://redhat-okp:8983")
+    assert config.html_mirror_url == "http://redhat-okp:8080"
+
+
+def test_html_mirror_url_explicit_override():
+    """An explicit URL wins over the derived default."""
+    config = ServerConfig(solr_url="http://redhat-okp:8983", okp_html_url="https://mirror.example/docs/")
+    assert config.html_mirror_url == "https://mirror.example/docs"
+
+
+def test_html_mirror_url_opt_out():
+    """'-' disables the lookup so outlines stay title-only."""
+    assert ServerConfig(solr_url="http://redhat-okp:8983", okp_html_url="-").html_mirror_url == ""
+
+
+def test_html_mirror_url_unparseable_solr_url():
+    """A solr_url with no host disables the lookup rather than building junk."""
+    assert ServerConfig(solr_url="not-a-url").html_mirror_url == ""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -210,3 +210,34 @@ def test_stateless_http_in_transport_kwargs(transport, stateless_http, expected_
     config = ServerConfig(transport=transport, stateless_http=stateless_http)
     kwargs = config.transport_kwargs
     assert ("stateless_http" in kwargs) == expected_in_kwargs
+
+
+# --- html_mirror_url ---
+
+
+def test_html_mirror_url_derived_from_solr_host():
+    """The OKP appliance serves the mirror on 8080 beside Solr, so derive it."""
+    config = ServerConfig(solr_url="http://redhat-okp:8983")
+    assert config.html_mirror_url == "http://redhat-okp:8080"
+
+
+def test_html_mirror_url_explicit_override():
+    """An explicit URL wins over the derived default."""
+    config = ServerConfig(solr_url="http://redhat-okp:8983", okp_html_url="https://mirror.example/docs/")
+    assert config.html_mirror_url == "https://mirror.example/docs"
+
+
+def test_html_mirror_url_brackets_an_ipv6_host():
+    """urlsplit strips the brackets an IPv6 literal needs before a port."""
+    config = ServerConfig(solr_url="http://[2001:db8::1]:8983")
+    assert config.html_mirror_url == "http://[2001:db8::1]:8080"
+
+
+def test_html_mirror_url_opt_out():
+    """'-' disables the lookup so outlines stay title-only."""
+    assert ServerConfig(solr_url="http://redhat-okp:8983", okp_html_url="-").html_mirror_url == ""
+
+
+def test_html_mirror_url_unparseable_solr_url():
+    """A solr_url with no host disables the lookup rather than building junk."""
+    assert ServerConfig(solr_url="not-a-url").html_mirror_url == ""

--- a/tests/test_content.py
+++ b/tests/test_content.py
@@ -4,9 +4,12 @@ import pytest
 
 from okp_mcp.content import _select_within_budget
 from okp_mcp.content import clean_content
+from okp_mcp.content import clean_heading
 from okp_mcp.content import doc_uri
+from okp_mcp.content import format_sections
 from okp_mcp.content import strip_boilerplate
 from okp_mcp.content import truncate_content
+from okp_mcp.outline import Section
 from okp_mcp.types import SolrDoc
 
 
@@ -183,3 +186,147 @@ def test_select_within_budget_first_exceeds_budget_multi():
     assert "Content truncated" in output
     assert len(output) <= 200
     assert "Budget reached" not in output
+
+
+# ---------------------------------------------------------------------------
+# clean_heading / format_sections
+# ---------------------------------------------------------------------------
+
+
+def test_clean_heading_collapses_nbsp():
+    """Solr numbering separators (U+00A0) become ordinary spaces."""
+    assert clean_heading("Chapter\u00a09.\u00a0Admission plugins") == "Chapter 9. Admission plugins"
+
+
+def test_clean_heading_trims_and_collapses_runs():
+    """Surrounding and repeated whitespace collapses to single spaces."""
+    assert clean_heading("  1.1.  About   OpenShift  ") == "1.1. About OpenShift"
+
+
+def test_clean_heading_preserves_unicode_text():
+    """Non-ASCII headings survive normalisation unchanged."""
+    assert clean_heading("インストール概要") == "インストール概要"
+
+
+def test_format_sections_empty():
+    """No headings → empty string."""
+    assert format_sections(SolrDoc()) == ""
+
+
+def test_format_sections_blank_headings_only():
+    """Headings that are only whitespace do not produce an empty outline."""
+    assert format_sections(SolrDoc(heading_h1=["   ", " "])) == ""
+
+
+def test_format_sections_lists_h1_and_h2():
+    """Chapters are listed first, then sections, both normalised."""
+    doc = SolrDoc(
+        heading_h1=["Chapter 1. Overview"],
+        heading_h2=["1.1. Prerequisites", "1.2. Steps"],
+    )
+    result = format_sections(doc)
+    assert "Sections in this document:" in result
+    assert result.index("Chapter 1. Overview") < result.index("1.1. Prerequisites")
+    assert "1.2. Steps" in result
+
+
+def test_format_sections_emits_no_anchor_fragments_without_anchors():
+    """Without anchors from the mirror the outline must not invent #fragment links."""
+    doc = SolrDoc(heading_h1=["About the installation"], heading_h2=["1.1. Prerequisites"])
+    result = format_sections(doc)
+    assert "#about-the-installation" not in result
+    assert "do not invent a #fragment" in result
+
+
+def test_format_sections_deduplicates_across_levels():
+    """A title indexed as both h1 and h2 is listed once."""
+    doc = SolrDoc(heading_h1=["Overview"], heading_h2=["Overview", "Details"])
+    result = format_sections(doc)
+    assert result.count("Overview") == 1
+
+
+def test_format_sections_sheds_h2_before_h1_over_budget():
+    """Over budget, the chapter list survives and the h2 detail is dropped."""
+    doc = SolrDoc(heading_h1=["Chapter A", "Chapter B"], heading_h2=[f"Detail {n}" for n in range(50)])
+    result = format_sections(doc, max_chars=60)
+    assert "Chapter A" in result
+    assert "Chapter B" in result
+    assert "Detail 0" not in result
+    assert "deeper subsections omitted" in result
+
+
+def test_format_sections_reports_the_full_total_when_trimmed():
+    """The note names how many sections the document really has."""
+    doc = SolrDoc(heading_h1=["Chapter A"], heading_h2=[f"Detail {n}" for n in range(9)])
+    result = format_sections(doc, max_chars=100)
+    assert "of 10 sections" in result
+
+
+# ---------------------------------------------------------------------------
+# format_sections with real anchors from the HTML mirror
+# ---------------------------------------------------------------------------
+
+_URL = "https://access.redhat.com/documentation/en-us/guide/index"
+_SECTIONS = [
+    Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview"),
+    Section("mapping_properties_and_values", "1.1. Mapping properties and values"),
+]
+
+
+def test_format_sections_renders_real_anchors():
+    """Anchors from the mirror are rendered as #fragment plus the section title."""
+    result = format_sections(SolrDoc(), _SECTIONS, url=_URL)
+    assert "#con-config-tuning-intro-str — Chapter 1. Kafka tuning overview" in result
+    assert "#mapping_properties_and_values — 1.1. Mapping properties and values" in result
+
+
+def test_format_sections_anchors_show_a_linkable_example():
+    """The guidance line demonstrates a URL the caller can copy."""
+    result = format_sections(SolrDoc(), _SECTIONS, url=_URL)
+    assert f"{_URL}#con-config-tuning-intro-str" in result
+    assert "do not invent" not in result
+
+
+def test_format_sections_anchors_take_precedence_over_headings():
+    """Solr headings are the fallback; real anchors win when both are present."""
+    doc = SolrDoc(heading_h1=["Stale heading from Solr"])
+    result = format_sections(doc, _SECTIONS, url=_URL)
+    assert "Stale heading from Solr" not in result
+
+
+def test_format_sections_falls_back_when_mirror_returns_nothing():
+    """An unreachable mirror still yields the title-only outline."""
+    doc = SolrDoc(heading_h1=["About the installation"])
+    result = format_sections(doc, (), url=_URL)
+    assert "About the installation" in result
+    assert "do not invent a #fragment" in result
+
+
+def test_format_sections_keeps_whole_outline_within_budget():
+    """A guide-sized outline is shown in full, tail chapters included."""
+    sections = [Section("intro", "Chapter 1. Intro", 1)] + [
+        Section(f"sec-{n}", f"9.{n}. Late section", 2) for n in range(12)
+    ]
+    result = format_sections(SolrDoc(), sections, url=_URL)
+    assert "#sec-11" in result
+    assert "showing" not in result
+
+
+def test_format_sections_sheds_deepest_level_first_for_anchors():
+    """Over budget, chapters keep their anchors and subsections are dropped."""
+    sections = [Section(f"ch-{n}", f"Chapter {n}", 1) for n in range(3)] + [
+        Section(f"sub-{n}", f"Subsection {n}", 2) for n in range(40)
+    ]
+    result = format_sections(SolrDoc(), sections, url=_URL, max_chars=150)
+    assert "#ch-0" in result
+    assert "#ch-2" in result
+    assert "#sub-0" not in result
+    assert "deeper subsections omitted" in result
+
+
+def test_format_sections_truncates_when_even_top_level_overflows():
+    """A reference page whose every entry is a chapter still gets capped."""
+    sections = [Section(f"ch-{n}", f"Chapter {n}", 1) for n in range(200)]
+    result = format_sections(SolrDoc(), sections, url=_URL, max_chars=200)
+    assert "of 200 sections" in result
+    assert "#ch-199" not in result

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,16 +11,20 @@ from prometheus_client import REGISTRY
 
 from okp_mcp import tools
 from okp_mcp.config import ServerConfig
+from okp_mcp.outline import NO_OUTLINE
+from okp_mcp.outline import parse_document
 from okp_mcp.solr import _clean_query
 from okp_mcp.tools.document import _doc_id_filter
 from okp_mcp.tools.document import _DOCUMENTATION_MAX_CHARS
 from okp_mcp.tools.document import _DOCUMENTATION_MAX_SECTIONS
 from okp_mcp.tools.document import _DOCUMENTATION_PER_SECTION
+from okp_mcp.tools.document import _drop_toc_passages
 from okp_mcp.tools.document import _fetch_document_raw
 from okp_mcp.tools.document import _fetch_document_with_query
 from okp_mcp.tools.document import _format_document_content
 from okp_mcp.tools.document import _format_document_passages
 from okp_mcp.tools.document import _format_metadata
+from okp_mcp.tools.document import _passage_label
 from okp_mcp.tools.document import _uses_document_passages
 from okp_mcp.types import SolrDoc
 from okp_mcp.types import SolrResponse
@@ -541,3 +545,96 @@ async def test_fetch_document_with_query_keeps_caller_query_out_of_q():
     assert params["defType"] == "lucene"
     assert params["hl.q"] == _clean_query("some unrelated question")
     assert "fq" not in params
+
+
+# ---------------------------------------------------------------------------
+# passage anchoring
+# ---------------------------------------------------------------------------
+
+_PASSAGE_HTML = (
+    '<section id="admission-plug-ins"><h1 class="title">Chapter 9. Admission plugins</h1>'
+    "<p>Admission plugins process resource requests to the control plane API.</p>"
+    '<section id="admission-webhooks-about_admission-plug-ins">'
+    '<h2 class="title">9.3. Webhook admission plugins</h2>'
+    "<p>You can implement dynamic admission through webhook admission plugins that "
+    "call webhook servers over HTTP at defined endpoints.</p></section></section>"
+)
+
+
+def test_passage_label_names_the_section_it_came_from():
+    """A passage from real prose is labelled with its anchor and section title."""
+    outline = parse_document(_PASSAGE_HTML)
+    snippet = "dynamic admission through webhook admission plugins that call webhook servers"
+    label = _passage_label(1, snippet, outline)
+    assert label == "Passage 1 [#admission-webhooks-about_admission-plug-ins — 9.3. Webhook admission plugins]:"
+
+
+def test_passage_label_attributes_to_the_innermost_section():
+    """Prose in a chapter's own text is not attributed to a nested subsection."""
+    outline = parse_document(_PASSAGE_HTML)
+    label = _passage_label(1, "process resource requests to the control plane API", outline)
+    assert "#admission-plug-ins " in label
+
+
+def test_passage_label_stays_bare_for_a_toc_fragment():
+    """A ToC run of headings has no home section and must not borrow one."""
+    outline = parse_document(_PASSAGE_HTML)
+    toc = "9.1. About admission plugins 9.2. Default admission plugins 9.4. Types of webhook"
+    assert _passage_label(2, toc, outline) == "Passage 2:"
+
+
+def test_passage_label_without_an_outline():
+    """With no mirror the label is unchanged from before anchors existed."""
+    assert _passage_label(3, "any passage text at all goes here", NO_OUTLINE) == "Passage 3:"
+
+
+def test_format_document_passages_announces_linkable_fragments():
+    """The header tells the caller what to do with the fragments."""
+    outline = parse_document(_PASSAGE_HTML)
+    result = _format_document_passages(
+        ["dynamic admission through webhook admission plugins that call webhook servers"],
+        query="webhooks",
+        max_chars=3000,
+        current_result="",
+        outline=outline,
+    )
+    assert "append a passage's fragment to the URL above" in result
+    assert "#admission-webhooks-about_admission-plug-ins" in result
+
+
+def test_format_document_passages_header_unchanged_without_anchors():
+    """Without a mirror the passage block keeps its original header."""
+    result = _format_document_passages(["some snippet"], query="q", max_chars=3000, current_result="")
+    assert result.startswith("\n\nRelevant passages:\n")
+
+
+# ---------------------------------------------------------------------------
+# ToC passage filtering
+# ---------------------------------------------------------------------------
+
+_TOC = "9.1. About admission plugins 9.2. Default admission plugins 9.4. Types of webhook"
+_PROSE = "dynamic admission through webhook admission plugins that call webhook servers"
+
+
+def test_drop_toc_passages_keeps_prose_only():
+    """A ToC run is dropped while the prose passage survives."""
+    outline = parse_document(_PASSAGE_HTML)
+    assert _drop_toc_passages([_TOC, _PROSE], outline) == [_PROSE]
+
+
+def test_drop_toc_passages_without_a_mirror():
+    """With no outline every passage looks unplaceable, so none may be dropped."""
+    assert _drop_toc_passages([_TOC, _PROSE], NO_OUTLINE) == [_TOC, _PROSE]
+
+
+def test_drop_toc_passages_when_everything_looks_like_toc():
+    """Returning nothing is worse than returning headings, so the list stands."""
+    outline = parse_document(_PASSAGE_HTML)
+    assert _drop_toc_passages([_TOC], outline) == [_TOC]
+
+
+def test_drop_toc_passages_preserves_order():
+    """Relevance order from Solr is not disturbed by filtering."""
+    outline = parse_document(_PASSAGE_HTML)
+    second = "Admission plugins process resource requests to the control plane API"
+    assert _drop_toc_passages([_PROSE, _TOC, second], outline) == [_PROSE, second]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -11,6 +11,8 @@ from prometheus_client import REGISTRY
 
 from okp_mcp import tools
 from okp_mcp.config import ServerConfig
+from okp_mcp.outline import NO_OUTLINE
+from okp_mcp.outline import parse_document
 from okp_mcp.solr import _clean_query
 from okp_mcp.tools.document import _doc_id_filter
 from okp_mcp.tools.document import _DOCUMENTATION_MAX_CHARS
@@ -21,6 +23,8 @@ from okp_mcp.tools.document import _fetch_document_with_query
 from okp_mcp.tools.document import _format_document_content
 from okp_mcp.tools.document import _format_document_passages
 from okp_mcp.tools.document import _format_metadata
+from okp_mcp.tools.document import _passage_label
+from okp_mcp.tools.document import _place_passages
 from okp_mcp.tools.document import _uses_document_passages
 from okp_mcp.types import SolrDoc
 from okp_mcp.types import SolrResponse
@@ -277,7 +281,7 @@ def test_documentation_no_main_content_with_query_returns_empty():
 
 def test_format_document_passages_respects_remaining_budget():
     """Passages stop accumulating when remaining character budget is exhausted."""
-    snippets = [f"Passage content {i} " + "a" * 500 for i in range(20)]
+    snippets = [(f"Passage content {i} " + "a" * 500, None) for i in range(20)]
     result = _format_document_passages(snippets, query="test", max_chars=3000, current_result="x" * 500)
     assert "Relevant passages:" in result
     # Total should respect the budget
@@ -286,7 +290,7 @@ def test_format_document_passages_respects_remaining_budget():
 
 def test_format_document_passages_negative_budget():
     """If metadata already exhausted the budget, passages return empty."""
-    result = _format_document_passages(["snippet"], query="test", max_chars=100, current_result="x" * 200)
+    result = _format_document_passages([("snippet", None)], query="test", max_chars=100, current_result="x" * 200)
     assert result == ""
 
 
@@ -541,3 +545,109 @@ async def test_fetch_document_with_query_keeps_caller_query_out_of_q():
     assert params["defType"] == "lucene"
     assert params["hl.q"] == _clean_query("some unrelated question")
     assert "fq" not in params
+
+
+# ---------------------------------------------------------------------------
+# passage anchoring
+# ---------------------------------------------------------------------------
+
+_PASSAGE_HTML = (
+    '<section id="admission-plug-ins"><h1 class="title">Chapter 9. Admission plugins</h1>'
+    "<p>Admission plugins process resource requests to the control plane API.</p>"
+    '<section id="admission-webhooks-about_admission-plug-ins">'
+    '<h2 class="title">9.3. Webhook admission plugins</h2>'
+    "<p>You can implement dynamic admission through webhook admission plugins that "
+    "call webhook servers over HTTP at defined endpoints.</p></section></section>"
+)
+
+
+def test_passage_label_names_the_section_it_came_from():
+    """A passage from real prose is labelled with its anchor and section title."""
+    outline = parse_document(_PASSAGE_HTML)
+    snippet = "dynamic admission through webhook admission plugins that call webhook servers"
+    label = _passage_label(1, outline.locate(snippet))
+    assert label == "Passage 1 [#admission-webhooks-about_admission-plug-ins — 9.3. Webhook admission plugins]:"
+
+
+def test_passage_label_attributes_to_the_innermost_section():
+    """Prose in a chapter's own text is not attributed to a nested subsection."""
+    outline = parse_document(_PASSAGE_HTML)
+    label = _passage_label(1, outline.locate("process resource requests to the control plane API"))
+    assert "#admission-plug-ins " in label
+
+
+def test_passage_label_stays_bare_for_a_toc_fragment():
+    """A ToC run of headings has no home section and must not borrow one."""
+    outline = parse_document(_PASSAGE_HTML)
+    toc = "9.1. About admission plugins 9.2. Default admission plugins 9.4. Types of webhook"
+    assert _passage_label(2, outline.locate(toc)) == "Passage 2:"
+
+
+def test_passage_label_without_an_outline():
+    """With no mirror the label is unchanged from before anchors existed."""
+    assert _passage_label(3, NO_OUTLINE.locate("any passage text at all goes here")) == "Passage 3:"
+
+
+def test_format_document_passages_announces_linkable_fragments():
+    """The header tells the caller what to do with the fragments."""
+    outline = parse_document(_PASSAGE_HTML)
+    snippets = ["dynamic admission through webhook admission plugins that call webhook servers"]
+    result = _format_document_passages(
+        _place_passages(snippets, outline),
+        query="webhooks",
+        max_chars=3000,
+        current_result="",
+    )
+    assert "append a passage's fragment to the URL above" in result
+    assert "#admission-webhooks-about_admission-plug-ins" in result
+
+
+def test_format_document_passages_header_unchanged_without_anchors():
+    """Without a mirror the passage block keeps its original header."""
+    result = _format_document_passages([("some snippet", None)], query="q", max_chars=3000, current_result="")
+    assert result.startswith("\n\nRelevant passages:\n")
+
+
+# ---------------------------------------------------------------------------
+# ToC passage filtering
+# ---------------------------------------------------------------------------
+
+_TOC = "9.1. About admission plugins 9.2. Default admission plugins 9.4. Types of webhook"
+_PROSE = "dynamic admission through webhook admission plugins that call webhook servers"
+
+
+def _texts(passages):
+    """The passage text of each placed passage, dropping the section."""
+    return [text for text, _ in passages]
+
+
+def test_place_passages_keeps_prose_only():
+    """A ToC run is dropped while the prose passage survives."""
+    outline = parse_document(_PASSAGE_HTML)
+    assert _texts(_place_passages([_TOC, _PROSE], outline)) == [_PROSE]
+
+
+def test_place_passages_carries_the_located_section():
+    """The section is resolved once here so labelling need not scan again."""
+    outline = parse_document(_PASSAGE_HTML)
+    [(_, section)] = _place_passages([_PROSE], outline)
+    assert section is not None
+    assert section.anchor == "admission-webhooks-about_admission-plug-ins"
+
+
+def test_place_passages_without_a_mirror():
+    """With no outline every passage looks unplaceable, so none may be dropped."""
+    assert _place_passages([_TOC, _PROSE], NO_OUTLINE) == [(_TOC, None), (_PROSE, None)]
+
+
+def test_place_passages_when_everything_looks_like_toc():
+    """Returning nothing is worse than returning headings, so the list stands."""
+    outline = parse_document(_PASSAGE_HTML)
+    assert _place_passages([_TOC], outline) == [(_TOC, None)]
+
+
+def test_place_passages_preserves_order():
+    """Relevance order from Solr is not disturbed by filtering."""
+    outline = parse_document(_PASSAGE_HTML)
+    second = "Admission plugins process resource requests to the control plane API"
+    assert _texts(_place_passages([_PROSE, _TOC, second], outline)) == [_PROSE, second]

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,0 +1,181 @@
+"""Tests for okp_mcp.outline: section anchors read from the OKP HTML mirror."""
+
+import httpx
+import pytest
+
+from okp_mcp.outline import _html_path
+from okp_mcp.outline import OutlineFetcher
+from okp_mcp.outline import parse_outline
+from okp_mcp.outline import Section
+
+
+# Mirrors the shape the OKP appliance serves: a wrapper section around the
+# document, chapters nested inside it, and topic sections nested in those.
+_GUIDE_HTML = """
+<html><body>
+<section id="mimir-doc--kafka_configuration_tuning">
+  <div class="titlepage"><h1 class="title">Kafka configuration tuning</h1></div>
+  <section id="con-config-tuning-intro-str">
+    <div class="titlepage"><h1 class="title">Chapter&nbsp;1.&nbsp;Kafka tuning overview</h1></div>
+    <p>Body text.</p>
+    <section id="mapping_properties_and_values">
+      <div class="titlepage"><h2 class="title">1.1. Mapping properties and values</h2></div>
+    </section>
+  </section>
+</section>
+</body></html>
+"""
+
+
+def test_parse_outline_extracts_anchor_and_title():
+    """Each section yields its id paired with the heading it contains."""
+    sections = parse_outline(_GUIDE_HTML)
+    assert Section("mapping_properties_and_values", "1.1. Mapping properties and values", 2) in sections
+
+
+def test_parse_outline_drops_document_wrapper():
+    """The mimir-doc-- wrapper is the page itself, not a linkable section."""
+    anchors = [section.anchor for section in parse_outline(_GUIDE_HTML)]
+    assert not any(anchor.startswith("mimir-doc--") for anchor in anchors)
+
+
+def test_parse_outline_normalizes_entities_and_whitespace():
+    """Numbering separators arrive as &nbsp; and must collapse to plain spaces."""
+    titles = [section.title for section in parse_outline(_GUIDE_HTML)]
+    assert "Chapter 1. Kafka tuning overview" in titles
+
+
+def test_parse_outline_preserves_document_order():
+    """Chapters precede the topics nested inside them."""
+    anchors = [section.anchor for section in parse_outline(_GUIDE_HTML)]
+    assert anchors.index("con-config-tuning-intro-str") < anchors.index("mapping_properties_and_values")
+
+
+def test_parse_outline_skips_sections_without_id():
+    """A section with no id contributes nothing and does not steal a heading.
+
+    Attributing its heading to the enclosing section would emit a link that
+    jumps to the wrong place, which is worse than omitting the entry.
+    """
+    html = '<section id="outer"><h1 class="title">Outer</h1><section><h2 class="title">Inner</h2></section></section>'
+    assert parse_outline(html) == [Section("outer", "Outer")]
+
+
+def test_parse_outline_ignores_headings_outside_sections():
+    """Site chrome headings (nav, footer) sit outside any section."""
+    assert parse_outline("<h2>CONTENT</h2><h2>HELP</h2>") == []
+
+
+def test_parse_outline_keeps_first_heading_per_section():
+    """A nested formatting heading must not overwrite the section title."""
+    html = '<section id="a"><h1 class="title">Real title</h1><div><h3>Sub label</h3></div></section>'
+    assert parse_outline(html) == [Section("a", "Real title")]
+
+
+def test_parse_outline_empty_document():
+    """A page with no sections yields no anchors rather than raising."""
+    assert parse_outline("<html><body><p>text</p></body></html>") == []
+
+
+@pytest.mark.parametrize(
+    "doc_id,expected",
+    [
+        ("/documentation/en-us/guide/index.html", "/documentation/en-us/guide/index.html"),
+        ("/documentation/en-us/guide/index", "/documentation/en-us/guide/index/index.html"),
+        ("/documentation/en-us/guide/index/", "/documentation/en-us/guide/index/index.html"),
+        ("documentation/en-us/guide/index", "/documentation/en-us/guide/index/index.html"),
+    ],
+    ids=["already-html", "bare-path", "trailing-slash", "missing-leading-slash"],
+)
+def test_html_path_maps_solr_id_to_mirror_path(doc_id, expected):
+    """Solr ids are crawled file paths, so the mapping only fixes the suffix."""
+    assert _html_path(doc_id) == expected
+
+
+def _fetcher(handler) -> OutlineFetcher:
+    transport = httpx.MockTransport(handler)
+    return OutlineFetcher("http://okp:8080", httpx.AsyncClient(transport=transport))
+
+
+async def test_fetcher_returns_parsed_sections():
+    """A successful mirror fetch is parsed into sections."""
+    fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
+    sections = await fetcher.get("/documentation/en-us/guide/index.html")
+    assert Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview", 1) in sections
+
+
+async def test_fetcher_requests_the_mirror_path():
+    """The request targets the mirror base joined with the document's path."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, text=_GUIDE_HTML)
+
+    await _fetcher(handler).get("/documentation/en-us/guide/index.html")
+    assert seen == ["http://okp:8080/documentation/en-us/guide/index.html"]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [httpx.Response(404), httpx.Response(500)],
+    ids=["not-found", "server-error"],
+)
+async def test_fetcher_degrades_on_http_error(response):
+    """An unavailable mirror yields no anchors instead of failing the tool call."""
+    fetcher = _fetcher(lambda request: response)
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+
+
+async def test_fetcher_degrades_on_transport_error():
+    """A deployment that exposes only Solr must still serve documents."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    assert await _fetcher(handler).get("/documentation/en-us/guide/index.html") == []
+
+
+async def test_fetcher_disabled_without_base_url():
+    """An empty base URL disables the lookup without issuing a request."""
+    fetcher = OutlineFetcher("", httpx.AsyncClient())
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+
+
+async def test_fetcher_caches_by_doc_id():
+    """A repeat lookup is served from cache rather than refetching ~200KB."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, text=_GUIDE_HTML)
+
+    fetcher = _fetcher(handler)
+    first = await fetcher.get("/documentation/en-us/guide/index.html")
+    second = await fetcher.get("/documentation/en-us/guide/index.html")
+    assert calls == 1
+    assert first == second
+
+
+async def test_fetcher_caches_empty_results():
+    """A mirror miss is remembered too, so it costs one request per document."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(404)
+
+    fetcher = _fetcher(handler)
+    await fetcher.get("/documentation/en-us/guide/index.html")
+    await fetcher.get("/documentation/en-us/guide/index.html")
+    assert calls == 1
+
+
+async def test_fetcher_evicts_least_recently_used():
+    """The cache stays bounded so a long-lived server cannot pin the corpus."""
+    fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
+    for index in range(200):
+        await fetcher.get(f"/documentation/en-us/guide{index}/index.html")
+    assert len(fetcher._cache) == 128

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -4,7 +4,9 @@ import httpx
 import pytest
 
 from okp_mcp.outline import _html_path
+from okp_mcp.outline import NO_OUTLINE
 from okp_mcp.outline import OutlineFetcher
+from okp_mcp.outline import parse_document
 from okp_mcp.outline import parse_outline
 from okp_mcp.outline import Section
 
@@ -17,7 +19,7 @@ _GUIDE_HTML = """
   <div class="titlepage"><h1 class="title">Kafka configuration tuning</h1></div>
   <section id="con-config-tuning-intro-str">
     <div class="titlepage"><h1 class="title">Chapter&nbsp;1.&nbsp;Kafka tuning overview</h1></div>
-    <p>Body text.</p>
+    <p>Admission plugins intercept requests to the control plane API to enforce policy.</p>
     <section id="mapping_properties_and_values">
       <div class="titlepage"><h2 class="title">1.1. Mapping properties and values</h2></div>
     </section>
@@ -100,8 +102,8 @@ def _fetcher(handler) -> OutlineFetcher:
 async def test_fetcher_returns_parsed_sections():
     """A successful mirror fetch is parsed into sections."""
     fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
-    sections = await fetcher.get("/documentation/en-us/guide/index.html")
-    assert Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview", 1) in sections
+    outline = await fetcher.get("/documentation/en-us/guide/index.html")
+    assert Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview", 1) in outline.sections
 
 
 async def test_fetcher_requests_the_mirror_path():
@@ -124,7 +126,7 @@ async def test_fetcher_requests_the_mirror_path():
 async def test_fetcher_degrades_on_http_error(response):
     """An unavailable mirror yields no anchors instead of failing the tool call."""
     fetcher = _fetcher(lambda request: response)
-    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == NO_OUTLINE
 
 
 async def test_fetcher_degrades_on_transport_error():
@@ -133,13 +135,13 @@ async def test_fetcher_degrades_on_transport_error():
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("no route to host")
 
-    assert await _fetcher(handler).get("/documentation/en-us/guide/index.html") == []
+    assert await _fetcher(handler).get("/documentation/en-us/guide/index.html") == NO_OUTLINE
 
 
 async def test_fetcher_disabled_without_base_url():
     """An empty base URL disables the lookup without issuing a request."""
     fetcher = OutlineFetcher("", httpx.AsyncClient())
-    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == NO_OUTLINE
 
 
 async def test_fetcher_caches_by_doc_id():
@@ -178,4 +180,64 @@ async def test_fetcher_evicts_least_recently_used():
     fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
     for index in range(200):
         await fetcher.get(f"/documentation/en-us/guide{index}/index.html")
-    assert len(fetcher._cache) == 128
+    assert len(fetcher._cache) == 64
+
+
+# ---------------------------------------------------------------------------
+# DocumentOutline.locate
+# ---------------------------------------------------------------------------
+
+
+def test_locate_places_a_passage_in_its_section():
+    """A passage drawn from a section's prose resolves to that section."""
+    outline = parse_document(_GUIDE_HTML)
+    section = outline.locate("intercept requests to the control plane API to enforce policy")
+    assert section is not None
+    assert section.anchor == "con-config-tuning-intro-str"
+
+
+def test_locate_returns_none_for_text_outside_the_body():
+    """A ToC fragment exists in Solr's main_content but in no section."""
+    outline = parse_document(_GUIDE_HTML)
+    assert outline.locate("1. Kafka tuning overview 2. Managed broker configuration 3. Broker tuning") is None
+
+
+def test_locate_unescapes_entities_before_matching():
+    """Solr passages carry literal entities that the mirror text has decoded."""
+    html = '<section id="s"><h1 class="title">T</h1><p>run \'/root/x.sh\' now to finish the job</p></section>'
+    outline = parse_document(html)
+    section = outline.locate("run &#x27;/root/x.sh&#x27; now to finish the job")
+    assert section is not None
+    assert section.anchor == "s"
+
+
+def test_locate_probes_past_a_filtered_head():
+    """RHV filtering can strip a snippet's opening sentence; later probes recover it."""
+    tail = "the supported configuration is documented in the installation guide for this release"
+    html = f'<section id="s"><h1 class="title">T</h1><p>Original opening sentence. {tail}</p></section>'
+    outline = parse_document(html)
+    section = outline.locate(f"A sentence that is not in the page at all. {tail}")
+    assert section is not None
+    assert section.anchor == "s"
+
+
+def test_locate_rejects_a_probe_that_is_too_short_to_be_unique():
+    """A passage shorter than the minimum probe cannot be placed."""
+    assert parse_document(_GUIDE_HTML).locate("Body") is None
+
+
+def test_locate_on_empty_outline():
+    """The shared empty outline places nothing rather than raising."""
+    assert NO_OUTLINE.locate("anything at all, some reasonably long text here") is None
+
+
+def test_parse_document_body_excludes_navigation():
+    """Site nav repeats the whole ToC and must not be matchable body text."""
+    html = (
+        "<nav><a>Chapter 1. Intro</a></nav>"
+        '<section id="s"><h1 class="title">Chapter 1. Intro</h1>'
+        "<p>Real prose lives here in the body.</p></section>"
+    )
+    outline = parse_document(html)
+    assert "Real prose lives here in the body." in outline.body
+    assert outline.body.count("Chapter 1. Intro") == 1

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -4,7 +4,9 @@ import httpx
 import pytest
 
 from okp_mcp.outline import _html_path
+from okp_mcp.outline import NO_OUTLINE
 from okp_mcp.outline import OutlineFetcher
+from okp_mcp.outline import parse_document
 from okp_mcp.outline import parse_outline
 from okp_mcp.outline import Section
 
@@ -17,7 +19,7 @@ _GUIDE_HTML = """
   <div class="titlepage"><h1 class="title">Kafka configuration tuning</h1></div>
   <section id="con-config-tuning-intro-str">
     <div class="titlepage"><h1 class="title">Chapter&nbsp;1.&nbsp;Kafka tuning overview</h1></div>
-    <p>Body text.</p>
+    <p>Admission plugins intercept requests to the control plane API to enforce policy.</p>
     <section id="mapping_properties_and_values">
       <div class="titlepage"><h2 class="title">1.1. Mapping properties and values</h2></div>
     </section>
@@ -100,8 +102,8 @@ def _fetcher(handler) -> OutlineFetcher:
 async def test_fetcher_returns_parsed_sections():
     """A successful mirror fetch is parsed into sections."""
     fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
-    sections = await fetcher.get("/documentation/en-us/guide/index.html")
-    assert Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview", 1) in sections
+    outline = await fetcher.get("/documentation/en-us/guide/index.html")
+    assert Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview", 1) in outline.sections
 
 
 async def test_fetcher_requests_the_mirror_path():
@@ -124,7 +126,7 @@ async def test_fetcher_requests_the_mirror_path():
 async def test_fetcher_degrades_on_http_error(response):
     """An unavailable mirror yields no anchors instead of failing the tool call."""
     fetcher = _fetcher(lambda request: response)
-    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == NO_OUTLINE
 
 
 async def test_fetcher_degrades_on_transport_error():
@@ -133,7 +135,7 @@ async def test_fetcher_degrades_on_transport_error():
     def handler(request: httpx.Request) -> httpx.Response:
         raise httpx.ConnectError("no route to host")
 
-    assert await _fetcher(handler).get("/documentation/en-us/guide/index.html") == []
+    assert await _fetcher(handler).get("/documentation/en-us/guide/index.html") == NO_OUTLINE
 
 
 async def test_fetcher_does_not_log_the_mirror_url(caplog):
@@ -183,7 +185,7 @@ async def test_fetcher_logs_the_type_of_a_transport_error(caplog):
 async def test_fetcher_disabled_without_base_url():
     """An empty base URL disables the lookup without issuing a request."""
     fetcher = OutlineFetcher("", httpx.AsyncClient())
-    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == NO_OUTLINE
 
 
 async def test_fetcher_caches_by_doc_id():
@@ -222,4 +224,86 @@ async def test_fetcher_evicts_least_recently_used():
     fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
     for index in range(200):
         await fetcher.get(f"/documentation/en-us/guide{index}/index.html")
-    assert len(fetcher._cache) == 128
+    assert len(fetcher._cache) == 64
+
+
+# ---------------------------------------------------------------------------
+# DocumentOutline.locate
+# ---------------------------------------------------------------------------
+
+
+def test_locate_places_a_passage_in_its_section():
+    """A passage drawn from a section's prose resolves to that section."""
+    outline = parse_document(_GUIDE_HTML)
+    section = outline.locate("intercept requests to the control plane API to enforce policy")
+    assert section is not None
+    assert section.anchor == "con-config-tuning-intro-str"
+
+
+def test_locate_returns_none_for_text_outside_the_body():
+    """A ToC fragment exists in Solr's main_content but in no section."""
+    outline = parse_document(_GUIDE_HTML)
+    assert outline.locate("1. Kafka tuning overview 2. Managed broker configuration 3. Broker tuning") is None
+
+
+def test_locate_unescapes_entities_before_matching():
+    """Solr passages carry literal entities that the mirror text has decoded."""
+    html = '<section id="s"><h1 class="title">T</h1><p>run \'/root/x.sh\' now to finish the job</p></section>'
+    outline = parse_document(html)
+    section = outline.locate("run &#x27;/root/x.sh&#x27; now to finish the job")
+    assert section is not None
+    assert section.anchor == "s"
+
+
+def test_locate_probes_past_a_filtered_head():
+    """RHV filtering can strip a snippet's opening sentence; later probes recover it."""
+    tail = "the supported configuration is documented in the installation guide for this release"
+    html = f'<section id="s"><h1 class="title">T</h1><p>Original opening sentence. {tail}</p></section>'
+    outline = parse_document(html)
+    section = outline.locate(f"A sentence that is not in the page at all. {tail}")
+    assert section is not None
+    assert section.anchor == "s"
+
+
+def test_locate_rejects_a_short_passage_absent_from_the_body():
+    """Text the page does not contain has no home section, however short."""
+    assert parse_document(_GUIDE_HTML).locate("Body") is None
+
+
+def test_locate_places_a_short_passage_that_occurs_once():
+    """RHV filtering can shrink a prose highlight below the probe minimum."""
+    outline = parse_document(_GUIDE_HTML)
+    section = outline.locate("enforce policy.")
+    assert section is not None
+    assert section.anchor == "con-config-tuning-intro-str"
+
+
+def test_locate_rejects_a_short_passage_that_repeats():
+    """Repeated short text would otherwise be attributed to its first section."""
+    html = (
+        '<section id="first"><h1 class="title">First</h1><p>See the note below.</p></section>'
+        '<section id="second"><h1 class="title">Second</h1><p>See the note below.</p></section>'
+    )
+    assert parse_document(html).locate("See the note") is None
+
+
+def test_locate_rejects_an_empty_passage():
+    """An empty highlight matches at offset 0 in every page; it must not."""
+    assert parse_document(_GUIDE_HTML).locate("   ") is None
+
+
+def test_locate_on_empty_outline():
+    """The shared empty outline places nothing rather than raising."""
+    assert NO_OUTLINE.locate("anything at all, some reasonably long text here") is None
+
+
+def test_parse_document_body_excludes_navigation():
+    """Site nav repeats the whole ToC and must not be matchable body text."""
+    html = (
+        "<nav><a>Chapter 1. Intro</a></nav>"
+        '<section id="s"><h1 class="title">Chapter 1. Intro</h1>'
+        "<p>Real prose lives here in the body.</p></section>"
+    )
+    outline = parse_document(html)
+    assert "Real prose lives here in the body." in outline.body
+    assert outline.body.count("Chapter 1. Intro") == 1

--- a/tests/test_outline.py
+++ b/tests/test_outline.py
@@ -1,0 +1,225 @@
+"""Tests for okp_mcp.outline: section anchors read from the OKP HTML mirror."""
+
+import httpx
+import pytest
+
+from okp_mcp.outline import _html_path
+from okp_mcp.outline import OutlineFetcher
+from okp_mcp.outline import parse_outline
+from okp_mcp.outline import Section
+
+
+# Mirrors the shape the OKP appliance serves: a wrapper section around the
+# document, chapters nested inside it, and topic sections nested in those.
+_GUIDE_HTML = """
+<html><body>
+<section id="mimir-doc--kafka_configuration_tuning">
+  <div class="titlepage"><h1 class="title">Kafka configuration tuning</h1></div>
+  <section id="con-config-tuning-intro-str">
+    <div class="titlepage"><h1 class="title">Chapter&nbsp;1.&nbsp;Kafka tuning overview</h1></div>
+    <p>Body text.</p>
+    <section id="mapping_properties_and_values">
+      <div class="titlepage"><h2 class="title">1.1. Mapping properties and values</h2></div>
+    </section>
+  </section>
+</section>
+</body></html>
+"""
+
+
+def test_parse_outline_extracts_anchor_and_title():
+    """Each section yields its id paired with the heading it contains."""
+    sections = parse_outline(_GUIDE_HTML)
+    assert Section("mapping_properties_and_values", "1.1. Mapping properties and values", 2) in sections
+
+
+def test_parse_outline_drops_document_wrapper():
+    """The mimir-doc-- wrapper is the page itself, not a linkable section."""
+    anchors = [section.anchor for section in parse_outline(_GUIDE_HTML)]
+    assert not any(anchor.startswith("mimir-doc--") for anchor in anchors)
+
+
+def test_parse_outline_normalizes_entities_and_whitespace():
+    """Numbering separators arrive as &nbsp; and must collapse to plain spaces."""
+    titles = [section.title for section in parse_outline(_GUIDE_HTML)]
+    assert "Chapter 1. Kafka tuning overview" in titles
+
+
+def test_parse_outline_preserves_document_order():
+    """Chapters precede the topics nested inside them."""
+    anchors = [section.anchor for section in parse_outline(_GUIDE_HTML)]
+    assert anchors.index("con-config-tuning-intro-str") < anchors.index("mapping_properties_and_values")
+
+
+def test_parse_outline_skips_sections_without_id():
+    """A section with no id contributes nothing and does not steal a heading.
+
+    Attributing its heading to the enclosing section would emit a link that
+    jumps to the wrong place, which is worse than omitting the entry.
+    """
+    html = '<section id="outer"><h1 class="title">Outer</h1><section><h2 class="title">Inner</h2></section></section>'
+    assert parse_outline(html) == [Section("outer", "Outer")]
+
+
+def test_parse_outline_ignores_headings_outside_sections():
+    """Site chrome headings (nav, footer) sit outside any section."""
+    assert parse_outline("<h2>CONTENT</h2><h2>HELP</h2>") == []
+
+
+def test_parse_outline_keeps_first_heading_per_section():
+    """A nested formatting heading must not overwrite the section title."""
+    html = '<section id="a"><h1 class="title">Real title</h1><div><h3>Sub label</h3></div></section>'
+    assert parse_outline(html) == [Section("a", "Real title")]
+
+
+def test_parse_outline_empty_document():
+    """A page with no sections yields no anchors rather than raising."""
+    assert parse_outline("<html><body><p>text</p></body></html>") == []
+
+
+@pytest.mark.parametrize(
+    "doc_id,expected",
+    [
+        ("/documentation/en-us/guide/index.html", "/documentation/en-us/guide/index.html"),
+        ("/documentation/en-us/guide/index", "/documentation/en-us/guide/index/index.html"),
+        ("/documentation/en-us/guide/index/", "/documentation/en-us/guide/index/index.html"),
+        ("documentation/en-us/guide/index", "/documentation/en-us/guide/index/index.html"),
+    ],
+    ids=["already-html", "bare-path", "trailing-slash", "missing-leading-slash"],
+)
+def test_html_path_maps_solr_id_to_mirror_path(doc_id, expected):
+    """Solr ids are crawled file paths, so the mapping only fixes the suffix."""
+    assert _html_path(doc_id) == expected
+
+
+def _fetcher(handler) -> OutlineFetcher:
+    transport = httpx.MockTransport(handler)
+    return OutlineFetcher("http://okp:8080", httpx.AsyncClient(transport=transport))
+
+
+async def test_fetcher_returns_parsed_sections():
+    """A successful mirror fetch is parsed into sections."""
+    fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
+    sections = await fetcher.get("/documentation/en-us/guide/index.html")
+    assert Section("con-config-tuning-intro-str", "Chapter 1. Kafka tuning overview", 1) in sections
+
+
+async def test_fetcher_requests_the_mirror_path():
+    """The request targets the mirror base joined with the document's path."""
+    seen: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(str(request.url))
+        return httpx.Response(200, text=_GUIDE_HTML)
+
+    await _fetcher(handler).get("/documentation/en-us/guide/index.html")
+    assert seen == ["http://okp:8080/documentation/en-us/guide/index.html"]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [httpx.Response(404), httpx.Response(500)],
+    ids=["not-found", "server-error"],
+)
+async def test_fetcher_degrades_on_http_error(response):
+    """An unavailable mirror yields no anchors instead of failing the tool call."""
+    fetcher = _fetcher(lambda request: response)
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+
+
+async def test_fetcher_degrades_on_transport_error():
+    """A deployment that exposes only Solr must still serve documents."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    assert await _fetcher(handler).get("/documentation/en-us/guide/index.html") == []
+
+
+async def test_fetcher_does_not_log_the_mirror_url(caplog):
+    """The mirror host is internal and may carry credentials, so keep it out.
+
+    httpx repeats the request URL inside HTTPStatusError, so logging the
+    exception verbatim would leak it even though the format string does not.
+    """
+    transport = httpx.MockTransport(lambda request: httpx.Response(404))
+    fetcher = OutlineFetcher("http://user:secret@okp-internal:8080", httpx.AsyncClient(transport=transport))
+
+    with caplog.at_level("DEBUG", logger="okp_mcp.outline"):
+        await fetcher.get("/documentation/en-us/guide/index.html")
+
+    assert caplog.messages
+    assert not any("secret" in message or "okp-internal" in message for message in caplog.messages)
+    assert any("/documentation/en-us/guide/index.html" in message for message in caplog.messages)
+
+
+async def test_fetcher_logs_the_status_of_a_failed_fetch(caplog):
+    """Redacting the URL must not cost the reason the fetch failed."""
+    transport = httpx.MockTransport(lambda request: httpx.Response(503))
+    fetcher = OutlineFetcher("http://okp:8080", httpx.AsyncClient(transport=transport))
+
+    with caplog.at_level("DEBUG", logger="okp_mcp.outline"):
+        await fetcher.get("/documentation/en-us/guide/index.html")
+
+    assert any("HTTP 503" in message for message in caplog.messages)
+
+
+async def test_fetcher_logs_the_type_of_a_transport_error(caplog):
+    """A connect error carries no status, so name the failure instead."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("no route to host")
+
+    transport = httpx.MockTransport(handler)
+    fetcher = OutlineFetcher("http://okp-internal:8080", httpx.AsyncClient(transport=transport))
+
+    with caplog.at_level("DEBUG", logger="okp_mcp.outline"):
+        await fetcher.get("/documentation/en-us/guide/index.html")
+
+    assert any("ConnectError" in message for message in caplog.messages)
+    assert not any("okp-internal" in message for message in caplog.messages)
+
+
+async def test_fetcher_disabled_without_base_url():
+    """An empty base URL disables the lookup without issuing a request."""
+    fetcher = OutlineFetcher("", httpx.AsyncClient())
+    assert await fetcher.get("/documentation/en-us/guide/index.html") == []
+
+
+async def test_fetcher_caches_by_doc_id():
+    """A repeat lookup is served from cache rather than refetching ~200KB."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(200, text=_GUIDE_HTML)
+
+    fetcher = _fetcher(handler)
+    first = await fetcher.get("/documentation/en-us/guide/index.html")
+    second = await fetcher.get("/documentation/en-us/guide/index.html")
+    assert calls == 1
+    assert first == second
+
+
+async def test_fetcher_caches_empty_results():
+    """A mirror miss is remembered too, so it costs one request per document."""
+    calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(404)
+
+    fetcher = _fetcher(handler)
+    await fetcher.get("/documentation/en-us/guide/index.html")
+    await fetcher.get("/documentation/en-us/guide/index.html")
+    assert calls == 1
+
+
+async def test_fetcher_evicts_least_recently_used():
+    """The cache stays bounded so a long-lived server cannot pin the corpus."""
+    fetcher = _fetcher(lambda request: httpx.Response(200, text=_GUIDE_HTML))
+    for index in range(200):
+        await fetcher.get(f"/documentation/en-us/guide{index}/index.html")
+    assert len(fetcher._cache) == 128

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -108,6 +108,27 @@ async def test_app_context_http_client_is_async_client():
 
 
 @pytest.mark.asyncio
+async def test_app_lifespan_does_not_log_the_mirror_url(caplog):
+    """The mirror URL is an internal host and may carry credentials.
+
+    Startup logs at INFO by default, so the URL must not appear there; the
+    status is what an operator needs to see.
+    """
+    config = SimpleNamespace(
+        solr_endpoint="http://localhost:8983/solr/portal/select",
+        max_response_chars=30_000,
+        html_mirror_url="http://user:secret@okp-internal:8080",
+    )
+
+    with patch("okp_mcp.server.CONFIG", config), caplog.at_level(logging.INFO, logger="okp_mcp.server"):
+        async with _app_lifespan(mcp):
+            pass
+
+    assert any("HTML mirror: enabled" in message for message in caplog.messages)
+    assert not any("secret" in message or "okp-internal" in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
 async def test_app_lifespan_closes_client_on_normal_exit():
     """Lifespan always closes client when context exits normally."""
     mock_client = AsyncMock(spec=httpx.AsyncClient)

--- a/tests/test_tools_context.py
+++ b/tests/test_tools_context.py
@@ -387,6 +387,7 @@ async def test_get_document_normalizes_full_url():
     mock_app.http_client = AsyncMock(spec=httpx.AsyncClient)
     mock_app.solr_endpoint = _SOLR_ENDPOINT
     mock_app.max_response_chars = 5000
+    mock_app.outline_fetcher = None
 
     with (
         patch("okp_mcp.tools.document.get_app_context", return_value=mock_app),


### PR DESCRIPTION
## What this does

`get_document` now returns the **real** `#fragment` anchors Red Hat's
documentation uses, so an agent can link to the section it is quoting instead of
inventing one.

**Without a query** — the page's section outline, where this path previously
returned only "pass a query to get_document":

```
Sections in this document:
  #admission-plug-ins — Chapter 9. Admission plugins
  #admission-webhooks-about_admission-plug-ins — 9.3. Webhook admission plugins
```

**With a query** — an anchor on each passage, so a cited paragraph links to the
paragraph rather than to the guide:

```
Passage 1 [#admission-plug-ins-about_admission-plug-ins — 9.1. About admission plugins]:
```

## Why the anchors come from the HTML mirror

Slugifying the heading text was implemented first and rejected by measurement —
**1 of 44 headings matched** on the OpenShift 4.20 architecture guide:

| heading | derived slug | real anchor |
|---|---|---|
| About admission plugins | `about-admission-plugins` | `about-admission-plug-ins_architecture-overview` |

Red Hat assigns anchors in the AsciiDoc source, qualified by their parent
section; all 42 fields in the Solr schema were checked and none carries them.
The appliance also serves the rendered HTML over httpd on 8080, beside Solr on
8983, where each section is a `<section id>` holding exactly the fragment
`docs.redhat.com` uses — and Solr document ids *are* that mirror's file paths.
Parsed with stdlib `html.parser`, 13 ms on a 201 KB guide, no new dependency.

Matching passages against Solr's `main_content` instead does not work: it leads
with the page's ToC, where 64 of 73 headings recur, so passages anchor to ToC
entries. That and two further rejected approaches are recorded in `AGENTS.md`.

## ToC passages are dropped

The same mechanism identifies them. They are 26% of passages but **59% of the
characters**, so they crowd real prose out of the 10 K passage budget rather than
merely sitting beside it. Filtering leaves a subset of what Solr already
selected, in Solr's own order, so relevance cannot regress.

## Verification against a live appliance

| check | result |
|---|---|
| Produced anchors vs. the public docs.redhat.com page | **45 / 45 resolve**, 0 broken |
| Highlight passages placed (146 from 33 guides) | **104 / 104** of those drawn from prose, 0 misplaced |
| Documents exposing `<section id>` (250-doc sample) | 236 / 250; the rest are single-topic pages |

Every failure — mirror unreachable, document absent, page with no sections —
degrades to a title-only outline, and filtering can never empty the passage list.
Neither can fail the tool call.

## Deployment

`MCP_OKP_HTML_URL` defaults to the `solr_url` host on port 8080, so in-pod
deployments need no configuration; `-` disables the lookup. `podman-compose.yml`
publishes the mirror as `8085:8080` for running the server from source.

## Review notes

The commits are reviewable in order: the section outline, then the query path,
then the review rounds on top of them. Each carries its reasoning in its own
message, so it is not repeated here. The BM25 fallback path
(`_extract_relevant_section`) is not anchored yet.
