### PR TITLE
Prevent renovate from modifying the container unit files

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>rhel-lightspeed/renovate-config"],
-  "ignorePaths": [".konflux/requirements*.txt"],
+  "ignorePaths": [".konflux/requirements*.txt", "quadlet/*.container"],
   "tekton": {
     "enabled": false
   }


### PR DESCRIPTION
These files are for an alternative way of running the application and should be using the latest images. They do not affect the release build.